### PR TITLE
Logger refactor: validation for builtin and pluggable logger

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,7 +67,8 @@
       ],
       "rules": {
         "no-restricted-syntax": ["error", "ForOfStatement", "ForInStatement", "ArrayPattern"],
-        "compat/compat": ["error", "defaults, not ie < 10, not node < 6"]
+        "compat/compat": ["error", "defaults, not ie < 10, not node < 6"],
+        "no-throw-literal": "error"
       },
       "parserOptions": {
         "ecmaVersion": 2015,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,3 @@ export { evaluateFeature, evaluateFeatures } from './evaluator';
 // Utils:
 export { hash128 } from './utils/murmur3/murmur3_128';
 export { hash } from './utils/murmur3/murmur3';
-
-// Logger
-export { logFactory, API } from './logger/sdkLogger';

--- a/src/logger/__tests__/index.spec.ts
+++ b/src/logger/__tests__/index.spec.ts
@@ -33,10 +33,7 @@ test('SPLIT LOGGER / Logger class shape', () => {
   expect(typeof logger.info).toBe('function'); // instance.info should be a method.
   expect(typeof logger.warn).toBe('function'); // instance.warn should be a method.
   expect(typeof logger.error).toBe('function'); // instance.error should be a method.
-  expect(typeof logger.setLogLevel).toBe('function'); // @ts-ignore // instance.setLogLevel should be a method.
-  expect(typeof logger.options.logLevel).toBe('string'); // @ts-ignore // instance.options.logLevel should be a string.
-  expect(typeof logger.options.showLevel).toBe('boolean'); // instance.options.showLevel should be a boolean.
-
+  expect(typeof logger.setLogLevel).toBe('function'); // instance.setLogLevel should be a method.
 });
 
 const LOG_LEVELS_IN_ORDER = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'];

--- a/src/logger/__tests__/index.spec.ts
+++ b/src/logger/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
-import { Logger, LogLevels, setLogLevel, isLogLevelString } from '../index';
+import { LogLevel } from '../../types';
+import { Logger, LogLevels, isLogLevelString } from '../index';
 
 // We'll set this only once. These are the constants we will use for
 // comparing the LogLevel values.
@@ -9,12 +10,6 @@ export const LOG_LEVELS = {
   ERROR: 'ERROR',
   NONE: 'NONE'
 };
-
-test('SPLIT LOGGER / setLogLevel utility function', () => {
-  expect(typeof setLogLevel).toBe('function'); // setLogLevel should be a function
-  expect(setLogLevel).not.toThrow(); // Calling setLogLevel should not throw an error.
-
-});
 
 test('SPLIT LOGGER / isLogLevelString utility function', () => {
   expect(typeof isLogLevelString).toBe('function'); // isLogLevelString should be a function
@@ -32,18 +27,20 @@ test('SPLIT LOGGER / LogLevels exposed mappings', () => {
 test('SPLIT LOGGER / Logger class shape', () => {
   expect(typeof Logger).toBe('function'); // Logger should be a class we can instantiate.
 
-  const logger = new Logger('test-category', {});
+  const logger = new Logger('test-category');
 
   expect(typeof logger.debug).toBe('function'); // instance.debug should be a method.
   expect(typeof logger.info).toBe('function'); // instance.info should be a method.
   expect(typeof logger.warn).toBe('function'); // instance.warn should be a method.
   expect(typeof logger.error).toBe('function'); // instance.error should be a method.
+  expect(typeof logger.options.logLevel).toBe('string'); // instance.options.logLevel should be a string.
+  expect(typeof logger.options.showLevel).toBe('boolean'); // instance.options.showLevel should be a boolean.
 
 });
 
 const LOG_LEVELS_IN_ORDER = ['DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'];
 /* Utility function to avoid repeating too much code */
-function testLogLevels(levelToTest: string) {
+function testLogLevels(levelToTest: LogLevel) {
   // Builds the expected message.
   const buildExpectedMessage = (lvl: string, category: string, msg: string, showLevel?: boolean) => {
     let res = '';
@@ -57,24 +54,21 @@ function testLogLevels(levelToTest: string) {
   const consoleLogSpy = jest.spyOn(global.console, 'log');
 
   // Runs the suite with the given value for showLevel option.
-  const runTests = (showLevel?: boolean, displayAllErrors?: boolean) => {
+  const runTests = (showLevel?: boolean) => {
     let logLevelLogsCounter = 0;
     let testForNoLog = false;
     const logMethod = levelToTest.toLowerCase();
-    const logCategory = `test-category-${logMethod}${displayAllErrors ? 'displayAllErrors' : ''}`;
+    const logCategory = `test-category-${logMethod}`;
     const instance = new Logger(logCategory, {
-      showLevel, displayAllErrors
+      showLevel
     });
 
     LOG_LEVELS_IN_ORDER.forEach((logLevel, i) => {
-      const logMsg = `Test log for level ${levelToTest} (${displayAllErrors ? 'But all errors are configured to display' : 'Errors not forced to display'}) with showLevel: ${showLevel} ${logLevelLogsCounter}`;
+      const logMsg = `Test log for level ${levelToTest} with showLevel: ${showLevel} ${logLevelLogsCounter}`;
       const expectedMessage = buildExpectedMessage(levelToTest, logCategory, logMsg, showLevel);
 
-      // Log error should always be visible.
-      if (logMethod === LOG_LEVELS.ERROR.toLowerCase() && displayAllErrors) testForNoLog = false;
-
       // Set the logLevel for this iteration.
-      setLogLevel(LogLevels[logLevel]);
+      instance.options.logLevel = LogLevels[logLevel];
       // Call the method
       // @ts-ignore
       instance[logMethod](logMsg);
@@ -95,10 +89,8 @@ function testLogLevels(levelToTest: string) {
 
   // Show logLevel
   runTests(true);
-  runTests(true, true);
   // Hide logLevel
   runTests(false);
-  runTests(false, true);
 
   // Restore spied object.
   consoleLogSpy.mockRestore();

--- a/src/logger/__tests__/index.spec.ts
+++ b/src/logger/__tests__/index.spec.ts
@@ -33,7 +33,8 @@ test('SPLIT LOGGER / Logger class shape', () => {
   expect(typeof logger.info).toBe('function'); // instance.info should be a method.
   expect(typeof logger.warn).toBe('function'); // instance.warn should be a method.
   expect(typeof logger.error).toBe('function'); // instance.error should be a method.
-  expect(typeof logger.options.logLevel).toBe('string'); // instance.options.logLevel should be a string.
+  expect(typeof logger.setLogLevel).toBe('function'); // @ts-ignore // instance.setLogLevel should be a method.
+  expect(typeof logger.options.logLevel).toBe('string'); // @ts-ignore // instance.options.logLevel should be a string.
   expect(typeof logger.options.showLevel).toBe('boolean'); // instance.options.showLevel should be a boolean.
 
 });
@@ -66,7 +67,7 @@ function testLogLevels(levelToTest: LogLevel) {
       const expectedMessage = buildExpectedMessage(levelToTest, logCategory, logMsg, showLevel);
 
       // Set the logLevel for this iteration.
-      instance.options.logLevel = LogLevels[logLevel];
+      instance.setLogLevel(LogLevels[logLevel]);
       // Call the method
       // @ts-ignore
       instance[logMethod](logMsg);

--- a/src/logger/__tests__/sdkLogger.mock.ts
+++ b/src/logger/__tests__/sdkLogger.mock.ts
@@ -1,11 +1,10 @@
-import { ILoggerOptions } from '../types';
 
 export const loggerMock = {
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
   info: jest.fn(),
-  options: { logLevel: 'NONE', showLevel: true } as ILoggerOptions
+  setLogLevel: jest.fn()
 };
 
 export function mockClear() {
@@ -13,4 +12,5 @@ export function mockClear() {
   loggerMock.error.mockClear();
   loggerMock.debug.mockClear();
   loggerMock.info.mockClear();
+  loggerMock.setLogLevel.mockClear();
 }

--- a/src/logger/__tests__/sdkLogger.mock.ts
+++ b/src/logger/__tests__/sdkLogger.mock.ts
@@ -1,8 +1,11 @@
+import { ILoggerOptions } from '../types';
+
 export const loggerMock = {
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
   info: jest.fn(),
+  options: { logLevel: 'NONE', showLevel: true } as ILoggerOptions
 };
 
 export function mockClear() {

--- a/src/logger/__tests__/sdkLogger.spec.ts
+++ b/src/logger/__tests__/sdkLogger.spec.ts
@@ -1,28 +1,26 @@
 import { createLoggerAPI } from '../sdkLogger';
 import { Logger, LogLevels } from '../index';
 
-test('createLoggerAPI / methods and props', () => {
-  const logger = new Logger('category', {});
-
-  expect(typeof createLoggerAPI).toBe('function'); // Importing the module should return a function.
-
+test('LoggerAPI / methods and props', () => {
+  // creates a LoggerAPI instance
+  const logger = new Logger('category');
   const API = createLoggerAPI(logger);
 
   expect(typeof API).toBe('object'); // Our logger should expose an API object.
 
   expect(typeof API.setLogLevel).toBe('function'); // API object should have setLogLevel method.
-  API.setLogLevel('INFO'); // @ts-ignore
+  API.setLogLevel('INFO'); // @ts-ignore, accessing private prop
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel should update the log level.
-  // @ts-ignore
-  API.setLogLevel('warn'); // @ts-ignore
+  // @ts-ignore, passing wrong type
+  API.setLogLevel('warn'); // @ts-ignore, accessing private prop
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel with an invalid value should not update the log level.
 
   expect(typeof API.enable).toBe('function'); // API object should have enable method.
-  API.enable(); // @ts-ignore
+  API.enable(); // @ts-ignore, accessing private prop
   expect(logger.options.logLevel).toBe('DEBUG'); // calling enable should update logger log level to DEBUG.
 
   expect(typeof API.disable).toBe('function'); // API object should have disable method.
-  API.disable(); // @ts-ignore
+  API.disable(); // @ts-ignore, accessing private prop
   expect(logger.options.logLevel).toBe('NONE'); // calling disable should update logger log level to NONE.
 
   expect(API.LogLevel).toEqual(LogLevels); // API object should have LogLevel prop including all available levels.

--- a/src/logger/__tests__/sdkLogger.spec.ts
+++ b/src/logger/__tests__/sdkLogger.spec.ts
@@ -1,22 +1,30 @@
-import { logFactory, API } from '../sdkLogger';
-import { Logger } from '../index';
-import { LOG_LEVELS } from './index.spec';
+import { createLoggerAPI } from '../sdkLogger';
+import { Logger, LogLevels } from '../index';
 
-test('SPLIT SDK LOGGER FACTORY / methods and props', () => {
+test('createLoggerAPI / methods and props', () => {
+  const logger = new Logger('category', {});
 
-  expect(typeof logFactory).toBe('function'); // Importing the module should return a function.
+  expect(typeof createLoggerAPI).toBe('function'); // Importing the module should return a function.
 
-  expect(typeof API).toBe('object'); // Our logger should expose an API object.
-  expect(typeof API.enable).toBe('function'); // API object should have enable method.
-  expect(typeof API.disable).toBe('function'); // API object should have disable method.
-  expect(typeof API.setLogLevel).toBe('function'); // API object should have setLogLevel method.
-  expect(API.LogLevel).toEqual(LOG_LEVELS); // API object should have LogLevel prop including all available levels.
+  const loggerAPI = createLoggerAPI(logger);
 
-});
+  expect(typeof loggerAPI).toBe('object'); // Our logger should expose an API object.
 
-test('SPLIT SDK LOGGER FACTORY / create factory returned instance', () => {
-  const logger = logFactory('category', {});
+  expect(typeof loggerAPI.setLogLevel).toBe('function'); // API object should have setLogLevel method.
+  loggerAPI.setLogLevel('INFO');
+  expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel should update the log level.
+  // @ts-ignore
+  loggerAPI.setLogLevel('warn');
+  expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel with an invalid value should not update the log level.
 
-  expect(logger instanceof Logger).toBe(true); // Our logger should expose an API object.
+  expect(typeof loggerAPI.enable).toBe('function'); // API object should have enable method.
+  loggerAPI.enable();
+  expect(logger.options.logLevel).toBe('DEBUG'); // calling enable should update logger log level to DEBUG.
+
+  expect(typeof loggerAPI.disable).toBe('function'); // API object should have disable method.
+  loggerAPI.disable();
+  expect(logger.options.logLevel).toBe('NONE'); // calling disable should update logger log level to NONE.
+
+  expect(loggerAPI.LogLevel).toEqual(LogLevels); // API object should have LogLevel prop including all available levels.
 
 });

--- a/src/logger/__tests__/sdkLogger.spec.ts
+++ b/src/logger/__tests__/sdkLogger.spec.ts
@@ -6,25 +6,25 @@ test('createLoggerAPI / methods and props', () => {
 
   expect(typeof createLoggerAPI).toBe('function'); // Importing the module should return a function.
 
-  const loggerAPI = createLoggerAPI(logger);
+  const API = createLoggerAPI(logger);
 
-  expect(typeof loggerAPI).toBe('object'); // Our logger should expose an API object.
+  expect(typeof API).toBe('object'); // Our logger should expose an API object.
 
-  expect(typeof loggerAPI.setLogLevel).toBe('function'); // API object should have setLogLevel method.
-  loggerAPI.setLogLevel('INFO'); // @ts-ignore
+  expect(typeof API.setLogLevel).toBe('function'); // API object should have setLogLevel method.
+  API.setLogLevel('INFO'); // @ts-ignore
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel should update the log level.
   // @ts-ignore
-  loggerAPI.setLogLevel('warn'); // @ts-ignore
+  API.setLogLevel('warn'); // @ts-ignore
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel with an invalid value should not update the log level.
 
-  expect(typeof loggerAPI.enable).toBe('function'); // API object should have enable method.
-  loggerAPI.enable(); // @ts-ignore
+  expect(typeof API.enable).toBe('function'); // API object should have enable method.
+  API.enable(); // @ts-ignore
   expect(logger.options.logLevel).toBe('DEBUG'); // calling enable should update logger log level to DEBUG.
 
-  expect(typeof loggerAPI.disable).toBe('function'); // API object should have disable method.
-  loggerAPI.disable(); // @ts-ignore
+  expect(typeof API.disable).toBe('function'); // API object should have disable method.
+  API.disable(); // @ts-ignore
   expect(logger.options.logLevel).toBe('NONE'); // calling disable should update logger log level to NONE.
 
-  expect(loggerAPI.LogLevel).toEqual(LogLevels); // API object should have LogLevel prop including all available levels.
+  expect(API.LogLevel).toEqual(LogLevels); // API object should have LogLevel prop including all available levels.
 
 });

--- a/src/logger/__tests__/sdkLogger.spec.ts
+++ b/src/logger/__tests__/sdkLogger.spec.ts
@@ -11,18 +11,18 @@ test('createLoggerAPI / methods and props', () => {
   expect(typeof loggerAPI).toBe('object'); // Our logger should expose an API object.
 
   expect(typeof loggerAPI.setLogLevel).toBe('function'); // API object should have setLogLevel method.
-  loggerAPI.setLogLevel('INFO');
+  loggerAPI.setLogLevel('INFO'); // @ts-ignore
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel should update the log level.
   // @ts-ignore
-  loggerAPI.setLogLevel('warn');
+  loggerAPI.setLogLevel('warn'); // @ts-ignore
   expect(logger.options.logLevel).toBe('INFO'); // calling setLogLevel with an invalid value should not update the log level.
 
   expect(typeof loggerAPI.enable).toBe('function'); // API object should have enable method.
-  loggerAPI.enable();
+  loggerAPI.enable(); // @ts-ignore
   expect(logger.options.logLevel).toBe('DEBUG'); // calling enable should update logger log level to DEBUG.
 
   expect(typeof loggerAPI.disable).toBe('function'); // API object should have disable method.
-  loggerAPI.disable();
+  loggerAPI.disable(); // @ts-ignore
   expect(logger.options.logLevel).toBe('NONE'); // calling disable should update logger log level to NONE.
 
   expect(loggerAPI.LogLevel).toEqual(LogLevels); // API object should have LogLevel prop including all available levels.

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -21,12 +21,17 @@ const defaultOptions = {
 };
 
 export class Logger implements ILogger {
+
   private category: string;
-  public options: Required<ILoggerOptions>;
+  private options: Required<ILoggerOptions>;
 
   constructor(category: string, options?: ILoggerOptions) {
     this.category = category;
     this.options = objectAssign({}, defaultOptions, options);
+  }
+
+  setLogLevel(logLevel: LogLevel) {
+    this.options.logLevel = logLevel;
   }
 
   debug(msg: string) {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -11,57 +11,49 @@ export const LogLevels: { [level: string]: LogLevel } = {
   NONE: 'NONE'
 };
 
-// DEBUG is the default. The log level is not specific to an SDK instance.
-let globalLogLevel = LogLevels.DEBUG;
-
-export function setLogLevel(level: LogLevel) {
-  globalLogLevel = level;
-}
-
 export function isLogLevelString(str: string): str is LogLevel {
   return !!find(LogLevels, (lvl: string) => str === lvl);
 }
 
 const defaultOptions = {
+  logLevel: LogLevels.NONE,
   showLevel: true,
 };
 
 export class Logger implements ILogger {
   private category: string;
-  private options: Required<ILoggerOptions>;
+  public options: Required<ILoggerOptions>;
 
-  constructor(category: string, options: ILoggerOptions) {
+  constructor(category: string, options?: ILoggerOptions) {
     this.category = category;
     this.options = objectAssign({}, defaultOptions, options);
   }
 
   debug(msg: string) {
-    if (this._shouldLog(LogLevels.DEBUG))
-      this._log(LogLevels.DEBUG, msg);
+    this._log(LogLevels.DEBUG, msg);
   }
 
   info(msg: string) {
-    if (this._shouldLog(LogLevels.INFO))
-      this._log(LogLevels.INFO, msg);
+    this._log(LogLevels.INFO, msg);
   }
 
   warn(msg: string) {
-    if (this._shouldLog(LogLevels.WARN))
-      this._log(LogLevels.WARN, msg);
+    this._log(LogLevels.WARN, msg);
   }
 
   error(msg: string) {
-    if (this._shouldLog(LogLevels.ERROR))
-      this._log(LogLevels.ERROR, msg);
+    this._log(LogLevels.ERROR, msg);
   }
 
-  _log(level: string, text: string) {
-    const formattedText = this._generateLogMessage(level, text);
+  _log(level: LogLevel, text: string) {
+    if (this._shouldLog(level)) {
+      const formattedText = this._generateLogMessage(level, text);
 
-    console.log(formattedText);
+      console.log(formattedText);
+    }
   }
 
-  _generateLogMessage(level: string, text: string) {
+  _generateLogMessage(level: LogLevel, text: string) {
     const textPre = ' => ';
     let result = '';
 
@@ -77,7 +69,7 @@ export class Logger implements ILogger {
   }
 
   _shouldLog(level: LogLevel) {
-    const logLevel = globalLogLevel;
+    const logLevel = this.options.logLevel;
     const levels = Object.keys(LogLevels).map((f) => LogLevels[f as keyof typeof LogLevels]);
     const index = levels.indexOf(level); // What's the index of what it's trying to check if it should log
     const levelIdx = levels.indexOf(logLevel); // What's the current log level index.

--- a/src/logger/sdkLogger.ts
+++ b/src/logger/sdkLogger.ts
@@ -1,78 +1,47 @@
-/**
- * This file defines the logger interface and default options for the SDKs, not necessarily for the Logger as it's own.
- */
-import { ILoggerOptions } from './types';
-import { Logger, LogLevels, setLogLevel, isLogLevelString } from '.';
-import { isLocalStorageAvailable } from '../utils/env/isLocalStorageAvailable';
-import { isNode } from '../utils/env/isNode';
-import { merge } from '../utils/lang';
+import { LogLevels, isLogLevelString } from './index';
 import { ILoggerAPI } from '../types';
+import { ILogger } from './types';
+// const log = logFactory('splitio-utils:logger');
 
-// @TODO when integrating with other packages, find the best way to update LoggerOption defaults per package (node, evaluator, etc.)
-const defaultOptions: ILoggerOptions = {
-  showLevel: true,
-};
-
-// @TODO when integrating with other packages, find the best way to handle initial state per package/environment
-const LS_KEY = 'splitio_debug';
-const ENV_VAR_KEY = 'SPLITIO_DEBUG';
 
 /**
- * Logger initial debug level, that is disabled ('NONE') by default.
- * Acceptable values are: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'.
- * Other acceptable values are 'on', 'enable' and 'enabled', which are equivalent to 'DEBUG'.
- * Any other string value is equivalent to disable.
+ * The public Logger utility API exposed via SplitFactory, used to update the log level.
+ *
+ * @param log the factory logger instance to handle
  */
-const initialState = String(
-  // eslint-disable-next-line no-undef
-  isNode ? process.env[ENV_VAR_KEY] : isLocalStorageAvailable() ? localStorage.getItem(LS_KEY) : ''
-);
+export function createLoggerAPI(log: ILogger): ILoggerAPI {
 
-// we expose the logger instance creator
-export const logFactory = (namespace: string, options = {}) => new Logger(namespace, merge(options, defaultOptions));
-
-const ownLog = logFactory('splitio-utils:logger');
-
-/**
- * The public Logger utility API exposed via SplitFactory.
- */
-export const API: ILoggerAPI = {
-  /**
-   * Enables all the logs.
-   */
-  enable() {
-    setLogLevel(LogLevels.DEBUG);
-  },
-  /**
-   * Sets a custom log Level for the SDK.
-   * @param {string} logLevel - Custom LogLevel value.
-   */
-  setLogLevel(logLevel: string) {
+  function setLogLevel(logLevel: string) {
     if (isLogLevelString(logLevel)) {
-      setLogLevel(logLevel);
+      log.options.logLevel = logLevel;
     } else {
-      ownLog.error('Invalid Log Level - No changes to the logs will be applied.');
+      log.error('Invalid Log Level - No changes to the logs will be applied.');
     }
-  },
-  /**
-   * Disables all the log levels.
-   */
-  disable() {
-    // Disabling is equal logLevel none
-    setLogLevel(LogLevels.NONE);
-  },
-  /**
-   * Exposed for usage with setLogLevel
-   */
-  LogLevel: LogLevels
-};
+  }
 
-// Kept to avoid a breaking change ('on', 'enable' and 'enabled' are equivalent)
-if (/^(enabled?|on)/i.test(initialState)) {
-  API.enable();
-} else if (isLogLevelString(initialState)) {
-  API.setLogLevel(initialState);
-} else {
-  // By default it starts disabled.
-  API.disable();
+  return {
+    /**
+     * Enables all the logs.
+     */
+    enable() {
+      setLogLevel(LogLevels.DEBUG);
+    },
+    /**
+     * Sets a custom log Level for the SDK.
+     * @param {string} logLevel - Custom LogLevel value.
+     */
+    setLogLevel,
+    /**
+     * Disables all the log levels.
+     */
+    disable() {
+      // Disabling is equal logLevel none
+      setLogLevel(LogLevels.NONE);
+    },
+    /**
+     * Exposed for usage with setLogLevel
+     */
+    LogLevel: LogLevels
+  };
+
 }

--- a/src/logger/sdkLogger.ts
+++ b/src/logger/sdkLogger.ts
@@ -13,7 +13,7 @@ export function createLoggerAPI(log: ILogger): ILoggerAPI {
 
   function setLogLevel(logLevel: string) {
     if (isLogLevelString(logLevel)) {
-      log.options.logLevel = logLevel;
+      log.setLogLevel(logLevel);
     } else {
       log.error('Invalid Log Level - No changes to the logs will be applied.');
     }

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -1,8 +1,13 @@
+import { LogLevel } from '../types';
+
 export interface ILoggerOptions {
+  logLevel?: LogLevel,
   showLevel?: boolean,
 }
 
 export interface ILogger {
+  options: ILoggerOptions
+
   debug(msg: string): void
 
   info(msg: string): void

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -6,7 +6,7 @@ export interface ILoggerOptions {
 }
 
 export interface ILogger {
-  options: ILoggerOptions
+  setLogLevel(logLevel: LogLevel): void
 
   debug(msg: string): void
 

--- a/src/sdkFactory/__tests__/index.spec.ts
+++ b/src/sdkFactory/__tests__/index.spec.ts
@@ -1,6 +1,5 @@
 import { ISdkFactoryParams } from '../types';
 import { sdkFactory } from '../index';
-import { API } from '../../logger/sdkLogger';
 import { fullSettings } from '../../utils/settingsValidation/__tests__/settings.mocks';
 import { SplitIO } from '../../types';
 import EventEmitter from '../../utils/MinEvents';
@@ -14,6 +13,12 @@ const mockStorage = {
   events: jest.fn(),
   impressions: jest.fn()
 };
+const loggerApiMock = 'loggerApi';
+jest.mock('../../logger/sdkLogger', () => {
+  return {
+    createLoggerAPI: () => loggerApiMock
+  };
+});
 
 // IAsyncSDK, minimal params
 const paramsForAsyncSDK = {
@@ -48,7 +53,7 @@ const fullParamsForSyncSDK = {
 /** End Mocks */
 
 function assertSdkApi(sdk: SplitIO.IAsyncSDK | SplitIO.ISDK | SplitIO.ICsSDK, params: any) {
-  expect(sdk.Logger).toBe(API);
+  expect(sdk.Logger).toBe(loggerApiMock);
   expect(sdk.settings).toBe(params.settings);
   expect(sdk.client).toBe(params.sdkClientMethodFactory.mock.results[0].value);
   expect(sdk.manager()).toBe(params.sdkManagerFactory.mock.results[0].value);

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -9,7 +9,7 @@ import { ISplitApi } from '../services/types';
 import { getMatching } from '../utils/key';
 import { shouldBeOptimized } from '../trackers/impressionObserver/utils';
 import { validateAndTrackApiKey } from '../utils/inputValidation/apiKey';
-import { API } from '../logger/sdkLogger';
+import { createLoggerAPI } from '../logger/sdkLogger';
 // import { logFactory } from '../logger/sdkLogger';
 // const log = logFactory('splitio');
 
@@ -94,7 +94,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
     },
 
     // Logger wrapper API
-    Logger: API,
+    Logger: createLoggerAPI(settings.log),
 
     settings,
   };

--- a/src/services/splitHttpClient.ts
+++ b/src/services/splitHttpClient.ts
@@ -46,7 +46,7 @@ export function splitHttpClientFactory(log: ILogger, apikey: string, metadata: I
     return fetch ? fetch(url, request)
       // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful
       .then(response => {
-        if (!response.ok) {
+        if (!response.ok) { // eslint-disable-next-line no-throw-literal
           throw { response };
         }
         return response;

--- a/src/sync/offline/splitsParser/splitsParserFromFile.ts
+++ b/src/sync/offline/splitsParser/splitsParserFromFile.ts
@@ -31,10 +31,10 @@ function configFilesPath(configFilePath?: SplitIO.MockedFeaturesFilePath): Split
 
   // Validate the extensions
   if (!(endsWith(configFilePath, '.yaml', true) || endsWith(configFilePath, '.yml', true) || endsWith(configFilePath, '.split', true)))
-    throw `Invalid extension specified for Splits mock file. Accepted extensions are ".yml" and ".yaml". Your specified file is ${configFilePath}`;
+    throw new Error(`Invalid extension specified for Splits mock file. Accepted extensions are ".yml" and ".yaml". Your specified file is ${configFilePath}`);
 
   if (!fs.existsSync(configFilePath as SplitIO.MockedFeaturesFilePath))
-    throw `Split configuration not found in ${configFilePath} - Please review your Split file location.`;
+    throw new Error(`Split configuration not found in ${configFilePath} - Please review your Split file location.`);
 
   return configFilePath as SplitIO.MockedFeaturesFilePath;
 }

--- a/src/utils/settingsValidation/__tests__/index.spec.ts
+++ b/src/utils/settingsValidation/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { ISettings } from '../../../types';
 import { OPTIMIZED, DEBUG } from '../../constants';
 
@@ -17,7 +18,8 @@ const minimalSettingsParams = {
     },
     version: 'javascript-test',
   },
-  runtime: () => ({ ip: false, hostname: false } as ISettings['runtime'])
+  runtime: () => ({ ip: false, hostname: false } as ISettings['runtime']),
+  logger: () => (loggerMock as ISettings['log'])
 };
 
 describe('settingsValidation', () => {

--- a/src/utils/settingsValidation/index.ts
+++ b/src/utils/settingsValidation/index.ts
@@ -1,10 +1,8 @@
 import { merge } from '../lang';
 import mode from './mode';
 import { validateSplitFilters } from './splitFilters';
-import { API, logFactory } from '../../logger/sdkLogger';
 import { STANDALONE_MODE, OPTIMIZED, LOCALHOST_MODE } from '../constants';
 import validImpressionsMode from './impressionsMode';
-import { LogLevel } from '../../types';
 import { ISettingsInternal, ISettingsValidationParams } from './types';
 
 const base = {
@@ -88,18 +86,6 @@ function fromSecondsToMillis(n: number) {
   return Math.round(n * 1000);
 }
 
-function setupLogger(debugValue: any) {
-  if (typeof debugValue === 'boolean') {
-    if (debugValue) {
-      API.enable();
-    } else {
-      API.disable();
-    }
-  } else if (typeof debugValue === 'string') {
-    API.setLogLevel(debugValue as LogLevel);
-  }
-}
-
 /**
  * Validates the given config and use it to build a settings object.
  *
@@ -108,13 +94,14 @@ function setupLogger(debugValue: any) {
  */
 export function settingsValidation(config: unknown, validationParams: ISettingsValidationParams) {
 
-  const { defaults, runtime, storage, integrations } = validationParams;
+  const { defaults, runtime, storage, integrations, logger } = validationParams;
 
   // creates a settings object merging base, defaults and config objects.
   const withDefaults = merge({}, base, defaults, config) as ISettingsInternal;
 
-  // ensure a valid logger
-  const log = logFactory('splitio'); // @ts-ignore
+  // ensure a valid logger.
+  // First thing to validate, since other validators might use the logger.
+  const log = logger(withDefaults); // @ts-ignore
   withDefaults.log = log;
 
   // Scheduler periods
@@ -137,8 +124,6 @@ export function settingsValidation(config: unknown, validationParams: ISettingsV
   // ensure a valid Storage based on mode defined.
   // @ts-ignore
   if (storage) withDefaults.storage = storage(withDefaults);
-
-  setupLogger(withDefaults.debug);
 
   // Although `key` is mandatory according to TS declaration files, it can be omitted in LOCALHOST mode. In that case, the value `localhost_key` is used.
   if (withDefaults.mode === LOCALHOST_MODE && withDefaults.core.key === undefined) {

--- a/src/utils/settingsValidation/logger/builtinLogger.ts
+++ b/src/utils/settingsValidation/logger/builtinLogger.ts
@@ -1,0 +1,67 @@
+import { isLogLevelString, Logger, LogLevels } from '../../../logger';
+import { ILogger } from '../../../logger/types';
+import { LogLevel } from '../../../types';
+import { isLocalStorageAvailable } from '../../env/isLocalStorageAvailable';
+import { isNode } from '../../env/isNode';
+
+// @TODO when integrating with other packages, find the best way to handle initial state per environment
+const LS_KEY = 'splitio_debug';
+const ENV_VAR_KEY = 'SPLITIO_DEBUG';
+
+/**
+ * Logger initial debug level, that is disabled ('NONE') by default.
+ * Acceptable values are: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'.
+ * Other acceptable values are 'on', 'enable' and 'enabled', which are equivalent to 'DEBUG'.
+ * Any other string value is equivalent to disable.
+ */
+const initialState = String(
+  // eslint-disable-next-line no-undef
+  isNode ? process.env[ENV_VAR_KEY] : isLocalStorageAvailable() ? localStorage.getItem(LS_KEY) : ''
+);
+
+
+// By default it starts disabled.
+let initialLogLevel = LogLevels.NONE;
+
+// Kept to avoid a breaking change ('on', 'enable' and 'enabled' are equivalent)
+if (/^(enabled?|on)/i.test(initialState)) {
+  initialLogLevel = LogLevels.DEBUG;
+} else if (isLogLevelString(initialState)) {
+  initialLogLevel = initialState;
+}
+
+// returns the LogLevel for the given debugValue or undefined if it is invalid.
+// debugValue must be a boolean or LogLevel string.
+export function getLogLevel(debugValue: unknown): LogLevel | undefined {
+  if (typeof debugValue === 'boolean') {
+    if (debugValue) {
+      return LogLevels.DEBUG;
+    } else {
+      return LogLevels.NONE;
+    }
+  } else if (typeof debugValue === 'string' && isLogLevelString(debugValue)) {
+    return debugValue;
+  } else {
+    return undefined;
+  }
+}
+
+/**
+ * Validates the `debug` property at config and use it to set the log level.
+ *
+ * @param settings user config object
+ * @returns a logger instance with the log level at `settings.debug`. If `settings.debug` is invalid or not provided, `initialLogLevel` is used.
+ */
+export function validateLogger(settings: { debug: unknown} ): ILogger {
+
+  const settingLogLevel = settings.debug ? getLogLevel(settings.debug) : initialLogLevel;
+
+  const log = new Logger('splitio', { logLevel: settingLogLevel || initialLogLevel });
+
+  // logs error if the provided settings debug value is invalid
+  if (!settingLogLevel) log.error('Invalid Log Level - No changes to the logs will be applied.');
+
+  return log;
+}
+
+

--- a/src/utils/settingsValidation/logger/pluggableLogger.ts
+++ b/src/utils/settingsValidation/logger/pluggableLogger.ts
@@ -26,5 +26,6 @@ export function validateLogger(settings: { debug: unknown }): ILogger {
 
   if (isLogger(debug)) return debug;
 
+  // @TODO log error instead of throwing one
   throw new Error('The provided `debug` value at config is not valid');
 }

--- a/src/utils/settingsValidation/logger/pluggableLogger.ts
+++ b/src/utils/settingsValidation/logger/pluggableLogger.ts
@@ -1,7 +1,7 @@
 import { ILogger } from '../../../logger/types';
 
 const noopLogger: ILogger = {
-  options: { logLevel: 'NONE' },
+  setLogLevel() { },
   debug() { },
   info() { },
   warn() { },
@@ -10,7 +10,7 @@ const noopLogger: ILogger = {
 
 function isLogger(log: unknown): log is ILogger {
   // @ts-ignore
-  return log && typeof log.debug === 'function' && typeof log.info === 'function' && typeof log.warn === 'function' && typeof log.error === 'function';
+  return log && typeof log.debug === 'function' && typeof log.info === 'function' && typeof log.warn === 'function' && typeof log.error === 'function' && typeof log.setLogLevel === 'function';
 }
 
 /**

--- a/src/utils/settingsValidation/logger/pluggableLogger.ts
+++ b/src/utils/settingsValidation/logger/pluggableLogger.ts
@@ -8,8 +8,7 @@ const noopLogger: ILogger = {
   error() { }
 };
 
-function isLogger(log: unknown): log is ILogger {
-  // @ts-ignore
+function isLogger(log: any): log is ILogger {
   return log && typeof log.debug === 'function' && typeof log.info === 'function' && typeof log.warn === 'function' && typeof log.error === 'function' && typeof log.setLogLevel === 'function';
 }
 

--- a/src/utils/settingsValidation/logger/pluggableLogger.ts
+++ b/src/utils/settingsValidation/logger/pluggableLogger.ts
@@ -1,0 +1,31 @@
+import { ILogger } from '../../../logger/types';
+
+const noopLogger: ILogger = {
+  options: { logLevel: 'NONE' },
+  debug() { },
+  info() { },
+  warn() { },
+  error() { }
+};
+
+function isLogger(log: unknown): log is ILogger {
+  // @ts-ignore
+  return log && typeof log.debug === 'function' && typeof log.info === 'function' && typeof log.warn === 'function' && typeof log.error === 'function';
+}
+
+/**
+ * Validates the `log` (logger) property at config.
+ *
+ * @param settings user config object
+ * @returns the provided logger or a no-op logger if no one is provided
+ * @throws throws an error if a logger was provided but is invalid
+ */
+export function validateLogger(settings: { debug: unknown }): ILogger {
+  const { debug } = settings;
+
+  if (!debug) return noopLogger;
+
+  if (isLogger(debug)) return debug;
+
+  throw new Error('The provided `debug` value at config is not valid');
+}

--- a/src/utils/settingsValidation/types.ts
+++ b/src/utils/settingsValidation/types.ts
@@ -15,6 +15,8 @@ export interface ISettingsValidationParams {
   storage?: (settings: ISettings) => ISettings['storage'],
   /** Integrations validator */
   integrations?: (settings: ISettings) => ISettings['integrations'],
+  /** Logger validator */
+  logger: (settings: ISettings) => ISettings['log'],
 }
 
 /**


### PR DESCRIPTION
# Javascript commons library

Changes:
- removed `GlobalLogLevel` and `setLogLevel` because the log level is handled per instance now:
  - added `logLevel` to logger options and `setLogLevel` as a new Iogger interface method.
  - refactor Logger class: `_shouldLog` is invoked in `_log` to avoid duplicated code
- updated `defaultOptions.logLevel` from DEBUG to NONE, for consistency with initialLogLevel that is NONE by default. Thus, the change is not affecting anything.

- Added 2 variants of the logger validator:
  - `builtinLogger`: for Node and Isomorphic JS SDK. It keeps the legacy behaviour: creates a full version of the logger and validates `config.debug` param to set the log level. `setupLogger` function in settings validation and `initialState` handling in /logger/index, were moved to `standaloneLogger`.
  - `pluggableLogger`: for Browser SDK. It validates that the object provided via `settings.debug` is a valid logger.

[DONE] To discuss:
- [KEEP AS IS NOW] rename "builtin" logger?
- [KEEP AS IS NOW] 'enabled' and 'on' values at `initialState` are handled as DEBUG log level, but logs en error when set at `settings.debug`. is that okey or we should "support" those values in settings.debug ?
- [KEEP AS IS NOW] should `factory.Logger` and `factory.settings.log` be the same object ?
