### PR TITLE
Added to the SplitAPI Service, health checks request to Splits and Events API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.7",
+  "version": "0.1.1-canary.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "0.1.1-canary.7",
+  "version": "0.1.1-canary.8",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/services/__tests__/splitApi.spec.ts
+++ b/src/services/__tests__/splitApi.spec.ts
@@ -85,7 +85,7 @@ describe('splitApi', () => {
     const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
     const splitApi = splitApiFactory(settingsWithRuntime, { getFetch: () => fetchMock });
 
-    splitApi.getSplitAPIHealthCheck().then((res) => {
+    splitApi.getSplitSDKHealthCheck().then((res) => {
       expect(res).toEqual(true);
     });
     expect(fetchMock.mock.calls[0][0]).toMatch('sdk/version');

--- a/src/services/__tests__/splitApi.spec.ts
+++ b/src/services/__tests__/splitApi.spec.ts
@@ -53,7 +53,7 @@ describe('splitApi', () => {
     fetchMock.mockClear();
   });
 
-  test('reject requests if fetch Api is not provided', (done) => {
+  test('rejects requests if fetch Api is not provided', (done) => {
 
     const splitApi = splitApiFactory(settingsSplitApi, { getFetch: () => undefined });
 
@@ -81,4 +81,19 @@ describe('splitApi', () => {
     expect(fetchMock.mock.calls[1][1].headers['SplitSDKImpressionsMode']).toBe(settingsWithRuntime.sync.impressionsMode);
   });
 
+  test('performs APIs health service check', (done) => {
+    const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
+    const splitApi = splitApiFactory(settingsWithRuntime, { getFetch: () => fetchMock });
+
+    splitApi.getSplitAPIHealthCheck().then((res) => {
+      expect(res).toEqual(true);
+    });
+    expect(fetchMock.mock.calls[0][0]).toMatch('sdk/version');
+
+    splitApi.getEventsAPIHealthCheck().then((res) => {
+      expect(res).toEqual(true);
+      done();
+    });
+    expect(fetchMock.mock.calls[1][0]).toMatch('events/version');
+  });
 });

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -25,7 +25,7 @@ export function splitApiFactory(settings: ISettings, platform: Pick<IPlatform, '
   const splitHttpClient = splitHttpClientFactory(settings, platform.getFetch, platform.getOptions);
 
   return {
-    getSplitAPIHealthCheck() {
+    getSplitSDKHealthCheck() {
       const url = `${urls.sdk}/version`;
       return splitHttpClient(url).then(() => true).catch(() => false);
     },

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -25,6 +25,16 @@ export function splitApiFactory(settings: ISettings, platform: Pick<IPlatform, '
   const splitHttpClient = splitHttpClientFactory(settings, platform.getFetch, platform.getOptions);
 
   return {
+    getSplitAPIHealthCheck() {
+      const url = `${urls.sdk}/version`;
+      return splitHttpClient(url).then(() => true).catch(() => false);
+    },
+
+    getEventsAPIHealthCheck() {
+      const url = `${urls.events}/version`;
+      return splitHttpClient(url).then(() => true).catch(() => false);
+    },
+
     fetchAuth(userMatchingKeys?: string[]) {
       let url = `${urls.auth}/auth`;
       if (userMatchingKeys) { // accounting the possibility that `userMatchingKeys` is undefined (server-side API)

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -50,7 +50,7 @@ export type IPostMetricsCounters = (body: string) => Promise<IResponse>
 export type IPostMetricsTimes = (body: string) => Promise<IResponse>
 
 export interface ISplitApi {
-  getSplitAPIHealthCheck: IHealthCheckAPI;
+  getSplitSDKHealthCheck: IHealthCheckAPI;
   getEventsAPIHealthCheck: IHealthCheckAPI;
 	fetchAuth: IFetchAuth
 	fetchSplitChanges: IFetchSplitChanges

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -27,6 +27,8 @@ export type IResponse = {
 export type IFetch = (url: string, options?: IRequestOptions) => Promise<IResponse>
 
 // IFetch specialization
+export type IHealthCheckAPI = () => Promise<boolean>
+
 export type ISplitHttpClient = (url: string, options?: IRequestOptions, logErrorsAsInfo?: boolean) => Promise<IResponse>
 
 export type IFetchAuth = (userKeys?: string[]) => Promise<IResponse>
@@ -48,6 +50,8 @@ export type IPostMetricsCounters = (body: string) => Promise<IResponse>
 export type IPostMetricsTimes = (body: string) => Promise<IResponse>
 
 export interface ISplitApi {
+  getSplitAPIHealthCheck: IHealthCheckAPI;
+  getEventsAPIHealthCheck: IHealthCheckAPI;
 	fetchAuth: IFetchAuth
 	fetchSplitChanges: IFetchSplitChanges
 	fetchSegmentChanges: IFetchSegmentChanges


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
I'm adding two methods to the SplitAPI service class, to check for the availability of both the Split and the Events API.
Is is required for the NodeJS Slim Synchronizer in order to check API's statuses previous to execute its synchronizing activities.

**Notices that this implementation is fetching `/version` from the APIs, and this works ok for now, but ideally the COE team is [going to create the corresponding health check endpoints](https://splitio.atlassian.net/browse/NOC-698), and when is done we should change this implementation.**

## How do we test the changes introduced in this PR?
1 - Checkout this branch
`git checkout efant_addSplitApis_Healthcheck`
2 - Run tests
`npm run test`

And you can check it in this Synchonizer's PR.

## Extra Notes