### PR TITLE
Prevent issue with dynamic config and MinEmitter default export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.0.1-rc.4",
+  "version": "1.0.1-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.0.1-rc.4",
+  "version": "1.0.1-rc.5",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/__tests__/testUtils/eventSourceMock.ts
+++ b/src/__tests__/testUtils/eventSourceMock.ts
@@ -12,7 +12,7 @@
  *
  */
 
-import EventEmitter from '../../utils/MinEvents';
+import { EventEmitter } from '../../utils/MinEvents';
 import { IEventEmitter } from '../../types';
 
 type ReadyStateType = 0 | 1 | 2;

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -1,7 +1,6 @@
 import Engine from './Engine';
 import thenable from '../utils/promise/thenable';
 import * as LabelsConstants from '../utils/labels';
-import { get } from '../utils/lang';
 import { CONTROL } from '../utils/constants';
 import { ISplit, MaybeThenable } from '../dtos/types';
 import { IStorageAsync, IStorageSync } from '../storages/types';
@@ -106,17 +105,17 @@ function getEvaluation(
     const split = Engine.parse(log, splitJSON, storage);
     evaluation = split.getTreatment(key, attributes, evaluateFeature);
 
-    // If the storage is async, evaluation and changeNumber will return a thenable
+    // If the storage is async and the evaluated split uses segment, evaluation is thenable
     if (thenable(evaluation)) {
       return evaluation.then(result => {
         result.changeNumber = split.getChangeNumber();
-        result.config = get(splitJSON, `configurations.${result.treatment}`, null);
+        result.config = splitJSON.configurations && splitJSON.configurations[result.treatment] || null;
 
         return result;
       });
     } else {
       evaluation.changeNumber = split.getChangeNumber(); // Always sync and optional
-      evaluation.config = get(splitJSON, `configurations.${evaluation.treatment}`, null);
+      evaluation.config = splitJSON.configurations && splitJSON.configurations[evaluation.treatment] || null;
     }
   }
 

--- a/src/logger/messages/warn.ts
+++ b/src/logger/messages/warn.ts
@@ -21,9 +21,9 @@ export const codesWarn: [number, string][] = codesError.concat([
   [c.WARN_TRIMMING_PROPERTIES, '%s: Event has more than 300 properties. Some of them will be trimmed when processed.'],
   [c.WARN_CONVERTING, '%s: %s "%s" is not of type string, converting.'],
   [c.WARN_TRIMMING, '%s: %s "%s" has extra whitespace, trimming.'],
-  [c.WARN_NOT_EXISTENT_SPLIT, '%s: split "%s" does not exist in this environment, please double check what splits exist in the web console.'],
+  [c.WARN_NOT_EXISTENT_SPLIT, '%s: split "%s" does not exist in this environment, please double check what splits exist in the Split web console.'],
   [c.WARN_LOWERCASE_TRAFFIC_TYPE, '%s: traffic_type_name should be all lowercase - converting string to lowercase.'],
-  [c.WARN_NOT_EXISTENT_TT, '%s: traffic type "%s" does not have any corresponding split in this environment, make sure you\'re tracking your events to a valid traffic type defined in the web console.'],
+  [c.WARN_NOT_EXISTENT_TT, '%s: traffic type "%s" does not have any corresponding split in this environment, make sure you\'re tracking your events to a valid traffic type defined in the Split web console.'],
   // initialization / settings validation
   [c.WARN_INTEGRATION_INVALID, c.LOG_PREFIX_SETTINGS+': %s integration item(s) at settings is invalid. %s'],
   [c.WARN_SPLITS_FILTER_IGNORED, c.LOG_PREFIX_SETTINGS+': split filters have been configured but will have no effect if mode is not "%s", since synchronization is being deferred to an external tool.'],

--- a/src/readiness/__tests__/readinessManager.spec.ts
+++ b/src/readiness/__tests__/readinessManager.spec.ts
@@ -1,5 +1,5 @@
 import { readinessManagerFactory } from '../readinessManager';
-import EventEmitter from '../../utils/MinEvents';
+import { EventEmitter } from '../../utils/MinEvents';
 import { IReadinessManager } from '../types';
 import { SDK_READY, SDK_UPDATE, SDK_SPLITS_ARRIVED, SDK_SEGMENTS_ARRIVED, SDK_READY_FROM_CACHE, SDK_SPLITS_CACHE_LOADED, SDK_READY_TIMED_OUT } from '../constants';
 

--- a/src/sdkFactory/__tests__/index.spec.ts
+++ b/src/sdkFactory/__tests__/index.spec.ts
@@ -2,7 +2,7 @@ import { ISdkFactoryParams } from '../types';
 import { sdkFactory } from '../index';
 import { fullSettings } from '../../utils/settingsValidation/__tests__/settings.mocks';
 import { SplitIO } from '../../types';
-import EventEmitter from '../../utils/MinEvents';
+import { EventEmitter } from '../../utils/MinEvents';
 
 /** Mocks */
 

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -46,7 +46,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
     // Callback used to emit SDK_READY in consumer mode, where `syncManagerFactory` is undefined
     // or only instantiates submitters, and therefore it is not able to emit readiness events.
     onReadyCb: (error) => {
-      if (error) return; // don't emit SDK_READY if storage failed to connect.
+      if (error) return; // Don't emit SDK_READY if storage failed to connect. Error message is logged by wrapperAdapter
       readinessManager.splits.emit(SDK_SPLITS_ARRIVED);
       readinessManager.segments.emit(SDK_SEGMENTS_ARRIVED);
     },

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -70,7 +70,7 @@ export interface IPluggableStorageWrapper {
   /** Integer operations */
 
   /**
-   * Increments in 1 the given `key` value or set it in 1 if the value doesn't exist.
+   * Increments in 1 the given `key` value or set it to 1 if the value doesn't exist.
    *
    * @function incr
    * @param {string} key Key to increment
@@ -79,7 +79,7 @@ export interface IPluggableStorageWrapper {
    */
   incr: (key: string) => Promise<number>
   /**
-   * Decrements in 1 the given `key` value or set it in -1 if the value doesn't exist.
+   * Decrements in 1 the given `key` value or set it to -1 if the value doesn't exist.
    *
    * @function decr
    * @param {string} key Key to decrement

--- a/src/sync/polling/updaters/__tests__/splitChangesUpdater.spec.ts
+++ b/src/sync/polling/updaters/__tests__/splitChangesUpdater.spec.ts
@@ -8,7 +8,7 @@ import { splitChangesUpdaterFactory, parseSegments, computeSplitsMutation } from
 import splitChangesMock1 from '../../../../__tests__/mocks/splitchanges.since.-1.json';
 import fetchMock from '../../../../__tests__/testUtils/fetchMock';
 import { settingsSplitApi } from '../../../../utils/settingsValidation/__tests__/settings.mocks';
-import EventEmitter from '../../../../utils/MinEvents';
+import { EventEmitter } from '../../../../utils/MinEvents';
 import { loggerMock } from '../../../../logger/__tests__/sdkLogger.mock';
 
 const activeSplitWithSegments = {

--- a/src/sync/streaming/AuthClient/__tests__/index.spec.ts
+++ b/src/sync/streaming/AuthClient/__tests__/index.spec.ts
@@ -3,7 +3,7 @@ import { splitApiFactory } from '../../../../services/splitApi';
 import { authDataResponseSample, authDataSample, jwtSampleInvalid, jwtSampleNoChannels, jwtSampleNoIat, userKeySample, userKeyBase64HashSample } from '../../__tests__/dataMocks';
 import fetchMock from '../../../../__tests__/testUtils/fetchMock';
 import { settingsSplitApi } from '../../../../utils/settingsValidation/__tests__/settings.mocks';
-import EventEmitter from '../../../../utils/MinEvents';
+import { EventEmitter } from '../../../../utils/MinEvents';
 
 // module to test
 import { authenticateFactory, hashUserKey } from '../index';

--- a/src/sync/streaming/__tests__/pushManager.spec.ts
+++ b/src/sync/streaming/__tests__/pushManager.spec.ts
@@ -1,5 +1,5 @@
 import pushManagerFactory from '../pushManager';
-import EventEmitter from '../../../utils/MinEvents';
+import { EventEmitter } from '../../../utils/MinEvents';
 import { fullSettings } from '../../../utils/settingsValidation/__tests__/settings.mocks';
 import { IPushManagerCS } from '../types';
 

--- a/src/utils/MinEvents.ts
+++ b/src/utils/MinEvents.ts
@@ -30,6 +30,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import { IEventEmitter } from '../types';
+
 var R = typeof Reflect === 'object' ? Reflect : null;
 var ReflectApply = R && typeof R.apply === 'function'
   ? R.apply
@@ -37,9 +39,9 @@ var ReflectApply = R && typeof R.apply === 'function'
     return Function.prototype.apply.call(target, receiver, args);
   };
 
-export default function EventEmitter() {
+export const EventEmitter: { new(): IEventEmitter } = function EventEmitter() {
   EventEmitter.init.call(this);
-}
+};
 
 EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._eventsCount = 0;

--- a/src/utils/MinEvents.ts
+++ b/src/utils/MinEvents.ts
@@ -30,8 +30,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-import { IEventEmitter } from '../types';
-
 var R = typeof Reflect === 'object' ? Reflect : null;
 var ReflectApply = R && typeof R.apply === 'function'
   ? R.apply
@@ -39,14 +37,9 @@ var ReflectApply = R && typeof R.apply === 'function'
     return Function.prototype.apply.call(target, receiver, args);
   };
 
-function EventEmitter() {
+export default function EventEmitter() {
   EventEmitter.init.call(this);
 }
-
-export default EventEmitter as new () => IEventEmitter;
-
-// Backwards-compat with node 0.10.x
-EventEmitter.EventEmitter = EventEmitter;
 
 EventEmitter.prototype._events = undefined;
 EventEmitter.prototype._eventsCount = 0;


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Prevent returning null dynamic config if treatment name contains a "."
- Prevent issue with MinEmitter default export in Webpack

## How do we test the changes introduced in this PR?

- Updated tests in JS Browser SDK

## Extra Notes