### PR TITLE
Refactors to support React Native: signal listeners [WIP]

### DIFF
--- a/src/listeners/__tests__/browser.spec.ts
+++ b/src/listeners/__tests__/browser.spec.ts
@@ -133,12 +133,15 @@ test('Browser JS listener / Impressions optimized mode', () => {
 });
 
 test('Browser JS listener / Impressions debug mode', () => {
-  const syncManagerMockWithPushManager = { pushManager: { stop: jest.fn() } };
+  const syncManagerMockWithPushManager = { start: jest.fn(), pushManager: { stop: jest.fn() } };
 
   // @ts-expect-error
   const listener = new BrowserSignalListener(syncManagerMockWithPushManager, fullSettings, fakeStorageDebug as IStorageSync, fakeSplitApi);
 
   listener.start();
+
+  // starting the listener must start the syncManager
+  expect(syncManagerMockWithPushManager.start).toBeCalled();
 
   // Assigned right function to right signal.
   expect((global.window.addEventListener as jest.Mock).mock.calls).toEqual([[UNLOAD_DOM_EVENT, listener.flushData]]);
@@ -170,12 +173,15 @@ test('Browser JS listener / Impressions debug mode without sendBeacon API', () =
   // remove sendBeacon API
   const sendBeacon = global.navigator.sendBeacon; // @ts-expect-error
   global.navigator.sendBeacon = undefined;
-  const syncManagerMockWithoutPushManager = {};
+  const syncManagerMockWithoutPushManager = { start: jest.fn() };
 
   // @ts-expect-error
   const listener = new BrowserSignalListener(syncManagerMockWithoutPushManager, fullSettings, fakeStorageDebug as IStorageSync, fakeSplitApi);
 
   listener.start();
+
+  // starting the listener must start the syncManager
+  expect(syncManagerMockWithoutPushManager.start).toBeCalled();
 
   // Assigned right function to right signal.
   expect((global.window.addEventListener as jest.Mock).mock.calls).toEqual([[UNLOAD_DOM_EVENT, listener.flushData]]);

--- a/src/listeners/__tests__/node.spec.ts
+++ b/src/listeners/__tests__/node.spec.ts
@@ -7,10 +7,13 @@ const processKillSpy = jest.spyOn(process, 'kill').mockImplementation(() => true
 
 test('Node JS listener / Signal Listener class methods and start/stop functionality', () => {
 
-  const syncManagerMock = { flush: jest.fn() }; // @ts-expect-error
+  const syncManagerMock = { start: jest.fn(), flush: jest.fn() }; // @ts-expect-error
   const listener = new NodeSignalListener(syncManagerMock, fullSettings);
 
   listener.start();
+
+  // starting the listener must start the syncManager
+  expect(syncManagerMock.start).toBeCalled();
 
   // Assigned right function to right signal.
   // @ts-expect-error
@@ -27,7 +30,7 @@ test('Node JS listener / Signal Listener class methods and start/stop functional
 
 test('Node JS listener / Signal Listener SIGTERM callback with sync handler', () => {
 
-  const syncManagerMock = { flush: jest.fn() }; // @ts-expect-error
+  const syncManagerMock = { start: jest.fn(), flush: jest.fn() }; // @ts-expect-error
   const listener = new NodeSignalListener(syncManagerMock, fullSettings);
 
   listener.start();
@@ -56,7 +59,7 @@ test('Node JS listener / Signal Listener SIGTERM callback with sync handler', ()
 });
 
 test('Node JS listener / Signal Listener SIGTERM callback with sync handler that throws an error', () => {
-  const syncManagerMock = { flush: jest.fn(() => { throw 'some error'; }) }; // @ts-expect-error
+  const syncManagerMock = { start: jest.fn(), flush: jest.fn(() => { throw 'some error'; }) }; // @ts-expect-error
   const listener = new NodeSignalListener(syncManagerMock, fullSettings);
 
   listener.start();
@@ -92,7 +95,7 @@ test('Node JS listener / Signal Listener SIGTERM callback with async handler', a
       res();
     }, 0);
   });
-  const syncManagerMock = { flush: jest.fn(() => fakePromise) };
+  const syncManagerMock = { start: jest.fn(), flush: jest.fn(() => fakePromise) };
   // @ts-expect-error
   const listener = new NodeSignalListener(syncManagerMock, fullSettings);
 
@@ -136,7 +139,7 @@ test('Node JS listener / Signal Listener SIGTERM callback with async handler tha
       rej();
     }, 0);
   });
-  const syncManagerMock = { flush: jest.fn(() => fakePromise) };
+  const syncManagerMock = { start: jest.fn(), flush: jest.fn(() => fakePromise) };
   // @ts-expect-error
   const listener = new NodeSignalListener(syncManagerMock, fullSettings);
 

--- a/src/listeners/browser.ts
+++ b/src/listeners/browser.ts
@@ -39,6 +39,7 @@ export default class BrowserSignalListener implements ISignalListener {
    * We add a handler on unload events. The handler flushes remaining impressions and events to the backend.
    */
   start() {
+    this.syncManager?.start();
     if (typeof window !== 'undefined' && window.addEventListener) {
       this.settings.log.debug(CLEANUP_REGISTERING, [EVENT_NAME]);
       window.addEventListener(UNLOAD_DOM_EVENT, this.flushData);
@@ -48,7 +49,6 @@ export default class BrowserSignalListener implements ISignalListener {
   /**
    * stop method.
    * Called when client is destroyed.
-   * We need to remove the handler for unload events, since it can break if called when Split context was destroyed.
    */
   stop() {
     if (typeof window !== 'undefined' && window.removeEventListener) {

--- a/src/listeners/node.ts
+++ b/src/listeners/node.ts
@@ -22,7 +22,7 @@ export default class NodeSignalListener implements ISignalListener {
   private settings: ISettings;
 
   constructor(
-    syncManager: ISyncManager | undefined, // private handler: () => MaybeThenable<void>,
+    private syncManager: ISyncManager | undefined, // private handler: () => MaybeThenable<void>,
     settings: ISettings
   ) {
     // @TODO review handler logic when implementing Node SDK
@@ -37,6 +37,7 @@ export default class NodeSignalListener implements ISignalListener {
   }
 
   start() {
+    this.syncManager?.start();
     this.settings.log.debug(CLEANUP_REGISTERING, [EVENT_NAME]);
     // eslint-disable-next-line no-undef
     process.on(SIGTERM, this._sigtermHandler);

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -78,7 +78,9 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   const clientMethod = sdkClientMethodFactory({ eventTracker, impressionsTracker, sdkReadinessManager, settings, storage, syncManager, signalListener });
   const managerInstance = sdkManagerFactory(log, storage.splits, sdkReadinessManager);
 
-  syncManager && syncManager.start();
+  // If there is a signalListener, it is in charge of starting the syncManager.
+  // It is required for RN to consider the app state when the SDK is instantiated (foreground/background).
+  if (syncManager && !signalListener) syncManager.start();
   signalListener && signalListener.start();
 
   log.info(NEW_FACTORY);


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Updated SdkFactory and SignalListener: if a signal listener is provided, it should be in charge of starting the syncManager in order to consider the state of the application. For instance, in React Native, the SyncManager should not be started if the SDK is instantiated in the background.

## How do we test the changes introduced in this PR?

## Extra Notes