### PR TITLE
[Pluggable storage] splits producer methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Split has built and maintains SDKs for:
 * Java [Github](https://github.com/splitio/java-client) [Docs](https://help.split.io/hc/en-us/articles/360020405151-Java-SDK)
 * Javascript [Github](https://github.com/splitio/javascript-client) [Docs](https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK)
 * Node [Github](https://github.com/splitio/javascript-client) [Docs](https://help.split.io/hc/en-us/articles/360020564931-Node-js-SDK)
+* Javascript for Browser [Github](https://github.com/splitio/javascript-browser-client) [Docs](https://help.split.io/hc/en-us/articles/360058730852)
 * PHP [Github](https://github.com/splitio/php-client) [Docs](https://help.split.io/hc/en-us/articles/360020350372-PHP-SDK)
 * Python [Github](https://github.com/splitio/python-client) [Docs](https://help.split.io/hc/en-us/articles/360020359652-Python-SDK)
 * React [Github](https://github.com/splitio/react-client) [Docs](https://help.split.io/hc/en-us/articles/360038825091-React-SDK)

--- a/src/storages/AbstractSplitsCacheAsync.ts
+++ b/src/storages/AbstractSplitsCacheAsync.ts
@@ -20,7 +20,7 @@ export default abstract class AbstractSplitsCacheAsync implements ISplitsCacheAs
   abstract clear(): Promise<boolean | void>
 
   // @TODO revisit segment-related methods ('usesSegments', 'getRegisteredSegments', 'registerSegments')
-  // noop, just keeping the interface. This is used by client-side API only, and so only implemented by InLocalStorage.
+  // noop, just keeping the interface. This is used by standalone client-side API only, and so only implemented by InMemory and InLocalStorage.
   usesSegments(): Promise<boolean> {
     return Promise.resolve(true);
   }

--- a/src/storages/AbstractSplitsCacheAsync.ts
+++ b/src/storages/AbstractSplitsCacheAsync.ts
@@ -1,0 +1,65 @@
+import { ISplitsCacheAsync } from './types';
+import { ISplit } from '../dtos/types';
+
+/**
+ * This class provides a skeletal implementation of the ISplitsCacheAsync interface
+ * to minimize the effort required to implement this interface.
+ */
+export default abstract class AbstractSplitsCacheAsync implements ISplitsCacheAsync {
+
+  abstract addSplit(name: string, split: string): Promise<boolean>
+  abstract addSplits(entries: [string, string][]): Promise<boolean[] | void>
+  abstract removeSplits(names: string[]): Promise<boolean[] | void>
+  abstract getSplit(name: string): Promise<string | null>
+  abstract getSplits(names: string[]): Promise<Record<string, string | null>>
+  abstract setChangeNumber(changeNumber: number): Promise<boolean | void>
+  abstract getChangeNumber(): Promise<number>
+  abstract getAll(): Promise<string[]>
+  abstract getSplitNames(): Promise<string[]>
+  abstract trafficTypeExists(trafficType: string): Promise<boolean>
+  abstract clear(): Promise<boolean | void>
+
+  // @TODO revisit segment-related methods ('usesSegments', 'getRegisteredSegments', 'registerSegments')
+  // noop, just keeping the interface. This is used by client-side API only, and so only implemented by InLocalStorage.
+  usesSegments(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  /**
+   * Check if the splits information is already stored in cache.
+   * Noop, just keeping the interface. This is used by client-side implementations only.
+   */
+  checkCache(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  /**
+   * Kill `name` split and set `defaultTreatment` and `changeNumber`.
+   * Used for SPLIT_KILL push notifications.
+   *
+   * @param {string} name
+   * @param {string} defaultTreatment
+   * @param {number} changeNumber
+   * @returns {Promise} a promise that is resolved once the split kill operation is performed. The fulfillment value is a boolean: `true` if the kill success updating the split or `false` if no split is updated,
+   * for instance, if the `changeNumber` is old, or if the split is not found (e.g., `/splitchanges` hasn't been fetched yet), or if the storage fails to apply the update.
+   * The promise will never be rejected.
+   */
+  killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean> {
+    return this.getSplit(name).then(split => {
+
+      if (split) {
+        const parsedSplit: ISplit = JSON.parse(split);
+        if (!parsedSplit.changeNumber || parsedSplit.changeNumber < changeNumber) {
+          parsedSplit.killed = true;
+          parsedSplit.defaultTreatment = defaultTreatment;
+          parsedSplit.changeNumber = changeNumber;
+          const newSplit = JSON.stringify(parsedSplit);
+
+          return this.addSplit(name, newSplit);
+        }
+      }
+      return false;
+    }).catch(() => false);
+  }
+
+}

--- a/src/storages/KeyBuilder.ts
+++ b/src/storages/KeyBuilder.ts
@@ -37,6 +37,7 @@ export default class KeyBuilder {
     return `${this.prefix}.split.`;
   }
 
+  // @TODO remove, since it is not set by Synchronizer. ATM, only used by InLocalStorage.
   buildSplitsWithSegmentCountKey() {
     return `${this.prefix}.splits.usingSegments`;
   }

--- a/src/storages/KeyBuilder.ts
+++ b/src/storages/KeyBuilder.ts
@@ -37,7 +37,7 @@ export default class KeyBuilder {
     return `${this.prefix}.split.`;
   }
 
-  // @TODO remove, since it is not set by Synchronizer. ATM, only used by InLocalStorage.
+  // Only used by InLocalStorage.
   buildSplitsWithSegmentCountKey() {
     return `${this.prefix}.splits.usingSegments`;
   }

--- a/src/storages/__tests__/testUtils.ts
+++ b/src/storages/__tests__/testUtils.ts
@@ -11,3 +11,11 @@ export function assertStorageInterface(storage: IStorageSync | IStorageAsync) {
   expect(!storage.counts || typeof storage.counts === 'object').toBeTruthy;
   expect(!storage.impressionCounts || typeof storage.impressionCounts === 'object').toBeTruthy;
 }
+
+// Split mocks
+
+export const splitWithUserTT = '{ "trafficTypeName": "user_tt", "conditions": [] }';
+
+export const splitWithAccountTT = '{ "trafficTypeName": "account_tt", "conditions": [] }';
+
+export const splitWithAccountTTAndUsesSegments = '{ "trafficTypeName": "account_tt", "conditions": [{ "matcherGroup": { "matchers": [{ "matcherType": "IN_SEGMENT", "userDefinedSegmentMatcherData": { "segmentName": "employees" } }]}}] }';

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -1,10 +1,7 @@
 import SplitsCacheInLocal from '../SplitsCacheInLocal';
 import KeyBuilderCS from '../../KeyBuilderCS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-
-const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
-const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
-const splitWithAccountTTAndUsesSegments = '{ "trafficTypeName": "account_tt", "conditions": [{ "matcherGroup": { "matchers": [{ "matcherType": "IN_SEGMENT" }]}}] }';
+import { splitWithUserTT, splitWithAccountTT, splitWithAccountTTAndUsesSegments } from '../../__tests__/testUtils';
 
 test('SPLIT CACHE / LocalStorage', () => {
   const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -2,6 +2,10 @@ import SplitsCacheInLocal from '../SplitsCacheInLocal';
 import KeyBuilderCS from '../../KeyBuilderCS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 
+const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
+const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
+const splitWithAccountTTAndUsesSegments = '{ "trafficTypeName": "account_tt", "conditions": [{ "matcherGroup": { "matchers": [{ "matcherType": "IN_SEGMENT" }]}}] }';
+
 test('SPLIT CACHE / LocalStorage', () => {
   const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
 
@@ -73,12 +77,12 @@ test('SPLIT CACHE / LocalStorage / trafficTypeExists and ttcache tests', () => {
   const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
 
   cache.addSplits([ // loop of addSplit
-    ['split1', '{ "trafficTypeName": "user_tt" }'],
-    ['split2', '{ "trafficTypeName": "account_tt" }'],
-    ['split3', '{ "trafficTypeName": "user_tt" }'],
+    ['split1', splitWithUserTT],
+    ['split2', splitWithAccountTT],
+    ['split3', splitWithUserTT],
     ['malformed', '{}']
   ]);
-  cache.addSplit('split4', '{ "trafficTypeName": "user_tt" }');
+  cache.addSplit('split4', splitWithUserTT);
 
   expect(cache.trafficTypeExists('user_tt')).toBe(true);
   expect(cache.trafficTypeExists('account_tt')).toBe(true);
@@ -99,10 +103,10 @@ test('SPLIT CACHE / LocalStorage / trafficTypeExists and ttcache tests', () => {
   expect(cache.trafficTypeExists('user_tt')).toBe(false);
   expect(cache.trafficTypeExists('account_tt')).toBe(false);
 
-  cache.addSplit('split1', '{ "trafficTypeName": "user_tt" }');
+  cache.addSplit('split1', splitWithUserTT);
   expect(cache.trafficTypeExists('user_tt')).toBe(true);
 
-  cache.addSplit('split1', '{ "trafficTypeName": "account_tt" }');
+  cache.addSplit('split1', splitWithAccountTT);
   expect(cache.trafficTypeExists('account_tt')).toBe(true);
   expect(cache.trafficTypeExists('user_tt')).toBe(false);
 
@@ -138,4 +142,26 @@ test('SPLIT CACHE / LocalStorage / killLocally', () => {
   expect(updated).toBe(false); // killLocally resolves without update if changeNumber is old
   expect(lol1Split.defaultTreatment).not.toBe('some_treatment_2'); // existing split is not updated if given changeNumber is older
 
+});
+
+test('SPLIT CACHE / LocalStorage / usesSegments', () => {
+  const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
+
+  expect(cache.usesSegments()).toBe(true); // true initially, until data is synchronized
+  cache.setChangeNumber(1); // to indicate that data has been synced.
+
+  cache.addSplits([['split1', splitWithUserTT], ['split2', splitWithAccountTT],]);
+  expect(cache.usesSegments()).toBe(false); // 0 splits using segments
+
+  cache.addSplit('split3', splitWithAccountTTAndUsesSegments);
+  expect(cache.usesSegments()).toBe(true); // 1 split using segments
+
+  cache.addSplit('split4', splitWithAccountTTAndUsesSegments);
+  expect(cache.usesSegments()).toBe(true); // 2 splits using segments
+
+  cache.removeSplit('split3');
+  expect(cache.usesSegments()).toBe(true); // 1 split using segments
+
+  cache.removeSplit('split4');
+  expect(cache.usesSegments()).toBe(false); // 0 splits using segments
 });

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -223,7 +223,7 @@ export default class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
    *
    * @NOTE documentation says it never fails.
    */
-  clear(): Promise<boolean> {
+  clear() {
     return this.redis.flushdb().then(status => status === 'OK');
   }
 

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -1,9 +1,11 @@
 import { isFiniteNumber, isNaNNumber } from '../../utils/lang';
 import KeyBuilderSS from '../KeyBuilderSS';
-import { ISplitsCacheAsync } from '../types';
 import { Redis } from 'ioredis';
 import { ILogger } from '../../logger/types';
 import { LOG_PREFIX } from './constants';
+import { ISplit } from '../../dtos/types';
+import { SplitError } from '../../utils/lang/errors';
+import AbstractSplitsCacheAsync from '../AbstractSplitsCacheAsync';
 
 /**
  * Discard errors for an answer of multiple operations.
@@ -19,7 +21,7 @@ function processPipelineAnswer(results: Array<[Error | null, string]>): string[]
  * ISplitsCacheAsync implementation that stores split definitions in Redis.
  * Supported by Node.
  */
-export default class SplitsCacheInRedis implements ISplitsCacheAsync {
+export default class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
 
   private readonly log: ILogger;
   private readonly redis: Redis;
@@ -27,6 +29,7 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
   private redisError?: string;
 
   constructor(log: ILogger, keys: KeyBuilderSS, redis: Redis) {
+    super();
     this.log = log;
     this.redis = redis;
     this.keys = keys;
@@ -42,50 +45,82 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
     });
   }
 
-  // @TODO fix: incr/decr TT and segments for producer mode. Follow pluggable storage signature
-  addSplit(name: string, split: string): Promise<boolean> {
-    return this.redis.set(
-      this.keys.buildSplitKey(name), split
-    ).then(
-      status => status === 'OK'
-    );
-  }
-
-  // @TODO fix: incr/decr TT and segments for producer mode. Follow pluggable storage signature
-  addSplits(entries: [string, string][]): Promise<boolean[]> {
-    if (entries.length) {
-      const cmds = entries.map(keyValuePair => ['set', this.keys.buildSplitKey(keyValuePair[0]), keyValuePair[1]]);
-
-      return this.redis.pipeline(cmds)
-        .exec()
-        .then(processPipelineAnswer)
-        .then(answers => answers.map((status: string) => status === 'OK'));
-    } else {
-      return Promise.resolve([true]);
+  private _decrementCounts(split: ISplit) {
+    if (split.trafficTypeName) {
+      const ttKey = this.keys.buildTrafficTypeKey(split.trafficTypeName);
+      return this.redis.decr(ttKey);
     }
   }
 
-  // @TODO implement for producer mode. Follow pluggable storage signature
-  killLocally(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+  private _incrementCounts(split: ISplit) {
+    if (split.trafficTypeName) {
+      const ttKey = this.keys.buildTrafficTypeKey(split.trafficTypeName);
+      return this.redis.incr(ttKey);
+    }
   }
 
   /**
-   * Remove a given split from Redis. Returns the number of deleted keys.
+   * Add a given split.
+   * The returned promise is resolved when the operation success
+   * or rejected with if it fails (e.g., redis operation fails)
    */
-  removeSplit(name: string): Promise<any> {
-    return this.redis.del(this.keys.buildSplitKey(name));
+  addSplit(name: string, split: string): Promise<boolean> {
+    const splitKey = this.keys.buildSplitKey(name);
+    return this.redis.get(splitKey).then(splitFromStorage => {
+
+      // handling parsing error as SplitErrors
+      let parsedPreviousSplit, parsedSplit;
+      try {
+        parsedPreviousSplit = splitFromStorage ? JSON.parse(splitFromStorage) : undefined;
+        parsedSplit = JSON.parse(split);
+      } catch (e) {
+        throw new SplitError('Error parsing split definition: ' + e);
+      }
+
+      return Promise.all([
+        this.redis.set(splitKey, split),
+        this._incrementCounts(parsedSplit),
+        // If it's an update, we decrement the traffic type of the existing split,
+        parsedPreviousSplit && this._decrementCounts(parsedPreviousSplit)
+      ]);
+    }).then(([status]) => status === 'OK');
   }
 
   /**
-   * Bulk delete of splits from Redis. Returns the number of deleted keys.
+   * Add a list of splits.
+   * The returned promise is resolved when the operation success
+   * or rejected with an SplitError if it fails (e.g., redis operation fails)
+   */
+  addSplits(entries: [string, string][]): Promise<boolean[]> {
+    return Promise.all(entries.map(keyValuePair => this.addSplit(keyValuePair[0], keyValuePair[1])))
+      // @TODO remove if refactoring SDK error handling (it is necessary to distinguish from user cb errors).
+      .catch((e) => { throw new SplitError(e); });
+  }
+
+  /**
+   * Remove a given split.
+   * The returned promise is resolved when the operation success, with 1 or 0 indicating if the split existed or not.
+   * or rejected if it fails (e.g., redis operation fails).
+   */
+  removeSplit(name: string): Promise<number> {
+    return this.getSplit(name).then((split) => {
+      if (split) {
+        const parsedSplit = JSON.parse(split);
+        this._decrementCounts(parsedSplit);
+      }
+      return this.redis.del(this.keys.buildSplitKey(name));
+    });
+  }
+
+  /**
+   * Remove a list of splits.
+   * The returned promise is resolved when the operation success,
+   * or rejected with an SplitError if it fails (e.g., redis operation fails).
    */
   removeSplits(names: string[]): Promise<any> {
-    if (names.length) {
-      return this.redis.del(names.map(n => this.keys.buildSplitKey(n)));
-    } else {
-      return Promise.resolve(0);
-    }
+    return Promise.all(names.map(name => this.removeSplit(name)))
+      // @TODO remove if refactoring SDK error handling (it is necessary to distinguish from user cb errors).
+      .catch((e) => { throw new SplitError(e); });
   }
 
   /**
@@ -104,29 +139,38 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
 
   /**
    * Set till number.
-   *
-   * @TODO pending error handling
+   * The returned promise is resolved when the operation success,
+   * or rejected with an SplitError if it fails.
    */
   setChangeNumber(changeNumber: number): Promise<boolean> {
     return this.redis.set(this.keys.buildSplitsTillKey(), changeNumber + '').then(
       status => status === 'OK'
-    );
+    )
+      // @TODO remove if refactoring SDK error handling (it is necessary to distinguish from user cb errors).
+      .catch((e) => { throw new SplitError(e); });
   }
 
   /**
    * Get till number or -1 if it's not defined.
-   *
-   * @TODO pending error handling
+   * The returned promise is resolved with the changeNumber or -1 if it doesn't exist or a redis operation fails.
+   * The promise will never be rejected.
    */
   getChangeNumber(): Promise<number> {
     return this.redis.get(this.keys.buildSplitsTillKey()).then((value: string | null) => {
       const i = parseInt(value as string, 10);
 
       return isNaNNumber(i) ? -1 : i;
+    }).catch((e) => {
+      this.log.error(LOG_PREFIX + 'Could not retrieve changeNumber from storage. Error: ' + e);
+      return -1;
     });
   }
 
   /**
+   * Get list of all split definitions.
+   * The returned promise is resolved with the list of split definitions,
+   * or rejected if redis operation fails (no need to wrap the error as a SplitError).
+   *
    * @TODO we need to benchmark which is the maximun number of commands we could
    *       pipeline without kill redis performance.
    */
@@ -136,12 +180,23 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
     ).then(processPipelineAnswer);
   }
 
+  /**
+   * Get list of split names.
+   * The returned promise is resolved with the list of split names,
+   * or rejected if redis operation fails (no need to wrap the error as a SplitError).
+   */
   getSplitNames(): Promise<string[]> {
     return this.redis.keys(this.keys.searchPatternForSplitKeys()).then(
       (listOfKeys) => listOfKeys.map(this.keys.extractKey)
     );
   }
 
+  /**
+   * Check traffic type existence.
+   * The returned promise is resolved with a boolean indicating whether the TT exist or not.
+   * In case of redis operation failure, the promise resolves with a true value, assuming that the TT might exist.
+   * It will never be rejected.
+   */
   trafficTypeExists(trafficType: string): Promise<boolean> {
     // If there is a number there should be > 0, otherwise the TT is considered as not existent.
     return this.redis.get(this.keys.buildTrafficTypeKey(trafficType))
@@ -161,11 +216,6 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
         // If there is an error, bypass the validation so the event can get tracked.
         return true;
       });
-  }
-
-  // noop, just keeping the interface. This is used by client-side implementations only.
-  usesSegments(): Promise<boolean> {
-    return Promise.resolve(true);
   }
 
   /**
@@ -203,11 +253,4 @@ export default class SplitsCacheInRedis implements ISplitsCacheAsync {
       });
   }
 
-  /**
-   * Check if the splits information is already stored in cache. Redis would actually be the cache.
-   * Noop, just keeping the interface. This is used by client-side implementations only.
-   */
-  checkCache(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
 }

--- a/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
@@ -2,9 +2,7 @@ import Redis from 'ioredis';
 import SplitsCacheInRedis from '../SplitsCacheInRedis';
 import KeyBuilderSS from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-
-const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
-const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
+import { splitWithUserTT, splitWithAccountTT } from '../../__tests__/testUtils';
 
 describe('SPLITS CACHE REDIS', () => {
 

--- a/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
@@ -3,82 +3,132 @@ import SplitsCacheInRedis from '../SplitsCacheInRedis';
 import KeyBuilderSS from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 
-test('SPLITS CACHE / Redis', async () => {
-  const connection = new Redis();
-  // @ts-expect-error
-  const keys = new KeyBuilderSS();
-  const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
+const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
+const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
 
-  await cache.clear();
+describe('SPLITS CACHE REDIS', () => {
 
-  await cache.addSplits([
-    ['lol1', 'something'],
-    ['lol2', 'something else']
-  ]);
+  test('add/remove/get splits & set/get change number', async () => {
+    const connection = new Redis();
+    // @ts-expect-error
+    const keys = new KeyBuilderSS();
+    const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
 
-  let values = await cache.getAll();
+    await cache.clear();
 
-  expect(values.indexOf('something') !== -1).toBe(true);
-  expect(values.indexOf('something else') !== -1).toBe(true);
+    await cache.addSplits([
+      ['lol1', splitWithUserTT],
+      ['lol2', splitWithAccountTT]
+    ]);
 
-  let splitNames = await cache.getSplitNames();
+    let values = await cache.getAll();
 
-  expect(splitNames.indexOf('lol1') !== -1).toBe(true);
-  expect(splitNames.indexOf('lol2') !== -1).toBe(true);
+    expect(values.indexOf(splitWithUserTT) !== -1).toBe(true);
+    expect(values.indexOf(splitWithAccountTT) !== -1).toBe(true);
 
-  await cache.removeSplit('lol1');
+    let splitNames = await cache.getSplitNames();
 
-  values = await cache.getAll();
+    expect(splitNames.indexOf('lol1') !== -1).toBe(true);
+    expect(splitNames.indexOf('lol2') !== -1).toBe(true);
 
-  expect(values.indexOf('something') === -1).toBe(true);
-  expect(values.indexOf('something else') !== -1).toBe(true);
+    await cache.removeSplit('lol1');
 
-  expect(await cache.getSplit('lol1') == null).toBe(true);
-  expect(await cache.getSplit('lol2') === 'something else').toBe(true);
+    values = await cache.getAll();
 
-  await cache.setChangeNumber(123);
-  expect(await cache.getChangeNumber() === 123).toBe(true);
+    expect(values.indexOf(splitWithUserTT) === -1).toBe(true);
+    expect(values.indexOf(splitWithAccountTT) !== -1).toBe(true);
 
-  splitNames = await cache.getSplitNames();
+    expect(await cache.getSplit('lol1') == null).toBe(true);
+    expect(await cache.getSplit('lol2') === splitWithAccountTT).toBe(true);
 
-  expect(splitNames.indexOf('lol1') === -1).toBe(true);
-  expect(splitNames.indexOf('lol2') !== -1).toBe(true);
+    await cache.setChangeNumber(123);
+    expect(await cache.getChangeNumber() === 123).toBe(true);
 
-  const splits = await cache.getSplits(['lol1', 'lol2']);
-  expect(splits['lol1'] === null).toBe(true);
-  expect(splits['lol2'] === 'something else').toBe(true);
+    splitNames = await cache.getSplitNames();
 
-  await connection.quit();
-});
+    expect(splitNames.indexOf('lol1') === -1).toBe(true);
+    expect(splitNames.indexOf('lol2') !== -1).toBe(true);
 
-test('SPLITS CACHE / Redis / trafficTypeExists tests', async () => {
-  const prefix = 'splits_cache_ut';
-  const connection = new Redis();
-  // @ts-expect-error
-  const keys = new KeyBuilderSS(prefix);
-  const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
+    const splits = await cache.getSplits(['lol1', 'lol2']);
+    expect(splits['lol1'] === null).toBe(true);
+    expect(splits['lol2'] === splitWithAccountTT).toBe(true);
 
-  const testTTName = 'tt_test_name';
-  const testTTNameNoCount = 'tt_test_name_2';
-  const testTTNameInvalid = 'tt_test_name_3';
-  const ttKey = keys.buildTrafficTypeKey(testTTName);
-  const ttKeyNoCount = keys.buildTrafficTypeKey(testTTNameNoCount);
-  const ttKeyInvalid = keys.buildTrafficTypeKey(testTTNameInvalid);
+    await connection.quit();
+  });
 
-  await cache.clear();
+  test('trafficTypeExists', async () => {
+    const prefix = 'splits_cache_ut';
+    const connection = new Redis();
+    // @ts-expect-error
+    const keys = new KeyBuilderSS(prefix);
+    const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
 
-  await connection.set(ttKey, 3);
-  await connection.set(ttKeyNoCount, 0);
-  await connection.set(ttKeyInvalid, 'NaN');
+    const testTTName = 'tt_test_name';
+    const testTTNameNoCount = 'tt_test_name_2';
+    const testTTNameInvalid = 'tt_test_name_3';
+    const ttKey = keys.buildTrafficTypeKey(testTTName);
+    const ttKeyNoCount = keys.buildTrafficTypeKey(testTTNameNoCount);
+    const ttKeyInvalid = keys.buildTrafficTypeKey(testTTNameInvalid);
 
-  expect(await cache.trafficTypeExists(testTTName)).toBe(true);
-  expect(await cache.trafficTypeExists(testTTNameNoCount)).toBe(false);
-  expect(await cache.trafficTypeExists(ttKeyInvalid)).toBe(false);
-  expect(await cache.trafficTypeExists('not_existent_tt')).toBe(false);
+    await cache.clear();
 
-  await connection.del(ttKey);
-  await connection.del(ttKeyNoCount);
-  await connection.del(ttKeyInvalid);
+    await connection.set(ttKey, 3);
+    await connection.set(ttKeyNoCount, 0);
+    await connection.set(ttKeyInvalid, 'NaN');
 
-  await connection.quit();
+    expect(await cache.trafficTypeExists(testTTName)).toBe(true);
+    expect(await cache.trafficTypeExists(testTTNameNoCount)).toBe(false);
+    expect(await cache.trafficTypeExists(ttKeyInvalid)).toBe(false);
+    expect(await cache.trafficTypeExists('not_existent_tt')).toBe(false);
+
+    await connection.del(ttKey);
+    await connection.del(ttKeyNoCount);
+    await connection.del(ttKeyInvalid);
+
+    await connection.quit();
+  });
+
+  test('killLocally', async () => {
+    const connection = new Redis();
+    // @ts-expect-error
+    const keys = new KeyBuilderSS();
+    const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
+
+    await cache.addSplit('lol1', splitWithUserTT);
+    await cache.addSplit('lol2', splitWithAccountTT);
+    const initialChangeNumber = await cache.getChangeNumber();
+
+    // kill an non-existent split
+    let updated = await cache.killLocally('nonexistent_split', 'other_treatment', 101);
+    const nonexistentSplit = await cache.getSplit('nonexistent_split');
+
+    expect(updated).toBe(false); // killLocally resolves without update if split doesn't exist
+    expect(nonexistentSplit).toBe(null); // non-existent split keeps being non-existent
+
+    // kill an existent split
+    updated = await cache.killLocally('lol1', 'some_treatment', 100);
+    let lol1Split = JSON.parse(await cache.getSplit('lol1') as string);
+
+    expect(updated).toBe(true); // killLocally resolves with update if split is changed
+    expect(lol1Split.killed).toBe(true); // existing split must be killed
+    expect(lol1Split.defaultTreatment).toBe('some_treatment'); // existing split must have new default treatment
+    expect(lol1Split.changeNumber).toBe(100); // existing split must have the given change number
+    expect(await cache.getChangeNumber()).toBe(initialChangeNumber); // cache changeNumber is not changed
+
+    // not update if changeNumber is old
+    updated = await cache.killLocally('lol1', 'some_treatment_2', 90);
+    lol1Split = JSON.parse(await cache.getSplit('lol1') as string);
+
+    expect(updated).toBe(false); // killLocally resolves without update if changeNumber is old
+    expect(lol1Split.defaultTreatment).not.toBe('some_treatment_2'); // existing split is not updated if given changeNumber is older
+
+    // Delete splits and TT keys
+    await cache.removeSplits(['lol1', 'lol2']);
+    await connection.del(keys.buildTrafficTypeKey('account_tt'));
+    await connection.del(keys.buildTrafficTypeKey('user_tt'));
+    expect(await connection.keys('*')).toHaveLength(0);
+
+    await connection.quit();
+  });
+
 });

--- a/src/storages/pluggable/SplitsCachePluggable.ts
+++ b/src/storages/pluggable/SplitsCachePluggable.ts
@@ -202,8 +202,8 @@ export class SplitsCachePluggable extends AbstractSplitsCacheAsync {
     });
   }
 
-  // @TODO implement if required for DataLoader/Producer mode
-  clear(): Promise<boolean> {
+  // @TODO implement if required by DataLoader or producer mode
+  clear() {
     return Promise.resolve(true);
   }
 

--- a/src/storages/pluggable/SplitsCachePluggable.ts
+++ b/src/storages/pluggable/SplitsCachePluggable.ts
@@ -1,16 +1,16 @@
-import { isFiniteNumber, toNumber, isNaNNumber } from '../../utils/lang';
+import { isFiniteNumber, isNaNNumber } from '../../utils/lang';
 import KeyBuilder from '../KeyBuilder';
-import { ICustomStorageWrapper, ISplitsCacheAsync } from '../types';
+import { ICustomStorageWrapper } from '../types';
 import { ILogger } from '../../logger/types';
-import { usesSegments } from '../AbstractSplitsCacheSync';
 import { ISplit } from '../../dtos/types';
 import { LOG_PREFIX } from './constants';
 import { SplitError } from '../../utils/lang/errors';
+import AbstractSplitsCacheAsync from '../AbstractSplitsCacheAsync';
 
 /**
  * ISplitsCacheAsync implementation for pluggable storages.
  */
-export class SplitsCachePluggable implements ISplitsCacheAsync {
+export class SplitsCachePluggable extends AbstractSplitsCacheAsync {
 
   private readonly log: ILogger;
   private readonly keys: KeyBuilder;
@@ -23,39 +23,24 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
    * @param wrapper  Adapted wrapper storage.
    */
   constructor(log: ILogger, keys: KeyBuilder, wrapper: ICustomStorageWrapper) {
+    super();
     this.log = log;
     this.keys = keys;
     this.wrapper = wrapper;
   }
 
   private _decrementCounts(split: ISplit) {
-    const promises = [];
     if (split.trafficTypeName) {
       const ttKey = this.keys.buildTrafficTypeKey(split.trafficTypeName);
-      promises.push(this.wrapper.decr(ttKey));
+      return this.wrapper.decr(ttKey);
     }
-
-    if (usesSegments(split)) {
-      const segmentsCountKey = this.keys.buildSplitsWithSegmentCountKey();
-      promises.push(this.wrapper.decr(segmentsCountKey));
-    }
-
-    return Promise.all(promises);
   }
 
   private _incrementCounts(split: ISplit) {
-    const promises = [];
     if (split.trafficTypeName) {
       const ttKey = this.keys.buildTrafficTypeKey(split.trafficTypeName);
-      promises.push(this.wrapper.incr(ttKey));
+      return this.wrapper.incr(ttKey);
     }
-
-    if (usesSegments(split)) {
-      const segmentsCountKey = this.keys.buildSplitsWithSegmentCountKey();
-      promises.push(this.wrapper.incr(segmentsCountKey));
-    }
-
-    return Promise.all(promises);
   }
 
   /**
@@ -76,11 +61,11 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
         throw new SplitError('Error parsing split definition: ' + e);
       }
 
-      return Promise.all<boolean[], boolean, boolean[]>([
-        // If it's an update, we decrement the traffic type and segment count of the existing split,
-        parsedPreviousSplit && this._decrementCounts(parsedPreviousSplit),
+      return Promise.all([
         this.wrapper.set(splitKey, split),
-        this._incrementCounts(parsedSplit)
+        this._incrementCounts(parsedSplit),
+        // If it's an update, we decrement the traffic type and segment count of the existing split,
+        parsedPreviousSplit && this._decrementCounts(parsedPreviousSplit)
       ]);
     }).then(() => true);
   }
@@ -99,7 +84,7 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
    * The returned promise is resolved when the operation success, with a boolean indicating if the split existed or not.
    * or rejected with an SplitError if it fails (e.g., wrapper operation fails).
    */
-  removeSplit(name: string): Promise<boolean> {
+  removeSplit(name: string) {
     return this.getSplit(name).then((split) => {
       if (split) {
         const parsedSplit = JSON.parse(split);
@@ -114,7 +99,7 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
    * The returned promise is resolved when the operation success, with a boolean array indicating if the splits existed or not.
    * or rejected with an SplitError if it fails (e.g., wrapper operation fails).
    */
-  removeSplits(names: string[]): Promise<boolean[]> {
+  removeSplits(names: string[]): Promise<void> { // @ts-ignore
     return Promise.all(names.map(name => this.removeSplit(name)));
   }
 
@@ -197,7 +182,7 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
    * The returned promise is resolved when the operation success,
    * or rejected with an SplitError if it fails (e.g., wrapper operation fails).
    */
-  setChangeNumber(changeNumber: number): Promise<boolean> {
+  setChangeNumber(changeNumber: number) {
     return this.wrapper.set(this.keys.buildSplitsTillKey(), changeNumber + '');
   }
 
@@ -217,58 +202,9 @@ export class SplitsCachePluggable implements ISplitsCacheAsync {
     });
   }
 
-  // @TODO revisit segment-related methods ('usesSegments', 'getRegisteredSegments', 'registerSegments')
-  usesSegments(): Promise<boolean> {
-    return this.wrapper.get(this.keys.buildSplitsWithSegmentCountKey())
-      .then(storedCount => {
-        const splitsWithSegmentsCount = storedCount ? toNumber(storedCount) : 0;
-        if (isFiniteNumber(splitsWithSegmentsCount)) {
-          return splitsWithSegmentsCount > 0;
-        } else {
-          return true; // If stored valus is invalid, assume we need them.
-        }
-      }).catch(() => true); // If wrapper operation fails, assume we need them.
-  }
-
-  // @TODO implement for DataLoader/Producer mode
+  // @TODO implement if required for DataLoader/Producer mode
   clear(): Promise<boolean> {
     return Promise.resolve(true);
   }
 
-  /**
-   * Check if the splits information is already stored in cache.
-   * Noop, just keeping the interface. This is used by client-side implementations only.
-   */
-  checkCache(): Promise<boolean> {
-    return Promise.resolve(true);
-  }
-
-  /**
-   * Kill `name` split and set `defaultTreatment` and `changeNumber`.
-   * Used for SPLIT_KILL push notifications.
-   *
-   * @param {string} name
-   * @param {string} defaultTreatment
-   * @param {number} changeNumber
-   * @returns {Promise} a promise that is resolved once the split kill operation is performed. The fulfillment value is a boolean: `true` if the kill success updating the split or `false` if no split is updated,
-   * for instance, if the `changeNumber` is old, or if the split is not found (e.g., `/splitchanges` hasn't been fetched yet), or if the storage fails to apply the update.
-   * The promise will never be rejected.
-   */
-  killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean> {
-    return this.getSplit(name).then(split => {
-
-      if (split) {
-        const parsedSplit: ISplit = JSON.parse(split);
-        if (!parsedSplit.changeNumber || parsedSplit.changeNumber < changeNumber) {
-          parsedSplit.killed = true;
-          parsedSplit.defaultTreatment = defaultTreatment;
-          parsedSplit.changeNumber = changeNumber;
-          const newSplit = JSON.stringify(parsedSplit);
-
-          return this.addSplit(name, newSplit);
-        }
-      }
-      return false;
-    }).catch(() => false);
-  }
 }

--- a/src/storages/pluggable/__tests__/SplitsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/SplitsCachePluggable.spec.ts
@@ -2,9 +2,8 @@ import { SplitsCachePluggable } from '../SplitsCachePluggable';
 import KeyBuilder from '../../KeyBuilder';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMockFactory } from './wrapper.mock';
+import { splitWithUserTT, splitWithAccountTT } from '../../__tests__/testUtils';
 
-const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
-const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
 const keysBuilder = new KeyBuilder();
 
 describe('SPLITS CACHE PLUGGABLE', () => {

--- a/src/storages/pluggable/__tests__/SplitsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/SplitsCachePluggable.spec.ts
@@ -5,7 +5,6 @@ import { wrapperMockFactory } from './wrapper.mock';
 
 const splitWithUserTT = '{ "trafficTypeName": "user_tt" }';
 const splitWithAccountTT = '{ "trafficTypeName": "account_tt" }';
-const splitWithAccountTTAndUsesSegments = '{ "trafficTypeName": "account_tt", "conditions": [{ "matcherGroup": { "matchers": [{ "matcherType": "IN_SEGMENT" }]}}] }';
 const keysBuilder = new KeyBuilder();
 
 describe('SPLITS CACHE PLUGGABLE', () => {
@@ -117,25 +116,6 @@ describe('SPLITS CACHE PLUGGABLE', () => {
     expect(await cache.trafficTypeExists('account_tt')).toBe(true);
     expect(await cache.trafficTypeExists('user_tt')).toBe(false);
 
-  });
-
-  test('usesSegments', async () => {
-    const cache = new SplitsCachePluggable(loggerMock, keysBuilder, wrapperMockFactory());
-
-    await cache.addSplits([['split1', splitWithUserTT], ['split2', splitWithAccountTT],]);
-    expect(await cache.usesSegments()).toBe(false); // 0 splits using segments
-
-    await cache.addSplit('split3', splitWithAccountTTAndUsesSegments);
-    expect(await cache.usesSegments()).toBe(true); // 1 split using segments
-
-    await cache.addSplit('split4', splitWithAccountTTAndUsesSegments);
-    expect(await cache.usesSegments()).toBe(true); // 2 splits using segments
-
-    await cache.removeSplit('split3');
-    expect(await cache.usesSegments()).toBe(true); // 1 split using segments
-
-    await cache.removeSplit('split4');
-    expect(await cache.usesSegments()).toBe(false); // 0 splits using segments
   });
 
   test('killLocally', async () => {

--- a/src/storages/pluggable/__tests__/index.spec.ts
+++ b/src/storages/pluggable/__tests__/index.spec.ts
@@ -5,7 +5,7 @@ import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { IStorageFactoryParams } from '../../types';
 import { wrapperMock, wrapperMockFactory } from './wrapper.mock';
 
-const metadata = {  s: 'version', i: 'ip', n: 'hostname' };
+const metadata = { s: 'version', i: 'ip', n: 'hostname' };
 const prefix = 'some_prefix';
 
 // Test target

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -3,96 +3,149 @@ import { ILogger } from '../logger/types';
 import { SplitIO, ImpressionDTO } from '../types';
 
 /**
- * Interface to define a custom wrapper storage.
+ * Interface of a custom wrapper storage.
  */
 export interface ICustomStorageWrapper {
   /**
-   * Return a promise that resolves with the element value associated with the specified `key`, or null if the key can't be found in the storage.
+   * Get the value of given `key`.
+   *
+   * @function get
+   * @param {string} key item to retrieve
+   * @returns {Promise<string | null>} A promise that resolves with the element value associated with the specified `key`, or null if the key does not exist.
+   * The promise rejects if the operation fails.
    */
   get: (key: string) => Promise<string | null>
   /**
-   * Add or update an element with a specified `key` and `value`.
-   * Returns a promise that resolves with a boolean value:
-   *   - true if the element existed and was updated,
-   *   - or false if the element didn't exist and was added.
+   * Add or update an item with a specified `key` and `value`.
+   *
+   * @function set
+   * @param {string} key item to update
+   * @param {string} value value to set
+   * @returns {Promise<void>} A promise that resolves if the operation success, whether the key was added or updated.
+   * The promise rejects if the operation fails.
    */
-  set: (key: string, value: string) => Promise<boolean>
+  set: (key: string, value: string) => Promise<void | boolean>
   /**
-   * Add or update an element with a specified `key` and `value`.
-   * Returns a promise that resolves with the previous value associated to the given `key`, or null if not set.
-   *   - true if the element existed and was updated,
-   *   - or false if the element didn't exist and was added.
+   * Add or update an item with a specified `key` and `value`.
+   *
+   * @function getAndSet
+   * @param {string} key item to update
+   * @param {string} value value to set
+   * @returns {Promise<string | null>} A promise that resolves with the previous value associated to the given `key`, or null if not set.
+   * The promise rejects if the operation fails.
    */
   getAndSet: (key: string, value: string) => Promise<string | null>
   /**
-   * Remove the specified element by `key`.
-   * Return a promise that resolves with a boolean value:
-   *   - true if the element existed and has been removed,
-   *   - or false if the element does not exist.
+   * Removes the specified item by `key`.
+   *
+   * @function del
+   * @param {string} key item to delete
+   * @returns {Promise<void>} A promise that resolves if the operation success, whether the key existed and was removed or it didn't exist.
+   * The promise rejects if the operation fails, for example, if there is a connectin error.
    */
-  del: (key: string) => Promise<boolean>
+  del: (key: string) => Promise<void | boolean>
   /**
-   * Return a promise that resolves with the list of element keys that match with the given `prefix`.
+   * Returns all keys matching the given prefix.
+   *
+   * @function getKeysByPrefix
+   * @param {string} prefix string prefix to match
+   * @returns {Promise<string[]>} A promise that resolves with the list of keys that match the given `prefix`.
+   * The promise rejects if the operation fails.
    */
   getKeysByPrefix: (prefix: string) => Promise<string[]>
   /**
-   * Return a promise that resolves with the list of element values that match with the given `prefix`.
+   * Returns all values which keys match the given prefix.
+   *
+   * @function getByPrefix
+   * @param {string} prefix
+   * @returns {Promise<string[]>} A promise that resolves with the list of values which keys match the given `prefix`.
+   * The promise rejects if the operation fails.
    */
   getByPrefix: (prefix: string) => Promise<string[]>
   /**
-   * Increment in 1 the given `key` value or set it in 1 if the value doesn't exist.
-   * Return a resolved promise with a boolean value:
-   *   - true if the value was incremented,
-   *   - or false if the value already existed and couldn't be parsed into a finite number.
-   * @param key
+   * Increments in 1 the given `key` value or set it in 1 if the value doesn't exist.
+   *
+   * @function incr
+   * @param {string} key key to increment
+   * @returns {Promise<void>} A promise that resolves if the operation success.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key contains a string that can not be represented as integer.
    */
-  incr: (key: string) => Promise<boolean>
+  incr: (key: string) => Promise<void | boolean>
   /**
-   * Decrement in 1 the given `key` value or set it in -1 if the value doesn't exist.
-   * Return a promise that resolves with a boolean value:
-   *   - true if the value was decremented,
-   *   - or false if the value already existed and couldn't be parsed into a finite number.
-   * @param key
+   * Decrements in 1 the given `key` value or set it in -1 if the value doesn't exist.
+   *
+   * @function decr
+   * @param {string} key key to decrement
+   * @returns {Promise<void>} A promise that resolves if the operation success.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key contains a string that can not be represented as integer.
    */
-  decr: (key: string) => Promise<boolean>
+  decr: (key: string) => Promise<void | boolean>
   /**
-   * Return a promise that resolves with the list of elements associated with the specified list of `keys`.
+   * Returns the values of all given `keys`.
+   *
+   * @function getMany
+   * @param {string[]} keys list of keys to retrieve
+   * @returns {Promise<(string | null)[]>} A promise that resolves with the list of items associated with the specified list of `keys`. For every key that does not hold a string value or does not exist, null is returned.
+   * The promise rejects if the operation fails.
    */
   getMany: (keys: string[]) => Promise<(string | null)[]>
   /**
-   * Push given `items` to `key` list. If key does not exist, an empty list is created for the key before pushing the items.
-   * Return a promise that resolves if the operation success,
-   * or rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
+   * Inserts given items at the tail of `key` list. If `key` does not exist, an empty list is created before pushing the items.
+   *
+   * @function pushItems
+   * @param {string} key list key
+   * @param {string[]} items list of items to push
+   * @returns {Promise<void>} A promise that resolves if the operation success.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
    */
   pushItems: (key: string, items: string[]) => Promise<void>
   /**
-   * Pop `count` number of items from `key` queue.
-   * Return a promise that resolves with the list of removed items the removed members,
-   * or an empty array when key does not exist or is not a list.
+   * Removes and returns the first `count` items from a list. If `key` does not exist, an empty list is items is returned.
+   *
+   * @function popItems
+   * @param {string} key list key
+   * @param {number} count number of items to pop
+   * @returns {Promise<string[]>} A promise that resolves with the list of removed items from the list, or an empty array when key does not exist.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
    */
   popItems: (key: string, count: number) => Promise<string[]>
   /**
-   * Return a promise that resolves with the number of items at the `key` queue, or 0 when key does not exist or is not a list.
+   * Returns the count of items in a list, or 0 if `key` does not exist.
+   *
+   * @function getItemsCount
+   * @param {string} key list key
+   * @returns {Promise<number>} A promise that resolves with the number of items at the `key` list, or 0 when `key` does not exist.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
    */
   getItemsCount: (key: string) => Promise<number>
   /**
-   * Return a promise that resolves with true boolean value if `item` is a member of the list stored at `key`,
-   * or false if it is not a member or key does not exist or is not a list.
+   * Returns if item is a member of a list.
+   *
+   * @function itemContains
+   * @param {string} key list key
+   * @param {string} item item value
+   * @returns {Promise<boolean>} A promise that resolves with true boolean value if `item` is a member of the list stored at `key`, or false if it is not a member or `key` list does not exist.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
    */
   itemContains: (key: string, item: string) => Promise<boolean>
-
   /**
-   * For storages that requires to be connected, like database servers.
-   * Return a promise that resolves when the wrapper successfully connect to the underlying storage,
-   * or rejects if the wrapper fails to connect.
-   *
+   * Connects to the underlying storage.
+   * It is meant for storages that requires to be connected to some database or server. Otherwise it can just return a resolved promise.
    * Note: will be called once on SplitFactory instantiation.
+   *
+   * @function connect
+   * @returns {Promise<void>} A promise that resolves when the wrapper successfully connect to the underlying storage.
+   * The promise rejects with the corresponding error if the wrapper fails to connect.
    */
   connect: () => Promise<void>
   /**
-   * For storages that requires to be closed, for example, to release resources.
+   * Disconnects the underlying storage.
+   * It is meant for storages that requires to be closed, in order to release resources. Otherwise it can just return a resolved promise.
+   * Note: will be called once on SplitFactory client destroy.
    *
-   * Note: will be called once on SplitFactory default client destroy.
+   * @function close
+   * @returns {Promise<void>} A promise that resolves when the operation ends.
+   * The promise never rejects.
    */
   close: () => Promise<void>
 }
@@ -100,55 +153,53 @@ export interface ICustomStorageWrapper {
 /** Splits cache */
 
 export interface ISplitsCacheBase {
-  addSplit(name: string, split: string): MaybeThenable<boolean>, // @TODO remove as in spec
-  addSplits(entries: [string, string][]): MaybeThenable<boolean[]>,
-  removeSplit(name: string): MaybeThenable<boolean>, // @TODO remove as in spec
-  removeSplits(names: string[]): MaybeThenable<boolean[]>,
+  addSplits(entries: [string, string][]): MaybeThenable<boolean[] | void>,
+  removeSplits(names: string[]): MaybeThenable<boolean[] | void>,
   getSplit(name: string): MaybeThenable<string | null>,
   getSplits(names: string[]): MaybeThenable<Record<string, string | null>>, // `fetchMany` in spec
-  setChangeNumber(changeNumber: number): MaybeThenable<boolean>,
+  setChangeNumber(changeNumber: number): MaybeThenable<boolean | void>,
+  // should never reject or throw an exception. Instead return -1 by default, assuming no splits are present in the storage.
   getChangeNumber(): MaybeThenable<number>,
   getAll(): MaybeThenable<string[]>,
   getSplitNames(): MaybeThenable<string[]>,
+  // should never reject or throw an exception. Instead return true by default, asssuming the TT might exist.
   trafficTypeExists(trafficType: string): MaybeThenable<boolean>,
+  // only for Client-Side
   usesSegments(): MaybeThenable<boolean>,
-  clear(): MaybeThenable<void | boolean>,
+  clear(): MaybeThenable<boolean | void>,
+  // should never reject or throw an exception. Instead return false by default, to avoid emitting SDK_READY_FROM_CACHE.
   checkCache(): MaybeThenable<boolean>,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): MaybeThenable<boolean>
 }
 
 export interface ISplitsCacheSync extends ISplitsCacheBase {
-  addSplit(name: string, split: string): boolean,
-  addSplits(entries: [string, string][]): boolean[]
-  removeSplit(name: string): boolean
-  removeSplits(names: string[]): boolean[]
-  getSplit(name: string): string | null
-  getSplits(names: string[]): Record<string, string | null>
-  setChangeNumber(changeNumber: number): boolean
-  getChangeNumber(): number
-  getAll(): string[]
-  getSplitNames(): string[]
-  trafficTypeExists(trafficType: string): boolean
-  usesSegments(): boolean
-  clear(): void
-  checkCache(): boolean
+  addSplits(entries: [string, string][]): boolean[],
+  removeSplits(names: string[]): boolean[],
+  getSplit(name: string): string | null,
+  getSplits(names: string[]): Record<string, string | null>,
+  setChangeNumber(changeNumber: number): boolean,
+  getChangeNumber(): number,
+  getAll(): string[],
+  getSplitNames(): string[],
+  trafficTypeExists(trafficType: string): boolean,
+  usesSegments(): boolean,
+  clear(): void,
+  checkCache(): boolean,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): boolean
 }
 
 export interface ISplitsCacheAsync extends ISplitsCacheBase {
-  addSplit(name: string, split: string): Promise<boolean>,
-  addSplits(entries: [string, string][]): Promise<boolean[]>,
-  removeSplit(name: string): Promise<boolean>,
-  removeSplits(names: string[]): Promise<boolean[]>,
+  addSplits(entries: [string, string][]): Promise<boolean[] | void>,
+  removeSplits(names: string[]): Promise<boolean[] | void>,
   getSplit(name: string): Promise<string | null>,
   getSplits(names: string[]): Promise<Record<string, string | null>>,
-  setChangeNumber(changeNumber: number): Promise<boolean>,
+  setChangeNumber(changeNumber: number): Promise<boolean | void>,
   getChangeNumber(): Promise<number>,
   getAll(): Promise<string[]>,
   getSplitNames(): Promise<string[]>,
   trafficTypeExists(trafficType: string): Promise<boolean>,
   usesSegments(): Promise<boolean>,
-  clear(): Promise<boolean>,
+  clear(): Promise<boolean | void>,
   checkCache(): Promise<boolean>,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean>
 }
@@ -156,14 +207,14 @@ export interface ISplitsCacheAsync extends ISplitsCacheBase {
 /** Segments cache */
 
 export interface ISegmentsCacheBase {
-  addToSegment(name: string, segmentKeys: string[]): MaybeThenable<boolean> // different signature on Server and Client-Side
-  removeFromSegment(name: string, segmentKeys: string[]): MaybeThenable<boolean> // different signature on Server and Client-Side
+  addToSegment(name: string, segmentKeys: string[]): MaybeThenable<boolean | void> // different signature on Server and Client-Side
+  removeFromSegment(name: string, segmentKeys: string[]): MaybeThenable<boolean | void> // different signature on Server and Client-Side
   isInSegment(name: string, key?: string): MaybeThenable<boolean> // different signature on Server and Client-Side
-  registerSegments(names: string[]): MaybeThenable<boolean> // only for Server-Side
+  registerSegments(names: string[]): MaybeThenable<boolean | void> // only for Server-Side
   getRegisteredSegments(): MaybeThenable<string[]> // only for Server-Side
-  setChangeNumber(name: string, changeNumber: number): MaybeThenable<boolean> // only for Server-Side
+  setChangeNumber(name: string, changeNumber: number): MaybeThenable<boolean | void> // only for Server-Side
   getChangeNumber(name: string): MaybeThenable<number> // only for Server-Side
-  clear(): MaybeThenable<void | boolean>
+  clear(): MaybeThenable<boolean | void>
 }
 
 // Same API for both variants: SegmentsCache and MySegmentsCache (client-side API)
@@ -180,12 +231,12 @@ export interface ISegmentsCacheSync extends ISegmentsCacheBase {
 }
 
 export interface ISegmentsCacheAsync extends ISegmentsCacheBase {
-  addToSegment(name: string, segmentKeys: string[]): Promise<boolean>
-  removeFromSegment(name: string, segmentKeys: string[]): Promise<boolean>
+  addToSegment(name: string, segmentKeys: string[]): Promise<boolean | void>
+  removeFromSegment(name: string, segmentKeys: string[]): Promise<boolean | void>
   isInSegment(name: string, key?: string): Promise<boolean>
-  registerSegments(names: string[]): Promise<boolean>
+  registerSegments(names: string[]): Promise<boolean | void>
   getRegisteredSegments(): Promise<string[]>
-  setChangeNumber(name: string, changeNumber: number): Promise<boolean>
+  setChangeNumber(name: string, changeNumber: number): Promise<boolean | void>
   getChangeNumber(name: string): Promise<number>
   clear(): Promise<boolean>
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added/Fixed producer methods of `SplitsCacheInRedis`.
- Refactored `killLocally` and other common methods of Redis and Pluggable split cache, into an abstract class.
- Updated `SplitCachePluggable`: noop operation for `usesSegments`, which is not used in producer mode. It allows to avoid the use of the key "PREFIX.splits.usingSegments" in Redis and Pluggable storage, which is not set by the GO synchronizer.

## How do we test the changes introduced in this PR?

- Updated and added new UTs.

## Extra Notes