### PR TITLE
[Pluggable storage] added onReady callback param to async storages

### DIFF
--- a/src/storages/inRedis/index.ts
+++ b/src/storages/inRedis/index.ts
@@ -7,7 +7,6 @@ import ImpressionsCacheInRedis from './ImpressionsCacheInRedis';
 import EventsCacheInRedis from './EventsCacheInRedis';
 import LatenciesCacheInRedis from './LatenciesCacheInRedis';
 import CountsCacheInRedis from './CountsCacheInRedis';
-import { SDK_SPLITS_ARRIVED, SDK_SEGMENTS_ARRIVED } from '../../readiness/constants';
 
 export interface InRedisStorageOptions {
   prefix?: string
@@ -22,17 +21,14 @@ export function InRedisStorage(options: InRedisStorageOptions = {}) {
 
   const prefix = options.prefix ? options.prefix + '.SPLITIO' : 'SPLITIO';
 
-  return function InRedisStorageFactory({ log, readinessManager, metadata }: IStorageFactoryParams): IStorageAsync {
+  return function InRedisStorageFactory({ log, metadata, onReadyCb }: IStorageFactoryParams): IStorageAsync {
 
     const keys = new KeyBuilderSS(prefix, metadata);
     const redisClient = new RedisAdapter(log, options.options || {});
 
     // subscription to Redis connect event in order to emit SDK_READY event on consumer mode
     redisClient.on('connect', () => {
-      if (readinessManager) {
-        readinessManager.splits.emit(SDK_SPLITS_ARRIVED);
-        readinessManager.segments.emit(SDK_SEGMENTS_ARRIVED);
-      }
+      if (onReadyCb) onReadyCb();
     });
 
     return {

--- a/src/storages/pluggable/__tests__/index.spec.ts
+++ b/src/storages/pluggable/__tests__/index.spec.ts
@@ -16,7 +16,8 @@ describe('PLUGGABLE STORAGE', () => {
 
   const internalSdkParams: IStorageFactoryParams = {
     log: loggerMock,
-    metadata
+    metadata,
+    onReadyCb: jest.fn()
   };
 
   afterEach(() => {
@@ -35,6 +36,8 @@ describe('PLUGGABLE STORAGE', () => {
 
     await storage.destroy();
     expect(wrapperMock.close).toBeCalledTimes(1); // wrapper close method should be called once when storage is destroyed
+
+    expect(internalSdkParams.onReadyCb).toBeCalledTimes(1); // onReady callback should be called when the wrapper connect resolved with true
   });
 
   test('throws an exception if wrapper doesn\'t implement the expected interface', async () => {

--- a/src/storages/pluggable/index.ts
+++ b/src/storages/pluggable/index.ts
@@ -5,8 +5,6 @@ import { SplitsCachePluggable } from './SplitsCachePluggable';
 import { SegmentsCachePluggable } from './SegmentsCachePluggable';
 import { ImpressionsCachePluggable } from './ImpressionsCachePluggable';
 import { EventsCachePluggable } from './EventsCachePluggable';
-
-import { SDK_SPLITS_ARRIVED, SDK_SEGMENTS_ARRIVED } from '../../readiness/constants';
 import { wrapperAdapter, METHODS_TO_PROMISE_WRAP } from './wrapperAdapter';
 import { isObject } from '../../utils/lang';
 
@@ -41,16 +39,13 @@ export function PluggableStorage(options: PluggableStorageOptions) {
 
   const prefix = options.prefix ? options.prefix + '.SPLITIO' : 'SPLITIO';
 
-  return function PluggableStorageFactory({ log, metadata, readinessManager }: IStorageFactoryParams): IStorageAsync {
+  return function PluggableStorageFactory({ log, metadata, onReadyCb }: IStorageFactoryParams): IStorageAsync {
     const keys = new KeyBuilderSS(prefix, metadata);
     const wrapper = wrapperAdapter(log, options.wrapper);
 
     // subscription to Wrapper connect event in order to emit SDK_READY event
-    wrapper.connect().then(() => {
-      if (readinessManager) {
-        readinessManager.splits.emit(SDK_SPLITS_ARRIVED);
-        readinessManager.segments.emit(SDK_SEGMENTS_ARRIVED);
-      }
+    wrapper.connect().then((ready) => {
+      if (ready && onReadyCb) onReadyCb();
     });
 
     return {

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -1,6 +1,5 @@
 import { MaybeThenable, IMetadata, ISplitFiltersValidation } from '../dtos/types';
 import { ILogger } from '../logger/types';
-import { IReadinessManager } from '../readiness/types';
 import { SplitIO, ImpressionDTO } from '../types';
 
 /**
@@ -344,6 +343,6 @@ export interface IStorageFactoryParams {
   splitFiltersValidation?: ISplitFiltersValidation,
 
   // Used by InRedis and Pluggable Storage
-  readinessManager?: IReadinessManager,
+  onReadyCb?: () => void,
   metadata: IMetadata,
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added an `onReady` callback parameter for async storage factories (Redis and Pluggable) to decouple the storage from the SDK readiness manager, and then be easier to use by other modules, like the LW synchronizer.

## How do we test the changes introduced in this PR?

- Added assert to UTs.

## Extra Notes