### PR TITLE
Fix: tweak an Array.from exists validation

### DIFF
--- a/src/utils/lang/sets.ts
+++ b/src/utils/lang/sets.ts
@@ -104,7 +104,7 @@ interface ISetConstructor {
  */
 export function __getSetConstructor(): ISetConstructor {
   // eslint-disable-next-line compat/compat
-  if (Array.from && typeof Set === 'function' && Set.prototype && Set.prototype.values) {
+  if (typeof Array.from === 'function' && typeof Set === 'function' && Set.prototype && Set.prototype.values) {
     return Set;
   }
   return SetPoly;


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
I modified the `Array.from` validation because was causing issues when building the Lightweight synchroniser.

## How do we test the changes introduced in this PR?

## Extra Notes