### PR TITLE
[Pluggable storage] impressions and events producer methods for InRedis and Pluggable storages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.1",
+  "version": "0.1.1-canary.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4044,9 +4044,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -6563,9 +6563,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.defaults": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.1",
+  "version": "0.1.1-canary.2",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -65,7 +65,7 @@
     "jest": "^26.6.3",
     "jest-localstorage-mock": "^2.4.3",
     "js-yaml": "^3.14.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "redis-server": "1.2.2",
     "rimraf": "^3.0.2",

--- a/src/integrations/ga/__tests__/GaToSplit.spec.ts
+++ b/src/integrations/ga/__tests__/GaToSplit.spec.ts
@@ -122,6 +122,7 @@ function customMapper(model: UniversalAnalytics.Model, defaultEvent: SplitIO.Eve
 }
 // Updates defaultEvent
 function customMapper2(model: UniversalAnalytics.Model, defaultEvent: SplitIO.EventData) {
+  // @ts-ignore. The defaultEvent has a property value, that might be empty depending on the hitType
   defaultEvent.properties['someProp2'] = 'someProp2';
   return defaultEvent;
 }

--- a/src/listeners/browser.ts
+++ b/src/listeners/browser.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 // @TODO eventually migrate to JS-Browser-SDK package.
 import { ISignalListener } from './types';
-import { IRecorderCacheConsumerSync, IStorageSync } from '../storages/types';
+import { IRecorderCacheProducerSync, IStorageSync } from '../storages/types';
 import { fromImpressionsCollector } from '../sync/submitters/impressionsSyncTask';
 import { fromImpressionCountsCollector } from '../sync/submitters/impressionCountsSyncTask';
 import { ISplitApi } from '../services/types';
@@ -74,7 +74,7 @@ export default class BrowserSignalListener implements ISignalListener {
     if (this.storage.impressionCounts) this._flushData(eventsUrl + '/testImpressions/count/beacon', this.storage.impressionCounts, this.serviceApi.postTestImpressionsCount, fromImpressionCountsCollector);
   }
 
-  private _flushData<TState>(url: string, cache: IRecorderCacheConsumerSync<TState>, postService: (body: string) => Promise<Response>, fromCacheToPayload?: (cacheData: TState) => any, extraMetadata?: {}) {
+  private _flushData<TState>(url: string, cache: IRecorderCacheProducerSync<TState>, postService: (body: string) => Promise<Response>, fromCacheToPayload?: (cacheData: TState) => any, extraMetadata?: {}) {
     // if there is data in cache, send it to backend
     if (!cache.isEmpty()) {
       const dataPayload = fromCacheToPayload ? fromCacheToPayload(cache.state()) : cache.state();

--- a/src/sdkClient/client.ts
+++ b/src/sdkClient/client.ts
@@ -103,7 +103,7 @@ export default function clientFactory(params: IClientFactoryParams): SplitIO.ICl
   function track(key: SplitIO.SplitKey, trafficTypeName: string, eventTypeId: string, value?: number, properties?: SplitIO.Properties, size = 1024) {
     const matchingKey = getMatching(key);
     const timestamp = Date.now();
-    const eventData = {
+    const eventData: SplitIO.EventData = {
       eventTypeId,
       trafficTypeName,
       value,
@@ -115,7 +115,7 @@ export default function clientFactory(params: IClientFactoryParams): SplitIO.ICl
     // This may be async but we only warn, we don't actually care if it is valid or not in terms of queueing the event.
     validateTrafficTypeExistance(log, readinessManager, storage.splits, mode, trafficTypeName, 'track');
 
-    return eventTracker.track(eventData as SplitIO.EventData, size);
+    return eventTracker.track(eventData, size);
   }
 
   return {

--- a/src/storages/inMemory/ImpressionsCacheInMemory.ts
+++ b/src/storages/inMemory/ImpressionsCacheInMemory.ts
@@ -10,7 +10,6 @@ export default class ImpressionsCacheInMemory implements IImpressionsCacheSync {
    */
   track(data: ImpressionDTO[]) {
     this.queue.push(...data);
-    return true;
   }
 
   /**

--- a/src/storages/inRedis/EventsCacheInRedis.ts
+++ b/src/storages/inRedis/EventsCacheInRedis.ts
@@ -57,7 +57,13 @@ export default class EventsCacheInRedis implements IEventsCacheAsync {
     return this.redis.ltrim(this.key, count, -1);
   }
 
-  // @TODO follow Go implementation
+  /**
+   * Pop the given number of events from the storage.
+   * The returned promise rejects if the wrapper operation fails.
+   *
+   * NOTE: this method doesn't take into account MAX_EVENT_SIZE or MAX_QUEUE_BYTE_SIZE limits.
+   * It is the submitter responsability to handle that.
+   */
   popNWithMetadata(count: number): Promise<StoredEventWithMetadata[]> {
     return this.redis.lrange(this.key, 0, count - 1).then(items => {
       return this.redis.ltrim(this.key, items.length, -1).then(() => {

--- a/src/storages/inRedis/EventsCacheInRedis.ts
+++ b/src/storages/inRedis/EventsCacheInRedis.ts
@@ -22,6 +22,7 @@ export default class EventsCacheInRedis implements IEventsCacheAsync {
 
   /**
    * Add a new event object into the queue.
+   * Unlike `impressions::track`, result promise is never rejected.
    */
   track(eventData: SplitIO.EventData): Promise<boolean> {
     return this.redis.rpush(
@@ -31,7 +32,7 @@ export default class EventsCacheInRedis implements IEventsCacheAsync {
       // We use boolean values to signal successful queueing
       .then(() => true)
       .catch(err => {
-        this.log.error(LOG_PREFIX + `Error adding event to queue: ${err}.`);
+        this.log.error(`${LOG_PREFIX}Error adding event to queue: ${err}.`);
         return false;
       });
   }

--- a/src/storages/inRedis/ImpressionsCacheInRedis.ts
+++ b/src/storages/inRedis/ImpressionsCacheInRedis.ts
@@ -21,16 +21,15 @@ export default class ImpressionsCacheInRedis implements IImpressionsCacheAsync {
     this.metadata = metadata;
   }
 
-  track(impressions: ImpressionDTO[]): Promise<boolean> {
+  track(impressions: ImpressionDTO[]): Promise<void> { // @ts-ignore
     return this.redis.rpush(
       this.key,
       this._toJSON(impressions)
     ).then(queuedCount => {
       // If this is the creation of the key on Redis, set the expiration for it in 1hr.
       if (queuedCount === impressions.length) {
-        return this.redis.expire(this.key, IMPRESSIONS_TTL_REFRESH).then(result => result === 1); // 1 if the timeout was set. 0 if key does not exist.
+        return this.redis.expire(this.key, IMPRESSIONS_TTL_REFRESH);
       }
-      return true;
     });
   }
 

--- a/src/storages/inRedis/ImpressionsCacheInRedis.ts
+++ b/src/storages/inRedis/ImpressionsCacheInRedis.ts
@@ -1,29 +1,34 @@
 import { IImpressionsCacheAsync } from '../types';
 import { IMetadata } from '../../dtos/types';
 import { ImpressionDTO } from '../../types';
-import KeyBuilderSS from '../KeyBuilderSS';
 import { Redis } from 'ioredis';
+import { StoredImpressionWithMetadata } from '../../sync/submitters/types';
+import { ILogger } from '../../logger/types';
+
+const IMPRESSIONS_TTL_REFRESH = 3600; // 1 hr
 
 export default class ImpressionsCacheInRedis implements IImpressionsCacheAsync {
 
+  private readonly log: ILogger;
+  private readonly key: string;
   private readonly redis: Redis;
-  private readonly keys: KeyBuilderSS;
   private readonly metadata: IMetadata;
 
-  constructor(keys: KeyBuilderSS, redis: Redis, metadata: IMetadata) {
-    this.keys = keys;
+  constructor(log: ILogger, key: string, redis: Redis, metadata: IMetadata) {
+    this.log = log;
+    this.key = key;
     this.redis = redis;
     this.metadata = metadata;
   }
 
   track(impressions: ImpressionDTO[]): Promise<boolean> {
     return this.redis.rpush(
-      this.keys.buildImpressionsKey(),
+      this.key,
       this._toJSON(impressions)
     ).then(queuedCount => {
       // If this is the creation of the key on Redis, set the expiration for it in 1hr.
       if (queuedCount === impressions.length) {
-        return this.redis.expire(this.keys.buildImpressionsKey(), 3600).then(result => result === 1); // 1 if the timeout was set. 0 if key does not exist.
+        return this.redis.expire(this.key, IMPRESSIONS_TTL_REFRESH).then(result => result === 1); // 1 if the timeout was set. 0 if key does not exist.
       }
       return true;
     });
@@ -46,6 +51,30 @@ export default class ImpressionsCacheInRedis implements IImpressionsCacheAsync {
           c: changeNumber,
           m: time
         }
+      });
+    });
+  }
+
+  count(): Promise<number> {
+    return this.redis.llen(this.key).catch(() => 0);
+  }
+
+  drop(count?: number): Promise<any> {
+    if (!count) return this.redis.del(this.key);
+
+    return this.redis.ltrim(this.key, count, -1);
+  }
+
+  popNWithMetadata(count: number): Promise<StoredImpressionWithMetadata[]> {
+    return this.redis.lrange(this.key, 0, count - 1).then(items => {
+      return this.redis.ltrim(this.key, items.length, -1).then(() => {
+        // This operation will simply do nothing if the key no longer exists (queue is empty)
+        // It's only done in the "successful" exit path so that the TTL is not overriden if impressons weren't
+        // popped correctly. This will result in impressions getting lost but will prevent the queue from taking
+        // a huge amount of memory.
+        this.redis.expire(this.key, IMPRESSIONS_TTL_REFRESH).catch(() => { }); // noop catch handler
+
+        return items.map(item => JSON.parse(item) as StoredImpressionWithMetadata);
       });
     });
   }

--- a/src/storages/inRedis/RedisAdapter.ts
+++ b/src/storages/inRedis/RedisAdapter.ts
@@ -8,7 +8,7 @@ import timeout from '../../utils/promise/timeout';
 const LOG_PREFIX = 'storage:redis-adapter: ';
 
 // If we ever decide to fully wrap every method, there's a Commander.getBuiltinCommands from ioredis.
-const METHODS_TO_PROMISE_WRAP = ['set', 'exec', 'del', 'get', 'keys', 'sadd', 'srem', 'sismember', 'smembers', 'incr', 'rpush', 'pipeline', 'expire', 'mget'];
+const METHODS_TO_PROMISE_WRAP = ['set', 'exec', 'del', 'get', 'keys', 'sadd', 'srem', 'sismember', 'smembers', 'incr', 'rpush', 'pipeline', 'expire', 'mget', 'lrange', 'ltrim'];
 
 // Not part of the settings since it'll vary on each storage. We should be removing storage specific logic from elsewhere.
 const DEFAULT_OPTIONS = {

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -62,7 +62,7 @@ export default class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
   /**
    * Add a given split.
    * The returned promise is resolved when the operation success
-   * or rejected with if it fails (e.g., redis operation fails)
+   * or rejected with an SplitError if it fails (e.g., redis operation fails)
    */
   addSplit(name: string, split: string): Promise<boolean> {
     const splitKey = this.keys.buildSplitKey(name);

--- a/src/storages/inRedis/__tests__/EventsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/EventsCacheInRedis.spec.ts
@@ -1,19 +1,13 @@
 import Redis from 'ioredis';
-import find from 'lodash/find';
-import isEqual from 'lodash/isEqual';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import EventsCacheInRedis from '../EventsCacheInRedis';
+import { fakeMetadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored } from '../../pluggable/__tests__/EventsCachePluggable.spec';
 
 const prefix = 'events_cache_ut';
-const eventsKey = `${prefix}.impressions`;
-const fakeMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
+const eventsKey = `${prefix}.events`;
 
-test('EVENTS CACHE IN REDIS / should incrementally store values in redis', async () => {
+test('EVENTS CACHE IN REDIS / `track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
   const connection = new Redis();
-
-  const fakeEvent1 = { event: 1 };
-  const fakeEvent2 = { event: '2' };
-  const fakeEvent3 = { event: null };
 
   // Clean up in case there are still keys there.
   await connection.del(eventsKey);
@@ -28,40 +22,34 @@ test('EVENTS CACHE IN REDIS / should incrementally store values in redis', async
 
   const faultyCache = new EventsCacheInRedis(loggerMock, 'non-list-key', connection, fakeMetadata);
 
-  // @ts-expect-error
   expect(await cache.track(fakeEvent1)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
-  // @ts-expect-error
   expect(await cache.track(fakeEvent2)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
-  // @ts-expect-error
   expect(await cache.track(fakeEvent3)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
-  // @ts-expect-error
   expect(await faultyCache.track(fakeEvent1)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
-  // @ts-expect-error
   expect(await faultyCache.track(fakeEvent2)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
-  // @ts-expect-error
   expect(await faultyCache.track(fakeEvent3)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
 
+  // Events should be in redis
   redisValues = await connection.lrange(eventsKey, 0, -1);
-
   expect(redisValues.length).toBe(3); // After pushing we should have on Redis as many events as we have stored.
   expect(typeof redisValues[0]).toBe('string'); // All elements should be strings since those are stringified JSONs.
   expect(typeof redisValues[1]).toBe('string'); // All elements should be strings since those are stringified JSONs.
   expect(typeof redisValues[2]).toBe('string'); // All elements should be strings since those are stringified JSONs.
 
-  const findMatchingElem = (event: any) => {
-    return find(redisValues, elem => {
-      const parsedElem = JSON.parse(elem);
-      return isEqual(parsedElem.e, event) && isEqual(parsedElem.m, fakeMetadata);
-    });
-  };
+  // Testing popNWithMetadata
+  expect(await cache.popNWithMetadata(2)).toEqual([fakeEvent1stored, fakeEvent2stored]); // events are removed in FIFO order
+  expect(await cache.count()).toBe(1);
 
-  /* If the elements are found, then the values are correct. */
-  const foundEv1 = findMatchingElem(fakeEvent1);
-  const foundEv2 = findMatchingElem(fakeEvent2);
-  const foundEv3 = findMatchingElem(fakeEvent3);
-  expect(foundEv1).not.toBe(undefined); // Events stored on redis matched the values we are expecting.
-  expect(foundEv2).not.toBe(undefined); // Events stored on redis matched the values we are expecting.
-  expect(foundEv3).not.toBe(undefined); // Events stored on redis matched the values we are expecting.
+  expect(await cache.popNWithMetadata(1)).toEqual([fakeEvent3stored]);
+  expect(await cache.count()).toBe(0);
+
+  expect(await cache.popNWithMetadata(100)).toEqual([]); // no more events
+
+  // Testing drop method
+  await Promise.all([cache.track(fakeEvent1), cache.track(fakeEvent2), cache.track(fakeEvent3)]);
+  expect(await cache.count()).toBe(3);
+  await cache.drop();
+  expect(await cache.count()).toBe(0); // storage should be empty after droping it
 
   // Clean up then end.
   await connection.del(eventsKey);

--- a/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
@@ -2,105 +2,90 @@ import Redis from '../RedisAdapter';
 import ImpressionsCacheInRedis from '../ImpressionsCacheInRedis';
 import IORedis, { BooleanResponse } from 'ioredis';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
+import { fakeMetadata, o1, o2, o3, o1stored, o2stored, o3stored } from '../../pluggable/__tests__/ImpressionsCachePluggable.spec';
 
-const fakeMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
+describe('IMPRESSIONS CACHE IN REDIS', () => {
 
-test('IMPRESSIONS CACHE IN REDIS / should incrementally store values', async () => {
-  const connection = new Redis(loggerMock, {});
-  const impressionsKey = 'impr_cache_ut.impressions';
+  test('`track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
+    const connection = new Redis(loggerMock, {});
+    const impressionsKey = 'impr_cache_ut.impressions';
 
-  const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
+    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
 
-  const o1 = {
-    feature: 'test1',
-    keyName: 'facundo@split.io',
-    treatment: 'on',
-    time: Date.now(),
-    changeNumber: 1
-  };
+    // cleanup
+    await connection.del(impressionsKey);
 
-  const o2 = {
-    feature: 'test2',
-    keyName: 'pepep@split.io',
-    treatment: 'A',
-    time: Date.now(),
-    bucketingKey: '1234-5678',
-    label: 'is in segment',
-    changeNumber: 1
-  };
+    // Testing track and count methods.
+    await c.track([o1]);
+    expect(await c.count()).toBe(1); // count should return stored items
 
-  const o3 = {
-    feature: 'test3',
-    keyName: 'pipiip@split.io',
-    treatment: 'B',
-    time: Date.now(),
-    changeNumber: 1
-  };
+    await c.track([o2, o3]);
+    expect(await c.count()).toBe(3); // count should return stored items
 
-  // cleanup
-  await connection.del(impressionsKey);
+    // Impressions should be in redis
+    const state = await connection.lrange(impressionsKey, 0, -1);
+    expect(state[0]).toBe(JSON.stringify(o1stored));
+    expect(state[1]).toBe(JSON.stringify(o2stored));
+    expect(state[2]).toBe(JSON.stringify(o3stored));
 
-  // @ts-expect-error
-  await c.track([o1]); // @ts-expect-error
-  await c.track([o2, o3]);
-  const state = await connection.lrange(impressionsKey, 0, -1);
-  // This is testing both the track and the toJSON method.
-  expect(state[0]).toBe(JSON.stringify({
-    m: fakeMetadata,
-    i: { k: o1.keyName, f: o1.feature, t: o1.treatment, c: o1.changeNumber, m: o1.time }
-  }));
-  expect(state[1]).toBe(JSON.stringify({
-    m: fakeMetadata,
-    i: { k: o2.keyName, b: o2.bucketingKey, f: o2.feature, t: o2.treatment, r: o2.label, c: o2.changeNumber, m: o2.time }
-  }));
-  expect(state[2]).toBe(JSON.stringify({
-    m: fakeMetadata,
-    i: { k: o3.keyName, f: o3.feature, t: o3.treatment, c: o3.changeNumber, m: o3.time }
-  }));
+    // Testing popNWithMetadata and private toJSON methods.
+    expect(await c.popNWithMetadata(2)).toEqual([o1stored, o2stored]); // impressions are pop in FIFO order
+    expect(await c.count()).toBe(1);
 
-  await connection.del(impressionsKey);
-  await connection.quit();
-});
+    expect(await c.popNWithMetadata(1)).toEqual([o3stored]);
+    expect(await c.count()).toBe(0);
 
-test('IMPRESSIONS CACHE IN REDIS / should not resolve track before calling expire', async (done) => {
-  const impressionsKey = 'impr_cache_ut_2.impressions';
-  const connection = new Redis(loggerMock, {});
+    // Testing drop method
+    await c.track([o1, o2, o3]);
+    expect(await c.count()).toBe(3);
+    await c.drop();
+    expect(await c.count()).toBe(0); // storage should be empty after droping the storage
 
-  const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
-
-  const i1 = { feature: 'test4', keyName: 'nicolas@split.io', treatment: 'off', time: Date.now(), changeNumber: 1 };
-  const i2 = { feature: 'test5', keyName: 'matias@split.io', treatment: 'on', time: Date.now(), changeNumber: 2 };
-
-  const spy1 = jest.spyOn(connection, 'rpush');
-  const spy2 = jest.spyOn(connection, 'expire');
-
-  // Crap so we can reproduce the latency as we would have on a remote server.
-  const originalExpire = connection.expire;
-
-  connection.expire = function patchedForTestRedisExpire(...args: [key: IORedis.KeyType, seconds: number]) {
-    return new Promise<BooleanResponse>((res, rej) => {
-      setTimeout(() => {
-        originalExpire.apply(connection, args).then(res).catch(rej);
-      }, 150); // 150ms of delay on the expire
-    });
-  };
-
-  // cleanup prior to test.
-  await connection.del(impressionsKey);
-
-  // @ts-expect-error
-  c.track([i1, i2]).then(() => {
-    connection.del(impressionsKey);
-    connection.quit(); // Try to disconnect right away.
-    expect(spy1).toBeCalled(); // Redis rpush was called once before executing external callback.
-    // Following assertion fails if the expire takes place after disconnected and throws unhandledPromiseRejection
-    expect(spy2).toBeCalled(); // Redis expire was called once before executing external callback.
-  }).catch(e => {
-    throw new Error(`An error was generated from the redis expire tests: ${e}`);
-  }).then(() => {
-    // Finally clean up and wrap up.
-    spy1.mockRestore();
-    spy2.mockRestore();
-    done();
+    await connection.del(impressionsKey);
+    await connection.quit();
   });
+
+  test('`track` should not resolve before calling expire', async (done) => {
+    const impressionsKey = 'impr_cache_ut_2.impressions';
+    const connection = new Redis(loggerMock, {});
+
+    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
+
+    const i1 = { feature: 'test4', keyName: 'nicolas@split.io', treatment: 'off', time: Date.now(), changeNumber: 1 };
+    const i2 = { feature: 'test5', keyName: 'matias@split.io', treatment: 'on', time: Date.now(), changeNumber: 2 };
+
+    const spy1 = jest.spyOn(connection, 'rpush');
+    const spy2 = jest.spyOn(connection, 'expire');
+
+    // Crap so we can reproduce the latency as we would have on a remote server.
+    const originalExpire = connection.expire;
+
+    connection.expire = function patchedForTestRedisExpire(...args: [key: IORedis.KeyType, seconds: number]) {
+      return new Promise<BooleanResponse>((res, rej) => {
+        setTimeout(() => {
+          originalExpire.apply(connection, args).then(res).catch(rej);
+        }, 150); // 150ms of delay on the expire
+      });
+    };
+
+    // cleanup prior to test.
+    await connection.del(impressionsKey);
+
+    // @ts-expect-error
+    c.track([i1, i2]).then(() => {
+      connection.del(impressionsKey);
+      connection.quit(); // Try to disconnect right away.
+      expect(spy1).toBeCalled(); // Redis rpush was called once before executing external callback.
+      // Following assertion fails if the expire takes place after disconnected and throws unhandledPromiseRejection
+      expect(spy2).toBeCalled(); // Redis expire was called once before executing external callback.
+    }).catch(e => {
+      throw new Error(`An error was generated from the redis expire tests: ${e}`);
+    }).then(() => {
+      // Finally clean up and wrap up.
+      spy1.mockRestore();
+      spy2.mockRestore();
+      done();
+    });
+  });
+
 });

--- a/src/storages/inRedis/index.ts
+++ b/src/storages/inRedis/index.ts
@@ -34,8 +34,8 @@ export function InRedisStorage(options: InRedisStorageOptions = {}) {
     return {
       splits: new SplitsCacheInRedis(log, keys, redisClient),
       segments: new SegmentsCacheInRedis(log, keys, redisClient),
-      impressions: new ImpressionsCacheInRedis(keys, redisClient, metadata),
-      events: new EventsCacheInRedis(log, keys, redisClient, metadata),
+      impressions: new ImpressionsCacheInRedis(log, keys.buildImpressionsKey(), redisClient, metadata),
+      events: new EventsCacheInRedis(log, keys.buildEventsKey(), redisClient, metadata),
       latencies: new LatenciesCacheInRedis(keys, redisClient),
       counts: new CountsCacheInRedis(keys, redisClient),
 

--- a/src/storages/pluggable/EventsCachePluggable.ts
+++ b/src/storages/pluggable/EventsCachePluggable.ts
@@ -23,7 +23,7 @@ export class EventsCachePluggable implements IEventsCacheAsync {
    * Push given event to the storage.
    * @param eventData  Event item to push.
    * @returns  A promise that is resolved with a boolean value indicating if the push operation succeeded or failed.
-   * The promise will never be rejected.
+   * Unlike `impressions::track`, The promise will never be rejected.
    */
   track(eventData: SplitIO.EventData): Promise<boolean> {
     return this.wrapper.pushItems(
@@ -33,7 +33,7 @@ export class EventsCachePluggable implements IEventsCacheAsync {
       // We use boolean values to signal successful queueing
       .then(() => true)
       .catch(e => {
-        this.log.error(LOG_PREFIX + ` Error adding event to queue: ${e}.`);
+        this.log.error(`${LOG_PREFIX}Error adding event to queue: ${e}.`);
         return false;
       });
   }

--- a/src/storages/pluggable/EventsCachePluggable.ts
+++ b/src/storages/pluggable/EventsCachePluggable.ts
@@ -64,10 +64,12 @@ export class EventsCachePluggable implements IEventsCacheAsync {
   }
 
   /**
-   * Pop the given number of events from the store.
+   * Pop the given number of events from the storage.
    * The returned promise rejects if the wrapper operation fails.
+   *
+   * NOTE: this method doesn't take into account MAX_EVENT_SIZE or MAX_QUEUE_BYTE_SIZE limits.
+   * It is the submitter responsability to handle that.
    */
-  // @TODO follow Go implementation
   popNWithMetadata(count: number): Promise<StoredEventWithMetadata[]> {
     return this.wrapper.popItems(this.key, count).then((items) => {
       return items.map(item => JSON.parse(item) as StoredEventWithMetadata);

--- a/src/storages/pluggable/ImpressionsCachePluggable.ts
+++ b/src/storages/pluggable/ImpressionsCachePluggable.ts
@@ -2,7 +2,6 @@ import { ICustomStorageWrapper, IImpressionsCacheAsync } from '../types';
 import { IMetadata } from '../../dtos/types';
 import { ImpressionDTO } from '../../types';
 import { ILogger } from '../../logger/types';
-import { LOG_PREFIX } from './constants';
 import { StoredImpressionWithMetadata } from '../../sync/submitters/types';
 
 export class ImpressionsCachePluggable implements IImpressionsCacheAsync {
@@ -22,20 +21,14 @@ export class ImpressionsCachePluggable implements IImpressionsCacheAsync {
   /**
    * Push given impressions to the storage.
    * @param impressions  List of impresions to push.
-   * @returns  A promise that is resolved with a boolean value indicating if the push operation succeeded or failed.
-   * The promise will never be rejected.
+   * @returns  A promise that is resolved if the push operation succeeded
+   * or rejected if the wrapper operation fails.
    */
-  track(impressions: ImpressionDTO[]): Promise<boolean> {
+  track(impressions: ImpressionDTO[]): Promise<void> {
     return this.wrapper.pushItems(
       this.key,
       this._toJSON(impressions)
-    )
-      // We use boolean values to signal successful queueing
-      .then(() => true)
-      .catch((e) => {
-        this.log.error(LOG_PREFIX + ` Error adding event to queue: ${e}.`);
-        return false;
-      });
+    );
   }
 
   private _toJSON(impressions: ImpressionDTO[]): string[] {
@@ -71,7 +64,7 @@ export class ImpressionsCachePluggable implements IImpressionsCacheAsync {
    * Removes the given number of impressions from the store. If a number is not provided, it deletes all items.
    * The returned promise rejects if the wrapper operation fails.
    */
-  drop(count?: number): Promise<any> {
+  drop(count?: number): Promise<void> { // @ts-ignore
     if (!count) return this.wrapper.del(this.key);
 
     return this.wrapper.popItems(this.key, count).then(() => { });

--- a/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
@@ -1,52 +1,53 @@
-import find from 'lodash/find';
-import isEqual from 'lodash/isEqual';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { EventsCachePluggable } from '../EventsCachePluggable';
 import { wrapperMockFactory } from './wrapper.mock';
 import { wrapperAdapter } from '../wrapperAdapter';
 
 const prefix = 'events_cache_ut';
-const eventsKey = `${prefix}.impressions`;
+const eventsKey = `${prefix}.events`;
 const fakeMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
 
-const fakeEvent1 = { event: 1 };
-const fakeEvent2 = { event: '2' };
-const fakeEvent3 = { event: null };
+const fakeEvent1 = { eventTypeId: '1', timestamp: 111 };
+const fakeEvent1stored = { m: fakeMetadata, e: fakeEvent1 };
+
+const fakeEvent2 = { eventTypeId: '2', timestamp: 222 };
+const fakeEvent2stored = { m: fakeMetadata, e: fakeEvent2 };
+
+const fakeEvent3 = { eventTypeId: '3', timestamp: 333 };
+const fakeEvent3stored = { m: fakeMetadata, e: fakeEvent3 };
+
+export { fakeMetadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored };
 
 describe('PLUGGABLE EVENTS CACHE', () => {
 
-  test('`track` method should push values into the pluggable storage', async () => {
+  test('`track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
     const wrapperMock = wrapperMockFactory();
     const cache = new EventsCachePluggable(loggerMock, eventsKey, wrapperMock, fakeMetadata);
 
-    // @ts-expect-error
+    // Testing track and count methods.
     expect(await cache.track(fakeEvent1)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
-    // @ts-expect-error
+    expect(await cache.count()).toBe(1); // count should return stored items
     expect(await cache.track(fakeEvent2)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
-    // @ts-expect-error
     expect(await cache.track(fakeEvent3)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
+    expect(await cache.count()).toBe(3); // count should return stored items
 
     const values = wrapperMock._cache[eventsKey] as string[];
+    expect(values.length).toBe(3); // After pushing we should have events in the wrapper.
 
-    expect(values.length).toBe(3); // After pushing we should have as many events as we have stored.
-    expect(typeof values[0]).toBe('string'); // All elements should be strings since those are stringified JSONs.
-    expect(typeof values[1]).toBe('string'); // All elements should be strings since those are stringified JSONs.
-    expect(typeof values[2]).toBe('string'); // All elements should be strings since those are stringified JSONs.
+    // Testing popNWithMetadata
+    expect(await cache.popNWithMetadata(2)).toEqual([fakeEvent1stored, fakeEvent2stored]); // events are removed in FIFO order
+    expect(await cache.count()).toBe(1);
 
-    const findMatchingElem = (event: any) => {
-      return find(values, elem => {
-        const parsedElem = JSON.parse(elem);
-        return isEqual(parsedElem.e, event) && isEqual(parsedElem.m, fakeMetadata);
-      });
-    };
+    expect(await cache.popNWithMetadata(1)).toEqual([fakeEvent3stored]);
+    expect(await cache.count()).toBe(0);
 
-    /* If the elements are found, then the values are correct. */
-    const foundEv1 = findMatchingElem(fakeEvent1);
-    const foundEv2 = findMatchingElem(fakeEvent2);
-    const foundEv3 = findMatchingElem(fakeEvent3);
-    expect(foundEv1).not.toBe(undefined); // stored events matched the values we are expecting.
-    expect(foundEv2).not.toBe(undefined); // stored events matched the values we are expecting.
-    expect(foundEv3).not.toBe(undefined); // stored events matched the values we are expecting.
+    expect(await cache.popNWithMetadata(100)).toEqual([]); // no more events
+
+    // Testing drop method
+    await Promise.all([cache.track(fakeEvent1), cache.track(fakeEvent2), cache.track(fakeEvent3)]);
+    expect(await cache.count()).toBe(3);
+    await cache.drop();
+    expect(await cache.count()).toBe(0); // storage should be empty after droping it
 
     wrapperMock.mockClear();
   });
@@ -58,11 +59,8 @@ describe('PLUGGABLE EVENTS CACHE', () => {
     // wrapperMock is adapted this time to properly handle unexpected exceptions
     const faultyCache = new EventsCachePluggable(loggerMock, 'non-list-key', wrapperAdapter(loggerMock, wrapperMock), fakeMetadata);
 
-    // @ts-expect-error
     expect(await faultyCache.track(fakeEvent1)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
-    // @ts-expect-error
     expect(await faultyCache.track(fakeEvent2)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
-    // @ts-expect-error
     expect(await faultyCache.track(fakeEvent3)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
 
     wrapperMock.mockClear();

--- a/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
@@ -75,17 +75,18 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
     expect(await cache.count()).toBe(3); // count should return stored items
 
     // Testing popNWithMetadata and private toJSON methods.
-    expect(await cache.popNWithMetadata(2)).toEqual([o1stored, o2stored]); // impressions are pop in FIFO order
+    expect(await cache.popNWithMetadata(2)).toEqual([o1stored, o2stored]); // impressions are removed in FIFO order
     expect(await cache.count()).toBe(1);
 
     expect(await cache.popNWithMetadata(1)).toEqual([o3stored]);
     expect(await cache.count()).toBe(0);
+    expect(await cache.popNWithMetadata(100)).toEqual([]); // no more impressions
 
     // Testing drop method
     await cache.track([o1, o2, o3]);
     expect(await cache.count()).toBe(3);
     await cache.drop();
-    expect(await cache.count()).toBe(0); // storage should be empty after droping the storage
+    expect(await cache.count()).toBe(0); // storage should be empty after droping it
 
   });
 

--- a/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
@@ -1,5 +1,4 @@
 
-import KeyBuilderSS from '../../KeyBuilderSS';
 import { ImpressionsCachePluggable } from '../ImpressionsCachePluggable';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMock } from './wrapper.mock';
@@ -7,8 +6,7 @@ import { IMetadata } from '../../../dtos/types';
 
 const prefix = 'impr_cache_ut';
 const impressionsKey = `${prefix}.impressions`;
-const testMeta: IMetadata = { i: 'some_ip', n: 'some_host', s: 'some_sdk_version' }; // @ts-ignore
-const keys = new KeyBuilderSS(prefix, testMeta);
+const testMeta: IMetadata = { i: 'some_ip', n: 'some_host', s: 'some_sdk_version' };
 
 const o1 = {
   feature: 'test1',
@@ -46,7 +44,7 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
   });
 
   test('`track` method should push values into the pluggable storage', async () => {
-    const cache = new ImpressionsCachePluggable(loggerMock, keys, wrapperMock, testMeta);
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, testMeta);
 
     expect(await cache.track([o1])).toBe(true); // result should resolve to true
 
@@ -76,7 +74,7 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
   test('`track` method result should not reject if wrapper operation fails', async () => {
     // make wrapper operation fail
     wrapperMock.pushItems.mockImplementation(() => Promise.reject());
-    const cache = new ImpressionsCachePluggable(loggerMock, keys, wrapperMock, testMeta);
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, testMeta);
 
     expect(await cache.track([o1])).toBe(false); // result should resolve to false
   });

--- a/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
@@ -1,4 +1,3 @@
-
 import { ImpressionsCachePluggable } from '../ImpressionsCachePluggable';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMock } from './wrapper.mock';
@@ -6,7 +5,8 @@ import { IMetadata } from '../../../dtos/types';
 
 const prefix = 'impr_cache_ut';
 const impressionsKey = `${prefix}.impressions`;
-const testMeta: IMetadata = { i: 'some_ip', n: 'some_host', s: 'some_sdk_version' };
+
+const fakeMetadata: IMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
 
 const o1 = {
   feature: 'test1',
@@ -15,6 +15,11 @@ const o1 = {
   time: Date.now(),
   label: 'default rule',
   changeNumber: 1
+};
+
+const o1stored = {
+  m: fakeMetadata,
+  i: { k: o1.keyName, f: o1.feature, t: o1.treatment, r: o1.label, c: o1.changeNumber, m: o1.time }
 };
 
 const o2 = {
@@ -27,6 +32,11 @@ const o2 = {
   changeNumber: 1
 };
 
+const o2stored = {
+  m: fakeMetadata,
+  i: { k: o2.keyName, b: o2.bucketingKey, f: o2.feature, t: o2.treatment, r: o2.label, c: o2.changeNumber, m: o2.time }
+};
+
 const o3 = {
   feature: 'test3',
   keyName: 'pipiip@split.io',
@@ -36,6 +46,13 @@ const o3 = {
   changeNumber: 1
 };
 
+const o3stored = {
+  m: fakeMetadata,
+  i: { k: o3.keyName, f: o3.feature, t: o3.treatment, r: o3.label, c: o3.changeNumber, m: o3.time }
+};
+
+export { fakeMetadata, o1, o2, o3, o1stored, o2stored, o3stored };
+
 describe('PLUGGABLE IMPRESSIONS CACHE', () => {
 
   afterEach(() => {
@@ -43,40 +60,41 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
     wrapperMock.mockClear();
   });
 
-  test('`track` method should push values into the pluggable storage', async () => {
-    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, testMeta);
+  test('`track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, fakeMetadata);
 
-    expect(await cache.track([o1])).toBe(true); // result should resolve to true
-
+    // Testing track and count methods.
+    await cache.track([o1]);
     let state = wrapperMock._cache[impressionsKey] as string[];
     expect(state.length).toBe(1); // impression should be stored
+    expect(await cache.count()).toBe(1); // count should return stored items
 
-    expect(await cache.track([o2, o3])).toBe(true);
-
+    await cache.track([o2, o3]);
     state = wrapperMock._cache[impressionsKey] as string[];
     expect(state.length).toBe(3);
-    // This is testing both the track and the toJSON method.
-    expect(state[0]).toBe(JSON.stringify({
-      m: testMeta,
-      i: { k: o1.keyName, f: o1.feature, t: o1.treatment, r: o1.label, c: o1.changeNumber, m: o1.time }
-    }));
-    expect(state[1]).toBe(JSON.stringify({
-      m: testMeta,
-      i: { k: o2.keyName, b: o2.bucketingKey, f: o2.feature, t: o2.treatment, r: o2.label, c: o2.changeNumber, m: o2.time }
-    }));
-    expect(state[2]).toBe(JSON.stringify({
-      m: testMeta,
-      i: { k: o3.keyName, f: o3.feature, t: o3.treatment, r: o3.label, c: o3.changeNumber, m: o3.time }
-    }));
+    expect(await cache.count()).toBe(3); // count should return stored items
+
+    // Testing popNWithMetadata and private toJSON methods.
+    expect(await cache.popNWithMetadata(2)).toEqual([o1stored, o2stored]); // impressions are pop in FIFO order
+    expect(await cache.count()).toBe(1);
+
+    expect(await cache.popNWithMetadata(1)).toEqual([o3stored]);
+    expect(await cache.count()).toBe(0);
+
+    // Testing drop method
+    await cache.track([o1, o2, o3]);
+    expect(await cache.count()).toBe(3);
+    await cache.drop();
+    expect(await cache.count()).toBe(0); // storage should be empty after droping the storage
 
   });
 
-  test('`track` method result should not reject if wrapper operation fails', async () => {
+  test('`track` method rejects if wrapper operation fails', (done) => {
     // make wrapper operation fail
     wrapperMock.pushItems.mockImplementation(() => Promise.reject());
-    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, testMeta);
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, fakeMetadata);
 
-    expect(await cache.track([o1])).toBe(false); // result should resolve to false
+    cache.track([o1]).catch(done); // result should rejects
   });
 
 });

--- a/src/storages/pluggable/index.ts
+++ b/src/storages/pluggable/index.ts
@@ -53,8 +53,8 @@ export function PluggableStorage(options: PluggableStorageOptions) {
     return {
       splits: new SplitsCachePluggable(log, keys, wrapper),
       segments: new SegmentsCachePluggable(log, keys, wrapper),
-      impressions: new ImpressionsCachePluggable(log, keys, wrapper, metadata),
-      events: new EventsCachePluggable(log, keys, wrapper, metadata),
+      impressions: new ImpressionsCachePluggable(log, keys.buildImpressionsKey(), wrapper, metadata),
+      events: new EventsCachePluggable(log, keys.buildEventsKey(), wrapper, metadata),
       // @TODO add telemetry cache when required
 
       // Disconnect the underlying storage, to release its resources (such as open files, database connections, etc).

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -290,7 +290,7 @@ export interface ISegmentsCacheAsync extends ISegmentsCacheBase {
 
 export interface IImpressionsCacheBase {
   // Consumer API method, used by impressions tracker, in standalone and consumer modes, to push impressions into the storage.
-  track(data: ImpressionDTO[]): MaybeThenable<boolean>
+  track(data: ImpressionDTO[]): MaybeThenable<void>
 }
 
 export interface IEventsCacheBase {
@@ -313,7 +313,7 @@ export interface IRecorderCacheProducerSync<T> {
 
 
 export interface IImpressionsCacheSync extends IImpressionsCacheBase, IRecorderCacheProducerSync<ImpressionDTO[]> {
-  track(data: ImpressionDTO[]): boolean
+  track(data: ImpressionDTO[]): void
 }
 
 export interface IEventsCacheSync extends IEventsCacheBase, IRecorderCacheProducerSync<SplitIO.EventData[]> {
@@ -335,7 +335,7 @@ export interface IRecorderCacheProducerAsync<T> {
 
 export interface IImpressionsCacheAsync extends IImpressionsCacheBase, IRecorderCacheProducerAsync<StoredImpressionWithMetadata[]> {
   // Consumer API method, used by impressions tracker (in standalone and consumer modes) to push data into.
-  track(data: ImpressionDTO[]): Promise<boolean>
+  track(data: ImpressionDTO[]): Promise<void>
 }
 
 export interface IEventsCacheAsync extends IEventsCacheBase, IRecorderCacheProducerAsync<StoredEventWithMetadata[]> {

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -1,5 +1,6 @@
 import { MaybeThenable, IMetadata, ISplitFiltersValidation } from '../dtos/types';
 import { ILogger } from '../logger/types';
+import { StoredEventWithMetadata, StoredImpressionWithMetadata } from '../sync/submitters/types';
 import { SplitIO, ImpressionDTO } from '../types';
 
 /**
@@ -285,94 +286,100 @@ export interface ISegmentsCacheAsync extends ISegmentsCacheBase {
   clear(): Promise<boolean | void>
 }
 
-/**
- * Producer API of Recorder caches (Impressions, Events and Metrics cache), used by recorders to push data.
- */
-export interface IRecorderCacheProducerBase<TArgs extends any[]> {
-  track(...args: TArgs): MaybeThenable<boolean | void>
-}
+/** Recorder storages (impressions, events and telemetry) */
 
-/**
- * Consumer API of Recorder caches, used by submitters to pop data and post it to Split BE.
- */
-export interface IRecorderCacheConsumerSync<TState> {
-  isEmpty(): boolean // check if cache is empty. Return true if the cache was just created or cleared.
-  clear(): void // clear cache data
-  state(): TState // get cache data
-}
-
-export interface IRecorderCacheSync<TArgs extends any[], TState> extends IRecorderCacheProducerBase<TArgs>, IRecorderCacheConsumerSync<TState> {
-  track(...args: TArgs): boolean | void
-}
-
-export interface IRecorderCacheAsync<TArgs extends any[]> extends IRecorderCacheProducerBase<TArgs> {
-  track(...args: TArgs): Promise<boolean | void>
-}
-
-/** Impressions cache */
-
-export interface IImpressionsCacheBase extends IRecorderCacheProducerBase<[ImpressionDTO[]]> {
+export interface IImpressionsCacheBase {
+  // Consumer API method, used by impressions tracker, in standalone and consumer modes, to push impressions into the storage.
   track(data: ImpressionDTO[]): MaybeThenable<boolean>
 }
 
-export interface IImpressionsCacheSync extends IImpressionsCacheBase, IRecorderCacheSync<[ImpressionDTO[]], ImpressionDTO[]> {
-  track(data: ImpressionDTO[]): boolean
-}
-
-export interface IImpressionsCacheAsync extends IImpressionsCacheBase, IRecorderCacheAsync<[ImpressionDTO[]]> {
-  track(data: ImpressionDTO[]): Promise<boolean>
-}
-
-/** Impression counts cache */
-
-export interface IImpressionCountsCacheBase extends IRecorderCacheProducerBase<[string, number, number]> {
-  track(featureName: string, timeFrame: number, amount: number): MaybeThenable<void>
-}
-
-export interface IImpressionCountsCacheSync extends IImpressionCountsCacheBase, IRecorderCacheSync<[string, number, number], Record<string, number>> {
-  track(featureName: string, timeFrame: number, amount: number): void
-}
-
-export interface IImpressionCountsCacheAsync extends IImpressionCountsCacheBase, IRecorderCacheAsync<[string, number, number]> {
-  track(featureName: string, timeFrame: number, amount: number): Promise<void>
-}
-
-/** Events cache */
-
-export interface IEventsCacheBase extends IRecorderCacheProducerBase<[SplitIO.EventData, number | undefined]> {
+export interface IEventsCacheBase {
+  // Consumer API method, used by events tracker, in standalone and consumer modes, to push events into the storage.
   track(data: SplitIO.EventData, size?: number): MaybeThenable<boolean>
 }
 
-export interface IEventsCacheSync extends IEventsCacheBase, IRecorderCacheSync<[SplitIO.EventData, number | undefined], SplitIO.EventData[]> {
-  track(data: SplitIO.EventData, size?: number): boolean,
+/** Impressions and events cache for standalone mode (sync) */
+
+// Producer API methods for sync recorder storages, used by submitters in standalone mode to pop data and post it to Split BE.
+export interface IRecorderCacheProducerSync<T> {
+  // @TODO names are inconsistent with spec
+  /* Checks if cache is empty. Returns true if the cache was just created or cleared */
+  isEmpty(): boolean
+  /* clears cache data */
+  clear(): void
+  /* Gets cache data */
+  state(): T
+}
+
+
+export interface IImpressionsCacheSync extends IImpressionsCacheBase, IRecorderCacheProducerSync<ImpressionDTO[]> {
+  track(data: ImpressionDTO[]): boolean
+}
+
+export interface IEventsCacheSync extends IEventsCacheBase, IRecorderCacheProducerSync<SplitIO.EventData[]> {
+  track(data: SplitIO.EventData, size?: number): boolean
   setOnFullQueueCb(cb: () => void): void
 }
 
-export interface IEventsCacheAsync extends IEventsCacheBase, IRecorderCacheAsync<[SplitIO.EventData, number | undefined]> {
+/** Impressions and events cache for consumer and producer mode (async) */
+
+// Producer API methods for async recorder storages, used by submitters in producer mode to pop data and post it to Split BE.
+export interface IRecorderCacheProducerAsync<T> {
+  /* returns the number of stored items */
+  count(): Promise<number>
+  /* removes the given number of items from the store. If not provided, it deletes all items */
+  drop(count?: number): Promise<void>
+  /* pops the given number of items from the store */
+  popNWithMetadata(count: number): Promise<T>
+}
+
+export interface IImpressionsCacheAsync extends IImpressionsCacheBase, IRecorderCacheProducerAsync<StoredImpressionWithMetadata[]> {
+  // Consumer API method, used by impressions tracker (in standalone and consumer modes) to push data into.
+  track(data: ImpressionDTO[]): Promise<boolean>
+}
+
+export interface IEventsCacheAsync extends IEventsCacheBase, IRecorderCacheProducerAsync<StoredEventWithMetadata[]> {
+  // Consumer API method, used by events tracker (in standalone and consumer modes) to push data into.
   track(data: SplitIO.EventData, size?: number): Promise<boolean>
 }
 
-/** Latencies cache */
+/**
+ * Impression counts cache for impressions dedup in standalone and producer mode.
+ * Only in memory. Named `ImpressionsCounter` in spec.
+ */
+export interface IImpressionCountsCacheSync extends IRecorderCacheProducerSync<Record<string, number>> {
+  // Used by impressions tracker
+  track(featureName: string, timeFrame: number, amount: number): void
 
-export interface ILatenciesCacheBase extends IRecorderCacheProducerBase<[string, number]> { }
-
-export interface ILatenciesCacheSync extends ILatenciesCacheBase, IRecorderCacheSync<[string, number], Record<string, number[]>> {
-  track(metricName: string, latency: number): boolean
+  // Used by impressions count submitter in standalone and producer mode
+  isEmpty(): boolean // check if cache is empty. Return true if the cache was just created or cleared.
+  clear(): void // clear cache data
+  state(): Record<string, number> // get cache data
 }
 
-export interface ILatenciesCacheAsync extends ILatenciesCacheBase, IRecorderCacheAsync<[string, number]> {
+
+/** Latencies and metric counts cache */
+// @TODO remove. They are deprecated.
+
+export interface ILatenciesCacheSync extends IRecorderCacheProducerSync<Record<string, number[]>> {
+  track(metricName: string, latency: number): boolean
+  isEmpty(): boolean
+  clear(): void
+  state(): Record<string, number[]>
+}
+
+export interface ILatenciesCacheAsync {
   track(metricName: string, latency: number): Promise<boolean>
 }
 
-/** Counts cache */
-
-export interface ICountsCacheBase extends IRecorderCacheProducerBase<[string]> { }
-
-export interface ICountsCacheSync extends ICountsCacheBase, IRecorderCacheSync<[string], Record<string, number>> {
+export interface ICountsCacheSync extends IRecorderCacheProducerSync<Record<string, number>> {
   track(metricName: string): boolean
+  isEmpty(): boolean
+  clear(): void
+  state(): Record<string, number>
 }
 
-export interface ICountsCacheAsync extends ICountsCacheBase, IRecorderCacheAsync<[string]> {
+export interface ICountsCacheAsync {
   track(metricName: string): Promise<boolean>
 }
 
@@ -384,15 +391,14 @@ export interface IStorageBase<
   TSplitsCache extends ISplitsCacheBase,
   TSegmentsCache extends ISegmentsCacheBase,
   TImpressionsCache extends IImpressionsCacheBase,
-  TImpressionCountsCache extends IImpressionCountsCacheBase,
   TEventsCache extends IEventsCacheBase,
-  TLatenciesCache extends ILatenciesCacheBase,
-  TCountsCache extends ICountsCacheBase,
+  TLatenciesCache extends ILatenciesCacheSync | ILatenciesCacheAsync,
+  TCountsCache extends ICountsCacheSync | ICountsCacheAsync,
   > {
   splits: TSplitsCache,
   segments: TSegmentsCache,
   impressions: TImpressionsCache,
-  impressionCounts?: TImpressionCountsCache,
+  impressionCounts?: IImpressionCountsCacheSync,
   events: TEventsCache,
   latencies?: TLatenciesCache,
   counts?: TCountsCache,
@@ -403,7 +409,6 @@ export type IStorageSync = IStorageBase<
   ISplitsCacheSync,
   ISegmentsCacheSync,
   IImpressionsCacheSync,
-  IImpressionCountsCacheSync,
   IEventsCacheSync,
   ILatenciesCacheSync,
   ICountsCacheSync
@@ -417,7 +422,6 @@ export type IStorageAsync = IStorageBase<
   ISplitsCacheAsync,
   ISegmentsCacheAsync,
   IImpressionsCacheAsync,
-  IImpressionCountsCacheAsync,
   IEventsCacheAsync,
   ILatenciesCacheAsync,
   ICountsCacheAsync

--- a/src/sync/submitters/impressionsSyncTask.ts
+++ b/src/sync/submitters/impressionsSyncTask.ts
@@ -12,7 +12,7 @@ import { ILogger } from '../../logger/types';
  */
 export function fromImpressionsCollector(sendLabels: boolean, data: ImpressionDTO[]): ImpressionsPayload {
   let groupedByFeature = groupBy(data, 'feature');
-  let dto: any[] = [];
+  let dto: ImpressionsPayload = [];
 
   // using forOwn instead of for...in since the last also iterates over prototype enumerables
   forOwn(groupedByFeature, (value, name) => {

--- a/src/sync/submitters/submitterSyncTask.ts
+++ b/src/sync/submitters/submitterSyncTask.ts
@@ -1,6 +1,6 @@
 import syncTaskFactory from '../syncTask';
 import { ISyncTask, ITimeTracker } from '../types';
-import { IRecorderCacheConsumerSync } from '../../storages/types';
+import { IRecorderCacheProducerSync } from '../../storages/types';
 import { ILogger } from '../../logger/types';
 import { SUBMITTERS_PUSH, SUBMITTERS_PUSH_FAILS, SUBMITTERS_PUSH_RETRY } from '../../logger/constants';
 
@@ -10,13 +10,13 @@ import { SUBMITTERS_PUSH, SUBMITTERS_PUSH_FAILS, SUBMITTERS_PUSH_RETRY } from '.
 export function submitterSyncTaskFactory<TState extends { length?: number }>(
   log: ILogger,
   postClient: (body: string) => Promise<Response>,
-  sourceCache: IRecorderCacheConsumerSync<TState>,
+  sourceCache: IRecorderCacheProducerSync<TState>,
   postRate: number,
   dataName: string,
   latencyTracker?: ITimeTracker,
   fromCacheToPayload?: (cacheData: TState) => any,
   maxRetries: number = 0,
-): ISyncTask {
+): ISyncTask<[], void> {
 
   let retries = 0;
 

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -1,20 +1,64 @@
+import { IMetadata } from '../../dtos/types';
+import { SplitIO } from '../../types';
+
 export type ImpressionsPayload = {
-  f: string, // Split name
-  i: { // Key Impressions
-    k: string; // Key
-    t: string; // Treatment
-    m: number; // Timestamp
-    c: number; // ChangeNumber
-    r?: string; // Rule label
-    b?: string; // Bucketing Key
-    pt?: number; // Previous time
+  /** Split name */
+  f: string,
+  /** Key Impressions */
+  i: {
+    /** Key */
+    k: string;
+    /** Treatment */
+    t: string;
+    /** Timestamp */
+    m: number;
+    /** ChangeNumber */
+    c: number;
+    /** Rule label */
+    r?: string;
+    /** Bucketing Key */
+    b?: string;
+    /** Previous time */
+    pt?: number;
   }[]
 }[]
 
 export type ImpressionCountsPayload = {
   pf: {
-    f: string // Split name
-    m: number // Time Frame
-    rc: number // Count
+    /** Split name */
+    f: string
+    /** Time Frame */
+    m: number
+    /** Count */
+    rc: number
   }[]
+}
+
+export type StoredImpressionWithMetadata = {
+  /** Metadata */
+  m: IMetadata,
+  /** Stored impression */
+  i: {
+    /** keyName */
+    k: string,
+    /** bucketingKey */
+    b?: string,
+    /** Split name */
+    f: string,
+    /** treatment */
+    t: string,
+    /** label */
+    r: string,
+    /** changeNumber */
+    c: number,
+    /** time */
+    m: number
+  }
+}
+
+export type StoredEventWithMetadata = {
+  /** Metadata */
+  m: IMetadata,
+  /** Stored event */
+  e: SplitIO.EventData
 }

--- a/src/trackers/impressionsTracker.ts
+++ b/src/trackers/impressionsTracker.ts
@@ -1,7 +1,7 @@
 import objectAssign from 'object-assign';
 import thenable from '../utils/promise/thenable';
 import { truncateTimeFrame } from '../utils/time';
-import { IImpressionCountsCacheBase, IImpressionsCacheBase } from '../storages/types';
+import { IImpressionCountsCacheSync, IImpressionsCacheBase } from '../storages/types';
 import { IImpressionsHandler, IImpressionsTracker } from './types';
 import { SplitIO, ImpressionDTO, ISettings } from '../types';
 import { IImpressionObserver } from './impressionObserver/types';
@@ -30,7 +30,7 @@ export default function impressionsTrackerFactory(
   // if observer is provided, it implies `shouldAddPreviousTime` flag (i.e., if impressions previous time should be added or not)
   observer?: IImpressionObserver,
   // if countsCache is provided, it implies `isOptimized` flag (i.e., if impressions should be deduped or not)
-  countsCache?: IImpressionCountsCacheBase
+  countsCache?: IImpressionCountsCacheSync
 ): IImpressionsTracker {
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,7 +592,7 @@ export namespace SplitIO {
   export type EventData = {
     eventTypeId: string;
     value?: number;
-    properties: Properties;
+    properties?: Properties;
     trafficTypeName?: string;
     key?: string; // matching user key
     timestamp: number;

--- a/src/utils/inputValidation/eventProperties.ts
+++ b/src/utils/inputValidation/eventProperties.ts
@@ -10,7 +10,7 @@ const ECMA_SIZES = {
   NUMBER: 8
 };
 const MAX_PROPERTIES_AMOUNT = 300;
-const MAX_PROPERTIES_SIZE = 1024 * 32;
+const MAX_EVENT_SIZE = 1024 * 32;
 const BASE_EVENT_SIZE = 1024; // We assume 1kb events without properties (avg measured)
 
 export function validateEventProperties(log: ILogger, maybeProperties: any, method: string): { properties: SplitIO.Properties | null | false, size: number } {
@@ -55,7 +55,7 @@ export function validateEventProperties(log: ILogger, maybeProperties: any, meth
     else if (isBoolVal) output.size += ECMA_SIZES.BOOLEAN;
     else if (isStringVal) output.size += val.length * ECMA_SIZES.STRING;
 
-    if (output.size > MAX_PROPERTIES_SIZE) {
+    if (output.size > MAX_EVENT_SIZE) {
       log.error(ERROR_SIZE_EXCEEDED, [method]);
       output.properties = false;
       break;


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added `popNWithMetadata`, `drop` and `count` methods to { events, impressions } X { redis, pluggable } storages
- Fixed `track` method in impression storages: unlike events storages, returned promise might reject, and resolves with no value.

## How do we test the changes introduced in this PR?

- Added UTs for new methods

## Extra Notes