### PR TITLE
Redis intransit encryption support 

### DIFF
--- a/src/storages/inRedis/RedisAdapter.ts
+++ b/src/storages/inRedis/RedisAdapter.ts
@@ -164,6 +164,9 @@ export class RedisAdapter extends ioredis {
     } else { // If it IS the string URL, that'll be the first param for ioredis.
       result.unshift(options.url);
     }
+    if (options.tls) {
+      merge(opts, { tls: options.tls });
+    }
 
     return result;
   }
@@ -171,9 +174,9 @@ export class RedisAdapter extends ioredis {
   /**
    * Parses the options into what we care about.
    */
-  static _defineOptions({ connectionTimeout, operationTimeout, url, host, port, db, pass }: Record<string, any>) {
+  static _defineOptions({ connectionTimeout, operationTimeout, url, host, port, db, pass, tls }: Record<string, any>) {
     const parsedOptions = {
-      connectionTimeout, operationTimeout, url, host, port, db, pass
+      connectionTimeout, operationTimeout, url, host, port, db, pass, tls
     };
 
     return merge({}, DEFAULT_OPTIONS, parsedOptions);

--- a/src/storages/inRedis/RedisAdapter.ts
+++ b/src/storages/inRedis/RedisAdapter.ts
@@ -164,6 +164,9 @@ export class RedisAdapter extends ioredis {
     } else { // If it IS the string URL, that'll be the first param for ioredis.
       result.unshift(options.url);
     }
+    if (options.connectionTimeout) {
+      merge(opts, { connectTimeout: options.connectionTimeout });
+    }
     if (options.tls) {
       merge(opts, { tls: options.tls });
     }

--- a/src/storages/inRedis/__tests__/RedisAdapter.spec.ts
+++ b/src/storages/inRedis/__tests__/RedisAdapter.spec.ts
@@ -93,33 +93,36 @@ describe('STORAGE Redis Adapter', () => {
     new RedisAdapter(loggerMock, {
       url: redisUrl,
       connectionTimeout: 123,
-      operationTimeout: 124
+      operationTimeout: 124,
+      tls: { ca: 'ca' }
     });
     // Keep in mind we're storing the arguments object, not a true array.
     expect(constructorParams.length).toBe(2); // In this signature, the constructor receives two params.
     expect(constructorParams[0]).toBe(redisUrl); // When we use the Redis URL, that should be the first parameter passed to ioredis constructor
-    expect(constructorParams[1]).toEqual({ enableOfflineQueue: false, connectTimeout: 10000, lazyConnect: false }); // and the second parameter would be the default settings for the lib.
+    expect(constructorParams[1]).toEqual({ enableOfflineQueue: false, connectTimeout: 123, lazyConnect: false, tls: { ca: 'ca' } }); // and the second parameter would be the default settings for the lib.
 
     new RedisAdapter(loggerMock, {
       ...redisParams,
       connectionTimeout: 123,
-      operationTimeout: 124
+      operationTimeout: 124,
+      tls: { ca: 'ca' }
     });
 
     expect(constructorParams.length).toBe(1); // In this signature, the constructor receives one param.
     // we keep "pass" instead of "password" on our settings API to be backwards compatible.
-    expect(constructorParams[0]).toEqual({ host: redisParams.host, port: redisParams.port, db: redisParams.db, password: redisParams.pass, enableOfflineQueue: false, connectTimeout: 10000, lazyConnect: false }); // If we send all the redis params separate, it will pass one object to the library containing that and the rest of the options.
+    expect(constructorParams[0]).toEqual({ host: redisParams.host, port: redisParams.port, db: redisParams.db, password: redisParams.pass, enableOfflineQueue: false, connectTimeout: 123, lazyConnect: false, tls: { ca: 'ca' } }); // If we send all the redis params separate, it will pass one object to the library containing that and the rest of the options.
 
     new RedisAdapter(loggerMock, {
       ...redisParams,
       url: redisUrl,
-      connectionTimeout: 123,
-      operationTimeout: 124
+      // Using default connectionTimeout
+      operationTimeout: 124,
+      tls: { ca: 'ca' }
     });
 
     expect(constructorParams.length).toBe(2); // In this signature, the constructor receives two params.
     expect(constructorParams[0]).toBe(redisUrl); // When we use the Redis URL, even if we specified all the other params one by one the URL takes precedence, so that should be the first parameter passed to ioredis constructor
-    expect(constructorParams[1]).toEqual({ enableOfflineQueue: false, connectTimeout: 10000, lazyConnect: false }); // and the second parameter would be the default settings for the lib.
+    expect(constructorParams[1]).toEqual({ enableOfflineQueue: false, connectTimeout: 10000, lazyConnect: false, tls: { ca: 'ca' } }); // and the second parameter would be the default settings for the lib.
   });
 
   test('static method - _defineOptions', () => {


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added `tls` support, by forwarding `tls` option to ioredis.
- Fixed issue with `connectionTimeout`, by forwarding `connectionTimeout` option to `connectTimeout` ioredis option.

## How do we test the changes introduced in this PR?

- Updated unit tests

## Extra Notes