### PR TITLE
[Pluggable storage] segments producer methods for Redis and Pluggable storages

### DIFF
--- a/src/storages/inMemory/__tests__/SegmentsCacheInMemory.spec.ts
+++ b/src/storages/inMemory/__tests__/SegmentsCacheInMemory.spec.ts
@@ -1,33 +1,43 @@
 import SegmentsCache from '../SegmentsCacheInMemory';
 
-test('SEGMENTS CACHE / in memory', () => {
-  const cache = new SegmentsCache();
+describe('SEGMENTS CACHE IN MEMORY', () => {
 
-  cache.addToSegment('mocked-segment', [
-    'a', 'b', 'c'
-  ]);
+  test('isInSegment, set/getChangeNumber, add/removeFromSegment', () => {
+    const cache = new SegmentsCache();
 
-  cache.setChangeNumber('mocked-segment', 1);
+    cache.addToSegment('mocked-segment', [
+      'a', 'b', 'c'
+    ]);
 
-  cache.removeFromSegment('mocked-segment', [
-    'd'
-  ]);
+    cache.setChangeNumber('mocked-segment', 1);
 
-  expect(cache.getChangeNumber('mocked-segment') === 1).toBe(true);
+    cache.removeFromSegment('mocked-segment', ['d']);
 
-  cache.addToSegment('mocked-segment', [
-    'd', 'e'
-  ]);
+    expect(cache.getChangeNumber('mocked-segment') === 1).toBe(true);
 
-  cache.removeFromSegment('mocked-segment', [
-    'a', 'c'
-  ]);
+    cache.addToSegment('mocked-segment', ['d', 'e']);
 
-  expect(cache.getChangeNumber('mocked-segment') === 1).toBe(true);
+    cache.removeFromSegment('mocked-segment', ['a', 'c']);
 
-  expect(cache.isInSegment('mocked-segment', 'a')).toBe(false);
-  expect(cache.isInSegment('mocked-segment', 'b')).toBe(true); // b
-  expect(cache.isInSegment('mocked-segment', 'c')).toBe(false); // c
-  expect(cache.isInSegment('mocked-segment', 'd')).toBe(true); // d
-  expect(cache.isInSegment('mocked-segment', 'e')).toBe(true); // e
+    expect(cache.getChangeNumber('mocked-segment') === 1).toBe(true);
+
+    expect(cache.isInSegment('mocked-segment', 'a')).toBe(false);
+    expect(cache.isInSegment('mocked-segment', 'b')).toBe(true); // b
+    expect(cache.isInSegment('mocked-segment', 'c')).toBe(false); // c
+    expect(cache.isInSegment('mocked-segment', 'd')).toBe(true); // d
+    expect(cache.isInSegment('mocked-segment', 'e')).toBe(true); // e
+  });
+
+  test('registerSegment / getRegisteredSegments', async () => {
+    const cache = new SegmentsCache();
+
+    await cache.registerSegments(['s1']);
+    await cache.registerSegments(['s2']);
+    await cache.registerSegments(['s2', 's3', 's4']);
+
+    const segments = cache.getRegisteredSegments();
+
+    ['s1', 's2', 's3', 's4'].forEach(s => expect(segments.indexOf(s) !== -1).toBe(true));
+  });
+
 });

--- a/src/storages/inRedis/SegmentsCacheInRedis.ts
+++ b/src/storages/inRedis/SegmentsCacheInRedis.ts
@@ -71,7 +71,7 @@ export default class SegmentsCacheInRedis implements ISegmentsCacheAsync {
 
   getRegisteredSegments() {
     return this.redis.smembers(this.keys.buildRegisteredSegmentsKey())
-      // @TODO remove if refactoring SDK error handling (it is necessary to distinguish from user cb errors).
+      // Wrapping error to distinguish from user cb errors. @TODO remove if refactoring SDK error handling.
       .catch((e) => { throw new SplitError(e); });
   }
 

--- a/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
@@ -95,6 +95,7 @@ test('IMPRESSIONS CACHE IN REDIS / should not resolve track before calling expir
 
   // @ts-expect-error
   c.track([i1, i2]).then(() => {
+    connection.del(impressionsKey);
     connection.quit(); // Try to disconnect right away.
     expect(spy1).toBeCalled(); // Redis rpush was called once before executing external callback.
     // Following assertion fails if the expire takes place after disconnected and throws unhandledPromiseRejection

--- a/src/storages/inRedis/index.ts
+++ b/src/storages/inRedis/index.ts
@@ -33,7 +33,7 @@ export function InRedisStorage(options: InRedisStorageOptions = {}) {
 
     return {
       splits: new SplitsCacheInRedis(log, keys, redisClient),
-      segments: new SegmentsCacheInRedis(keys, redisClient),
+      segments: new SegmentsCacheInRedis(log, keys, redisClient),
       impressions: new ImpressionsCacheInRedis(keys, redisClient, metadata),
       events: new EventsCacheInRedis(log, keys, redisClient, metadata),
       latencies: new LatenciesCacheInRedis(keys, redisClient),

--- a/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
@@ -28,7 +28,7 @@ describe('PLUGGABLE EVENTS CACHE', () => {
     // @ts-expect-error
     expect(await cache.track(fakeEvent3)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
 
-    const values = wrapperMock._cache[key];
+    const values = wrapperMock._cache[key] as string[];
 
     expect(values.length).toBe(3); // After pushing we should have as many events as we have stored.
     expect(typeof values[0]).toBe('string'); // All elements should be strings since those are stringified JSONs.

--- a/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
@@ -50,12 +50,12 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
 
     expect(await cache.track([o1])).toBe(true); // result should resolve to true
 
-    let state = wrapperMock._cache[impressionsKey];
+    let state = wrapperMock._cache[impressionsKey] as string[];
     expect(state.length).toBe(1); // impression should be stored
 
     expect(await cache.track([o2, o3])).toBe(true);
 
-    state = wrapperMock._cache[impressionsKey];
+    state = wrapperMock._cache[impressionsKey] as string[];
     expect(state.length).toBe(3);
     // This is testing both the track and the toJSON method.
     expect(state[0]).toBe(JSON.stringify({

--- a/src/storages/pluggable/__tests__/SegmentsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/SegmentsCachePluggable.spec.ts
@@ -1,9 +1,10 @@
 import { SegmentsCachePluggable } from '../SegmentsCachePluggable';
-import KeyBuilder from '../../KeyBuilder';
+import KeyBuilderSS from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMock } from './wrapper.mock';
 
-const keyBuilder = new KeyBuilder();
+// @ts-ignore. Doesn't require metadata
+const keyBuilder = new KeyBuilderSS();
 
 describe('SEGMENTS CACHE PLUGGABLE', () => {
 
@@ -12,25 +13,44 @@ describe('SEGMENTS CACHE PLUGGABLE', () => {
     wrapperMock.mockClear();
   });
 
-  test('isInSegment, set/getChangeNumber', async () => {
+  test('isInSegment, set/getChangeNumber, add/removeFromSegment', async () => {
     const cache = new SegmentsCachePluggable(loggerMock, keyBuilder, wrapperMock);
 
-    // assert setChangeNumber and getChangeNumber
-    expect(await cache.setChangeNumber('mocked-segment', 100)).toBe(false);
-    expect(await cache.getChangeNumber('mocked-segment')).toBe(100);
-    expect(await cache.setChangeNumber('mocked-segment', 200)).toBe(true);
-    expect(await cache.getChangeNumber('mocked-segment')).toBe(200);
+    await cache.addToSegment('mocked-segment', ['a', 'b', 'c']);
+
+    await cache.setChangeNumber('mocked-segment', 1);
+
+    await cache.removeFromSegment('mocked-segment', ['d']);
+
+    expect(await cache.getChangeNumber('mocked-segment') === 1).toBe(true);
+
     expect(await cache.getChangeNumber('inexistent-segment')).toBe(-1); // -1 if the segment doesn't exist
 
-    // mock segment keys
-    wrapperMock._cache[keyBuilder.buildSegmentNameKey('mocked-segment')] = ['b', 'd'];
+    await cache.addToSegment('mocked-segment', ['d', 'e']);
+
+    await cache.removeFromSegment('mocked-segment', ['a', 'c']);
+
+    expect(await cache.getChangeNumber('mocked-segment') === 1).toBe(true);
 
     expect(await cache.isInSegment('mocked-segment', 'a')).toBe(false);
     expect(await cache.isInSegment('mocked-segment', 'b')).toBe(true);
     expect(await cache.isInSegment('mocked-segment', 'c')).toBe(false);
     expect(await cache.isInSegment('mocked-segment', 'd')).toBe(true);
+    expect(await cache.isInSegment('mocked-segment', 'e')).toBe(true);
 
     expect(await cache.isInSegment('inexistent-segment', 'a')).toBe(false);
+  });
+
+  test('registerSegment / getRegisteredSegments', async () => {
+    const cache = new SegmentsCachePluggable(loggerMock, keyBuilder, wrapperMock);
+
+    await cache.registerSegments(['s1']);
+    await cache.registerSegments(['s2']);
+    await cache.registerSegments(['s2', 's3', 's4']);
+
+    const segments = await cache.getRegisteredSegments();
+
+    ['s1', 's2', 's3', 's4'].forEach(s => expect(segments.indexOf(s) !== -1).toBe(true));
   });
 
 });

--- a/src/storages/pluggable/__tests__/wrapperAdapter.spec.ts
+++ b/src/storages/pluggable/__tests__/wrapperAdapter.spec.ts
@@ -36,6 +36,9 @@ export const wrapperWithIssues = {
   popItems: invalidThenable,
   getItemsCount: 'invalid value',
   itemContains: throwsException,
+  addItems: { then: 10 },
+  removeItems: invalidThenable,
+  getItems: { then: () => { throw new Error(); } }
 };
 
 const VALID_METHOD_CALLS = {
@@ -51,9 +54,12 @@ const VALID_METHOD_CALLS = {
   'getAndSet': ['some_key', 'some_value'],
   'getByPrefix': ['some_prefix'],
   'pushItems': ['some_key_list', ['item1', 'item2']],
-  'popItems': ['some_key'],
-  'getItemsCount': ['some_key'],
-  'itemContains': ['some_key', 'some_value'],
+  'popItems': ['some_key_list'],
+  'getItemsCount': ['some_key_list'],
+  'itemContains': ['some_key_set', 'some_value'],
+  'addItems': ['some_key_set', ['item1', 'item2']],
+  'removeItems': ['some_key_set', ['item1', 'item2']],
+  'getItems': ['some_key_set'],
 };
 
 // Test target

--- a/src/storages/pluggable/wrapperAdapter.ts
+++ b/src/storages/pluggable/wrapperAdapter.ts
@@ -17,6 +17,9 @@ export const METHODS_TO_PROMISE_WRAP: string[] = [
   'popItems',
   'getItemsCount',
   'itemContains',
+  'addItems',
+  'removeItems',
+  'getItems',
   'connect',
   'close'
 ];

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -6,6 +6,8 @@ import { SplitIO, ImpressionDTO } from '../types';
  * Interface of a custom wrapper storage.
  */
 export interface ICustomStorageWrapper {
+  /** Key-Value operations */
+
   /**
    * Get the value of given `key`.
    *
@@ -63,6 +65,18 @@ export interface ICustomStorageWrapper {
    */
   getByPrefix: (prefix: string) => Promise<string[]>
   /**
+   * Returns the values of all given `keys`.
+   *
+   * @function getMany
+   * @param {string[]} keys list of keys to retrieve
+   * @returns {Promise<(string | null)[]>} A promise that resolves with the list of items associated with the specified list of `keys`. For every key that does not hold a string value or does not exist, null is returned.
+   * The promise rejects if the operation fails.
+   */
+  getMany: (keys: string[]) => Promise<(string | null)[]>
+
+  /** Integer operations */
+
+  /**
    * Increments in 1 the given `key` value or set it in 1 if the value doesn't exist.
    *
    * @function incr
@@ -80,15 +94,9 @@ export interface ICustomStorageWrapper {
    * The promise rejects if the operation fails, for example, if there is a connectin error or the key contains a string that can not be represented as integer.
    */
   decr: (key: string) => Promise<void | boolean>
-  /**
-   * Returns the values of all given `keys`.
-   *
-   * @function getMany
-   * @param {string[]} keys list of keys to retrieve
-   * @returns {Promise<(string | null)[]>} A promise that resolves with the list of items associated with the specified list of `keys`. For every key that does not hold a string value or does not exist, null is returned.
-   * The promise rejects if the operation fails.
-   */
-  getMany: (keys: string[]) => Promise<(string | null)[]>
+
+  /** Queue operations */
+
   /**
    * Inserts given items at the tail of `key` list. If `key` does not exist, an empty list is created before pushing the items.
    *
@@ -118,16 +126,52 @@ export interface ICustomStorageWrapper {
    * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
    */
   getItemsCount: (key: string) => Promise<number>
+
+  /** Set operations */
+
   /**
-   * Returns if item is a member of a list.
+   * Returns if item is a member of a set.
    *
    * @function itemContains
-   * @param {string} key list key
+   * @param {string} key set key
    * @param {string} item item value
-   * @returns {Promise<boolean>} A promise that resolves with true boolean value if `item` is a member of the list stored at `key`, or false if it is not a member or `key` list does not exist.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
+   * @returns {Promise<boolean>} A promise that resolves with true boolean value if `item` is a member of the set stored at `key`, or false if it is not a member or `key` set does not exist.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
    */
   itemContains: (key: string, item: string) => Promise<boolean>
+  /**
+   * Add the specified `items` to the set stored at `key`. Those items that are already part of the set are ignored.
+   * If key does not exist, an empty set is created before adding the items.
+   *
+   * @function addItems
+   * @param {string} key set key
+   * @param {string} items items to add
+   * @returns {Promise<void>} A promise that resolves if the operation success.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   */
+  addItems: (key: string, items: string[]) => Promise<void>
+  /**
+   * Remove the specified `items` from the set stored at `key`. Those items that are not part of the set are ignored.
+   *
+   * @function removeItems
+   * @param {string} key set key
+   * @param {string} items items to remove
+   * @returns {Promise<void>} A promise that resolves if the operation success. If key does not exist, the promise also resolves.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   */
+  removeItems: (key: string, items: string[]) => Promise<void>
+  /**
+   * Returns all the items of the `key` set.
+   *
+   * @function getItems
+   * @param {string} key set key
+   * @returns {Promise<string[]>} A promise that resolves with the list of items. If key does not exist, the result is an empty list.
+   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   */
+  getItems: (key: string) => Promise<string[]>
+
+  /** Control operations */
+
   /**
    * Connects to the underlying storage.
    * It is meant for storages that requires to be connected to some database or server. Otherwise it can just return a resolved promise.
@@ -238,7 +282,7 @@ export interface ISegmentsCacheAsync extends ISegmentsCacheBase {
   getRegisteredSegments(): Promise<string[]>
   setChangeNumber(name: string, changeNumber: number): Promise<boolean | void>
   getChangeNumber(name: string): Promise<number>
-  clear(): Promise<boolean>
+  clear(): Promise<boolean | void>
 }
 
 /**

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -6,23 +6,24 @@ import { SplitIO, ImpressionDTO } from '../types';
  * Interface of a custom wrapper storage.
  */
 export interface ICustomStorageWrapper {
+
   /** Key-Value operations */
 
   /**
    * Get the value of given `key`.
    *
    * @function get
-   * @param {string} key item to retrieve
-   * @returns {Promise<string | null>} A promise that resolves with the element value associated with the specified `key`, or null if the key does not exist.
-   * The promise rejects if the operation fails.
+   * @param {string} key Item to retrieve
+   * @returns {Promise<string | null>} A promise that resolves with the element value associated with the specified `key`,
+   * or null if the key does not exist. The promise rejects if the operation fails.
    */
   get: (key: string) => Promise<string | null>
   /**
    * Add or update an item with a specified `key` and `value`.
    *
    * @function set
-   * @param {string} key item to update
-   * @param {string} value value to set
+   * @param {string} key Item to update
+   * @param {string} value Value to set
    * @returns {Promise<void>} A promise that resolves if the operation success, whether the key was added or updated.
    * The promise rejects if the operation fails.
    */
@@ -31,8 +32,8 @@ export interface ICustomStorageWrapper {
    * Add or update an item with a specified `key` and `value`.
    *
    * @function getAndSet
-   * @param {string} key item to update
-   * @param {string} value value to set
+   * @param {string} key Item to update
+   * @param {string} value Value to set
    * @returns {Promise<string | null>} A promise that resolves with the previous value associated to the given `key`, or null if not set.
    * The promise rejects if the operation fails.
    */
@@ -41,16 +42,16 @@ export interface ICustomStorageWrapper {
    * Removes the specified item by `key`.
    *
    * @function del
-   * @param {string} key item to delete
+   * @param {string} key Item to delete
    * @returns {Promise<void>} A promise that resolves if the operation success, whether the key existed and was removed or it didn't exist.
-   * The promise rejects if the operation fails, for example, if there is a connectin error.
+   * The promise rejects if the operation fails, for example, if there is a connection error.
    */
   del: (key: string) => Promise<void | boolean>
   /**
    * Returns all keys matching the given prefix.
    *
    * @function getKeysByPrefix
-   * @param {string} prefix string prefix to match
+   * @param {string} prefix String prefix to match
    * @returns {Promise<string[]>} A promise that resolves with the list of keys that match the given `prefix`.
    * The promise rejects if the operation fails.
    */
@@ -59,7 +60,7 @@ export interface ICustomStorageWrapper {
    * Returns all values which keys match the given prefix.
    *
    * @function getByPrefix
-   * @param {string} prefix
+   * @param {string} prefix String prefix to match
    * @returns {Promise<string[]>} A promise that resolves with the list of values which keys match the given `prefix`.
    * The promise rejects if the operation fails.
    */
@@ -68,9 +69,9 @@ export interface ICustomStorageWrapper {
    * Returns the values of all given `keys`.
    *
    * @function getMany
-   * @param {string[]} keys list of keys to retrieve
-   * @returns {Promise<(string | null)[]>} A promise that resolves with the list of items associated with the specified list of `keys`. For every key that does not hold a string value or does not exist, null is returned.
-   * The promise rejects if the operation fails.
+   * @param {string[]} keys List of keys to retrieve
+   * @returns {Promise<(string | null)[]>} A promise that resolves with the list of items associated with the specified list of `keys`.
+   * For every key that does not hold a string value or does not exist, null is returned. The promise rejects if the operation fails.
    */
   getMany: (keys: string[]) => Promise<(string | null)[]>
 
@@ -80,18 +81,18 @@ export interface ICustomStorageWrapper {
    * Increments in 1 the given `key` value or set it in 1 if the value doesn't exist.
    *
    * @function incr
-   * @param {string} key key to increment
-   * @returns {Promise<void>} A promise that resolves if the operation success.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key contains a string that can not be represented as integer.
+   * @param {string} key Key to increment
+   * @returns {Promise<void>} A promise that resolves if the operation success. The promise rejects if the operation fails,
+   * for example, if there is a connection error or the key contains a string that can not be represented as integer.
    */
   incr: (key: string) => Promise<void | boolean>
   /**
    * Decrements in 1 the given `key` value or set it in -1 if the value doesn't exist.
    *
    * @function decr
-   * @param {string} key key to decrement
-   * @returns {Promise<void>} A promise that resolves if the operation success.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key contains a string that can not be represented as integer.
+   * @param {string} key Key to decrement
+   * @returns {Promise<void>} A promise that resolves if the operation success. The promise rejects if the operation fails,
+   * for example, if there is a connection error or the key contains a string that can not be represented as integer.
    */
   decr: (key: string) => Promise<void | boolean>
 
@@ -101,29 +102,29 @@ export interface ICustomStorageWrapper {
    * Inserts given items at the tail of `key` list. If `key` does not exist, an empty list is created before pushing the items.
    *
    * @function pushItems
-   * @param {string} key list key
-   * @param {string[]} items list of items to push
+   * @param {string} key List key
+   * @param {string[]} items List of items to push
    * @returns {Promise<void>} A promise that resolves if the operation success.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a list.
    */
   pushItems: (key: string, items: string[]) => Promise<void>
   /**
    * Removes and returns the first `count` items from a list. If `key` does not exist, an empty list is items is returned.
    *
    * @function popItems
-   * @param {string} key list key
-   * @param {number} count number of items to pop
+   * @param {string} key List key
+   * @param {number} count Number of items to pop
    * @returns {Promise<string[]>} A promise that resolves with the list of removed items from the list, or an empty array when key does not exist.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a list.
    */
   popItems: (key: string, count: number) => Promise<string[]>
   /**
    * Returns the count of items in a list, or 0 if `key` does not exist.
    *
    * @function getItemsCount
-   * @param {string} key list key
+   * @param {string} key List key
    * @returns {Promise<number>} A promise that resolves with the number of items at the `key` list, or 0 when `key` does not exist.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a list.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a list.
    */
   getItemsCount: (key: string) => Promise<number>
 
@@ -133,10 +134,11 @@ export interface ICustomStorageWrapper {
    * Returns if item is a member of a set.
    *
    * @function itemContains
-   * @param {string} key set key
-   * @param {string} item item value
-   * @returns {Promise<boolean>} A promise that resolves with true boolean value if `item` is a member of the set stored at `key`, or false if it is not a member or `key` set does not exist.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   * @param {string} key Set key
+   * @param {string} item Item value
+   * @returns {Promise<boolean>} A promise that resolves with true boolean value if `item` is a member of the set stored at `key`,
+   * or false if it is not a member or `key` set does not exist. The promise rejects if the operation fails, for example,
+   * if there is a connection error or the key holds a value that is not a set.
    */
   itemContains: (key: string, item: string) => Promise<boolean>
   /**
@@ -144,29 +146,29 @@ export interface ICustomStorageWrapper {
    * If key does not exist, an empty set is created before adding the items.
    *
    * @function addItems
-   * @param {string} key set key
-   * @param {string} items items to add
+   * @param {string} key Set key
+   * @param {string} items Items to add
    * @returns {Promise<void>} A promise that resolves if the operation success.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a set.
    */
   addItems: (key: string, items: string[]) => Promise<void>
   /**
    * Remove the specified `items` from the set stored at `key`. Those items that are not part of the set are ignored.
    *
    * @function removeItems
-   * @param {string} key set key
-   * @param {string} items items to remove
+   * @param {string} key Set key
+   * @param {string} items Items to remove
    * @returns {Promise<void>} A promise that resolves if the operation success. If key does not exist, the promise also resolves.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a set.
    */
   removeItems: (key: string, items: string[]) => Promise<void>
   /**
    * Returns all the items of the `key` set.
    *
    * @function getItems
-   * @param {string} key set key
+   * @param {string} key Set key
    * @returns {Promise<string[]>} A promise that resolves with the list of items. If key does not exist, the result is an empty list.
-   * The promise rejects if the operation fails, for example, if there is a connectin error or the key holds a value that is not a set.
+   * The promise rejects if the operation fails, for example, if there is a connection error or the key holds a value that is not a set.
    */
   getItems: (key: string) => Promise<string[]>
 
@@ -436,8 +438,9 @@ export interface IStorageFactoryParams {
   matchingKey?: string, /* undefined on server-side SDKs */
   splitFiltersValidation?: ISplitFiltersValidation,
 
-  // This callback is invoked when the storage is ready to be used. If an error is passed, it means that the storge fail to connect and shouldn't be used.
-  // It is meant for emitting SDK_READY event in consumer mode, and for synchronizer tasks to wait before using the storage.
+  // This callback is invoked when the storage is ready to be used. Error-first callback style: if an error is passed,
+  // it means that the storge fail to connect and shouldn't be used.
+  // It is meant for emitting SDK_READY event in consumer mode, and for synchronizer to wait before using the storage.
   onReadyCb?: (error?: any) => void,
   metadata: IMetadata,
 }

--- a/src/sync/polling/updaters/segmentChangesUpdater.ts
+++ b/src/sync/polling/updaters/segmentChangesUpdater.ts
@@ -1,12 +1,13 @@
 import { ISegmentChangesFetcher } from '../fetchers/types';
 import { ISegmentsCacheBase } from '../../../storages/types';
 import { IReadinessManager } from '../../../readiness/types';
-import { ISegmentChangesResponse } from '../../../dtos/types';
+import { ISegmentChangesResponse, MaybeThenable } from '../../../dtos/types';
 import { findIndex } from '../../../utils/lang';
 import { SplitError } from '../../../utils/lang/errors';
 import { SDK_SEGMENTS_ARRIVED } from '../../../readiness/constants';
 import { ILogger } from '../../../logger/types';
 import { LOG_PREFIX_INSTANTIATION, LOG_PREFIX_SYNC_SEGMENTS } from '../../../logger/constants';
+import thenable from '../../../utils/promise/thenable';
 
 type ISegmentChangesUpdater = (segmentNames?: string[], noCache?: boolean, fetchOnlyNew?: boolean) => Promise<boolean>
 
@@ -18,13 +19,13 @@ type ISegmentChangesUpdater = (segmentNames?: string[], noCache?: boolean, fetch
  *
  * @param log logger instance
  * @param segmentChangesFetcher fetcher of `/segmentChanges`
- * @param segmentsCache segments storage, with sync or async methods
+ * @param segments segments storage, with sync or async methods
  * @param readiness optional readiness manager. Not required for synchronizer or producer mode.
  */
 export function segmentChangesUpdaterFactory(
   log: ILogger,
   segmentChangesFetcher: ISegmentChangesFetcher,
-  segmentsCache: ISegmentsCacheBase,
+  segments: ISegmentsCacheBase,
   readiness?: IReadinessManager,
 ): ISegmentChangesUpdater {
 
@@ -51,16 +52,16 @@ export function segmentChangesUpdaterFactory(
     log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Started segments update`);
 
     // If not a segment name provided, read list of available segments names to be updated.
-    let segmentsPromise = Promise.resolve(segmentNames ? segmentNames : segmentsCache.getRegisteredSegments());
+    let segmentsPromise = Promise.resolve(segmentNames ? segmentNames : segments.getRegisteredSegments());
 
-    return segmentsPromise.then(segments => {
+    return segmentsPromise.then(segmentNames => {
       // Async fetchers are collected here.
       const updaters: Promise<number>[] = [];
 
-      for (let index = 0; index < segments.length; index++) {
-        const segmentName = segments[index];
+      for (let index = 0; index < segmentNames.length; index++) {
+        const segmentName = segmentNames[index];
         log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processing segment ${segmentName}`);
-        let sincePromise = Promise.resolve(segmentsCache.getChangeNumber(segmentName));
+        let sincePromise = Promise.resolve(segments.getChangeNumber(segmentName));
 
         updaters.push(sincePromise.then(since => {
           // if fetchOnlyNew flag, avoid processing already fetched segments
@@ -68,17 +69,19 @@ export function segmentChangesUpdaterFactory(
 
           return segmentChangesFetcher(since, segmentName, noCache, _promiseDecorator).then(function (changes) {
             let changeNumber = -1;
+            const results: MaybeThenable<boolean | void>[] = [];
             changes.forEach(x => {
-              if (x.added.length > 0) segmentsCache.addToSegment(segmentName, x.added);
-              if (x.removed.length > 0) segmentsCache.removeFromSegment(segmentName, x.removed);
+              if (x.added.length > 0) results.push(segments.addToSegment(segmentName, x.added));
+              if (x.removed.length > 0) results.push(segments.removeFromSegment(segmentName, x.removed));
               if (x.added.length > 0 || x.removed.length > 0) {
-                segmentsCache.setChangeNumber(segmentName, x.till);
+                results.push(segments.setChangeNumber(segmentName, x.till));
                 changeNumber = x.till;
               }
 
               log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`);
             });
-
+            // If at least one storage operation result is a promise, join all in a single promise.
+            if (results.some(result => thenable(result))) return Promise.all(results).then(() => changeNumber);
             return changeNumber;
           });
         }));
@@ -94,7 +97,10 @@ export function segmentChangesUpdaterFactory(
         // if at least one segment fetch fails, return false to indicate that there was some error (e.g., invalid json, HTTP error, etc)
         if (shouldUpdateFlags.indexOf(-1) !== -1) return false;
         return true;
-      }).catch(error => {
+      });
+    })
+      // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
+      .catch(error => {
         // handle user callback errors
         if (!(error instanceof SplitError)) setTimeout(() => { throw error; }, 0);
 
@@ -106,7 +112,6 @@ export function segmentChangesUpdaterFactory(
 
         return false;
       });
-    });
   };
 
 }

--- a/src/sync/polling/updaters/splitChangesUpdater.ts
+++ b/src/sync/polling/updaters/splitChangesUpdater.ts
@@ -144,9 +144,13 @@ export function splitChangesUpdaterFactory(
 
             if (splitsEventEmitter) {
               // To emit SDK_SPLITS_ARRIVED for server-side SDK, we must check that all registered segments have been fetched
-              Promise.resolve(!splitsEventEmitter.splitsArrived || (since !== splitChanges.till && checkAllSegmentsExist(segments)))
-                .then(emitSplitsArrivedEvent => { if (emitSplitsArrivedEvent) splitsEventEmitter.emit(SDK_SPLITS_ARRIVED); })
-                .catch(() => {/** noop. just to handle a possible `checkAllSegmentsExist` promise rejection on custom or redis storage */ });
+              return Promise.resolve(!splitsEventEmitter.splitsArrived || (since !== splitChanges.till && checkAllSegmentsExist(segments)))
+                .catch(() => false /** noop. just to handle a possible `checkAllSegmentsExist` rejection, before emitting SDK event */)
+                .then(emitSplitsArrivedEvent => {
+                  // emit SDK events
+                  if (emitSplitsArrivedEvent) splitsEventEmitter.emit(SDK_SPLITS_ARRIVED);
+                  return true;
+                });
             }
             return true;
           });

--- a/src/sync/polling/updaters/splitChangesUpdater.ts
+++ b/src/sync/polling/updaters/splitChangesUpdater.ts
@@ -80,8 +80,8 @@ export function computeSplitsMutation(entries: ISplit[]): ISplitMutations {
  *
  * @param log  Logger instance
  * @param splitChangesFetcher  Fetcher of `/splitChanges`
- * @param splitsCache  Splits storage, with sync or async methods
- * @param segmentsCache  Segments storage, with sync or async methods
+ * @param splits  Splits storage, with sync or async methods
+ * @param segments  Segments storage, with sync or async methods
  * @param splitsEventEmitter  Optional readiness manager. Not required for synchronizer or producer mode.
  * @param requestTimeoutBeforeReady  How long the updater will wait for the request to timeout. Default 0, i.e., never timeout.
  * @param retriesOnFailureBeforeReady  How many retries on `/splitChanges` we the updater do in case of failure or timeout. Default 0, i.e., no retries.


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added producer methods for Redis and Pluggable segment storages.
- Added new set operations to the wrapper. 
- Updated segmentChangesUpdater, to handle other sources of possible rejected promises.
- Fixed splitsChangesUpdater, to properly handle user callback errors when emitting SDK_SPLITS_ARRIVED.

## How do we test the changes introduced in this PR?

- Added UTs.

## Extra Notes