### PR TITLE
SegmentChangesUpdater fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.6",
+  "version": "0.1.1-canary.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.6",
+  "version": "0.1.1-canary.7",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/storages/pluggable/SegmentsCachePluggable.ts
+++ b/src/storages/pluggable/SegmentsCachePluggable.ts
@@ -5,7 +5,7 @@ import KeyBuilderSS from '../KeyBuilderSS';
 import { ICustomStorageWrapper, ISegmentsCacheAsync } from '../types';
 import { ILogger } from '../../logger/types';
 import { LOG_PREFIX } from './constants';
-import { setToArray, _Set } from '../../utils/lang/sets';
+import { _Set } from '../../utils/lang/sets';
 
 /**
  * ISegmentsCacheAsync implementation for pluggable storages.

--- a/src/sync/polling/fetchers/segmentChangesFetcher.ts
+++ b/src/sync/polling/fetchers/segmentChangesFetcher.ts
@@ -14,13 +14,6 @@ function greedyFetch(fetchSegmentChanges: IFetchSegmentChanges, since: number, s
           return [flatMe[0], ...flatMe[1]];
         });
       }
-    })
-    .catch(err => {
-      // If the operation is forbidden it may be due to permissions, don't recover and propagate the error.
-      if (err.statusCode === 403) throw err;
-      // if something goes wrong with the request to the server, we are going to
-      // stop requesting information till the next round of downloading
-      return [];
     });
 }
 

--- a/src/sync/polling/updaters/segmentChangesUpdater.ts
+++ b/src/sync/polling/updaters/segmentChangesUpdater.ts
@@ -94,14 +94,13 @@ export function segmentChangesUpdaterFactory(
           readyOnAlreadyExistentState = false;
           if (readiness) readiness.segments.emit(SDK_SEGMENTS_ARRIVED);
         }
-        // if at least one segment fetch fails, return false to indicate that there was some error (e.g., invalid json, HTTP error, etc)
-        if (shouldUpdateFlags.indexOf(-1) !== -1) return false;
         return true;
       });
     })
       // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
       .catch(error => {
-        if (error.statusCode === 403) {
+        if (error && error.statusCode === 403) {
+          // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
           // @TODO although factory status is destroyed, synchronization is not stopped
           if (readiness) readiness.destroy();
           log.error(`${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an Api Key from the Split web console that is of type Server-side.`);

--- a/src/sync/streaming/SSEClient/index.ts
+++ b/src/sync/streaming/SSEClient/index.ts
@@ -55,6 +55,7 @@ export default class SSEClient implements ISSEClient {
 
     this.streamingUrl = settings.urls.streaming + '/sse';
     this.reopen = this.reopen.bind(this);
+    // @TODO get `useHeaders` flag from `getEventSource`, to use EventSource headers on client-side SDKs when possible.
     this.useHeaders = useHeaders;
     this.headers = buildSSEHeaders(settings);
   }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Updated `segmentChangesFetcher` to reject the returned promise if request fails, in order to be consistent with the other fetchers.
- Updated `segmentChangesUpdater` to avoid wrongly resolving to `false` when segment changes requests success without changes.

## How do we test the changes introduced in this PR?

- UTs will be added in the future, but the updated modules are already covered by E2E tests.

## Extra Notes