### PR TITLE
Updated promise wrapper and log messages on HTTP errors

### DIFF
--- a/src/logger/messages/error.ts
+++ b/src/logger/messages/error.ts
@@ -12,7 +12,7 @@ export const codesError: [number, string][] = [
   // synchronizer
   [c.ERROR_SYNC_OFFLINE_LOADING, c.LOG_PREFIX_SYNC_OFFLINE + 'There was an issue loading the mock Splits data, no changes will be applied to the current cache. %s'],
   [c.ERROR_STREAMING_SSE, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to connect or error on streaming connection, with error message: %s'],
-  [c.ERROR_STREAMING_AUTH, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to authenticate for streaming. Error: "%s".'],
+  [c.ERROR_STREAMING_AUTH, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to authenticate for streaming. Error: %s.'],
   [c.ERROR_HTTP, ' Response status is not OK. Status: %s. URL: %s. Message: %s'],
   // client status
   [c.ERROR_CLIENT_LISTENER, 'A listener was added for %s on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'],

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -12,7 +12,7 @@ import { ISettingsInternal } from '../utils/settingsValidation/types';
 
 /**
  * Environment related dependencies.
- * These getters are called only once per factory instantiation.
+ * These getters are called a fixed number of times per factory instantiation.
  */
 export interface IPlatform {
   getOptions?: () => object

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -11,7 +11,8 @@ import { SplitIO, ISettings, IEventEmitter } from '../types';
 import { ISettingsInternal } from '../utils/settingsValidation/types';
 
 /**
- * Environment related dependencies
+ * Environment related dependencies.
+ * These getters are called only once per factory instantiation.
  */
 export interface IPlatform {
   getOptions?: () => object

--- a/src/services/splitHttpClient.ts
+++ b/src/services/splitHttpClient.ts
@@ -43,8 +43,8 @@ export function splitHttpClientFactory(settings: Pick<ISettings, 'log' | 'versio
     return fetch ? fetch(url, request)
       // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful
       .then(response => {
-        if (!response.ok) { // eslint-disable-next-line no-throw-literal
-          throw { response };
+        if (!response.ok) {
+          return response.text().then(message => Promise.reject({ response, message }));
         }
         return response;
       })
@@ -56,18 +56,19 @@ export function splitHttpClientFactory(settings: Pick<ISettings, 'log' | 'versio
           switch (resp.status) {
             case 404: msg = 'Invalid API key or resource not found.';
               break;
-            default: msg = resp.statusText;
+            // Don't use resp.statusText since reason phrase is removed in HTTP/2
+            default: msg = error.message;
               break;
           }
         } else { // Something else, either an error making the request or a Network error.
-          msg = error.message;
+          msg = error.message || 'Network Error';
         }
 
         if (!resp || resp.status !== 403) { // 403's log we'll be handled somewhere else.
           log[logErrorsAsInfo ? 'info' : 'error'](ERROR_HTTP, [resp ? resp.status : 'NO_STATUS', url, msg]);
         }
 
-        const networkError: Error & {statusCode?: number} = new Error(msg);
+        const networkError: Error & { statusCode?: number } = new Error(msg);
         // passes `undefined` as statusCode if not an HTTP error (resp === undefined)
         networkError.statusCode = resp && resp.status;
         throw networkError;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -7,12 +7,12 @@ export type IRequestOptions = {
 export type IResponse = {
 	ok: boolean,
 	status: number,
-	json: () => Promise<any>,
+	json: () => Promise<any>, // Used to parse OK response body. Promise rejects if body cannot be parsed
+	text: () => Promise<string>, // Used to read Not OK response body. Promise never rejects
 
 	/** Other available properties when using Unfetch */
-	// statusText: string,
+	// statusText: string, // `undefined` in Web fetch if using HTTP/2: it doesn't have reason phrases anymore. `node-fetch` overwrites it according to the status code
 	// url: string,
-	// text: () => Promise<string>,
 	// blob: () => Promise<Blob>,
 	// clone: () => IResponse,
 	// headers: {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -11,7 +11,7 @@ export type IResponse = {
 	text: () => Promise<string>, // Used to read Not OK response body. Promise never rejects
 
 	/** Other available properties when using Unfetch */
-	// statusText: string, // `undefined` in Web fetch if using HTTP/2: it doesn't have reason phrases anymore. `node-fetch` overwrites it according to the status code
+	// statusText: string, // `undefined` in Web fetch since HTTP/2 doesn't have reason phrases anymore. `node-fetch` overwrites it depending on the status code
 	// url: string,
 	// blob: () => Promise<Blob>,
 	// clone: () => IResponse,

--- a/src/utils/promise/wrapper.ts
+++ b/src/utils/promise/wrapper.ts
@@ -37,16 +37,18 @@ export default function promiseWrapper<T>(customPromise: Promise<T>, defaultOnRe
 
     const originalThen = newPromise.then;
 
-    newPromise.then = function (onfulfilled, onrejected) {
-      const result: Promise<any> = originalThen.call(newPromise, onfulfilled, onrejected);
-      if (typeof onfulfilled === 'function') hasOnFulfilled = true;
-      if (typeof onrejected === 'function') {
-        hasOnRejected = true;
-        return result;
-      } else {
-        return chain(result);
+    Object.defineProperty(newPromise, 'then', {
+      value: function (onfulfilled: any, onrejected: any) {
+        const result: Promise<any> = originalThen.call(newPromise, onfulfilled, onrejected);
+        if (typeof onfulfilled === 'function') hasOnFulfilled = true;
+        if (typeof onrejected === 'function') {
+          hasOnRejected = true;
+          return result;
+        } else {
+          return chain(result);
+        }
       }
-    };
+    });
 
     return newPromise;
   }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Updated promise wrapper to support the case where `Promise.prototype.then` property is not writable.
- Fixed message log on HTTP errors: it uses now the body text content if available, instead of the status phrase, because it is not available in HTTP/2 and was leading to the incorrect `Split network error` log.

## How do we test the changes introduced in this PR?

Validated manually overwriting `Promise.prototype.then` descriptor and in a Meteor project.

## Extra Notes