### PR TITLE
Validate and sanitize key and trafficType in settings [WIP]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.2.1-rc.8",
+  "version": "1.2.1-rc.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4984,9 +4984,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.2.1-rc.8",
+  "version": "1.2.1-rc.9",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/sdkClient/__tests__/sdkClientMethodCS.spec.ts
+++ b/src/sdkClient/__tests__/sdkClientMethodCS.spec.ts
@@ -220,31 +220,6 @@ describe('sdkClientMethodCSFactory', () => {
     if (!ignoresTT) expect(() => sdkClientMethod('valid-key', ['invalid-TT'])).toThrow('Shared Client needs a valid traffic type or no traffic type at all.');
   });
 
-  test.each(testTargets)('invalid key/TT binds a false key/TT in the default client', (sdkClientMethodCSFactory, ignoresTT) => {
-    const paramsWithInvalidKeyAndTT = {
-      ...params,
-      settings: {
-        ...params.settings,
-        core: {
-          key: true, // invalid key
-          trafficType: '' // invalid TT
-        }
-      }
-    };
-
-    (clientCSDecoratorSpy as jest.Mock).mockClear();
-    // @ts-expect-error
-    const sdkClientMethod = sdkClientMethodCSFactory(paramsWithInvalidKeyAndTT);
-
-    // calling the function should return a client instance
-    const client = sdkClientMethod();
-    assertClientApi(client, params.sdkReadinessManager.sdkStatus);
-
-    // but with false as binded key and TT
-    if (ignoresTT) expect(clientCSDecoratorSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), false);
-    else expect(clientCSDecoratorSpy).toHaveBeenCalledWith(expect.anything(), expect.anything(), false, false);
-  });
-
   test.each(testTargets)('attributes binding - main client', (sdkClientMethodCSFactory) => {
     // @ts-expect-error
     const sdkClientMethod = sdkClientMethodCSFactory(params);

--- a/src/sdkClient/sdkClientMethodCS.ts
+++ b/src/sdkClient/sdkClientMethodCS.ts
@@ -23,15 +23,10 @@ const method = 'Client instantiation';
 export function sdkClientMethodCSFactory(params: ISdkClientFactoryParams): (key?: SplitIO.SplitKey) => SplitIO.ICsClient {
   const { storage, syncManager, sdkReadinessManager, settings: { core: { key }, startup: { readyTimeout }, log } } = params;
 
-  // Keeping similar behaviour as in the isomorphic JS SDK: if settings key is invalid,
-  // `false` value is used as binded key of the default client, but trafficType is ignored
-  // @TODO handle as a non-recoverable error
-  const validKey = validateKey(log, key, method);
-
   const mainClientInstance = clientCSDecorator(
     log,
     sdkClientFactory(params) as SplitIO.IClient, // @ts-ignore
-    validKey
+    key
   );
 
   const parsedDefaultKey = keyParser(key);

--- a/src/sdkClient/sdkClientMethodCSWithTT.ts
+++ b/src/sdkClient/sdkClientMethodCSWithTT.ts
@@ -25,20 +25,11 @@ const method = 'Client instantiation';
 export function sdkClientMethodCSFactory(params: ISdkClientFactoryParams): (key?: SplitIO.SplitKey, trafficType?: string) => SplitIO.ICsClient {
   const { storage, syncManager, sdkReadinessManager, settings: { core: { key, trafficType }, startup: { readyTimeout }, log } } = params;
 
-  // Keeping the behaviour as in the isomorphic JS SDK: if settings key or TT are invalid,
-  // `false` value is used as binded key/TT of the default client, which leads to several issues.
-  // @TODO update when supporting non-recoverable errors
-  const validKey = validateKey(log, key, method);
-  let validTrafficType;
-  if (trafficType !== undefined) {
-    validTrafficType = validateTrafficType(log, trafficType, method);
-  }
-
   const mainClientInstance = clientCSDecorator(
     log,
     sdkClientFactory(params) as SplitIO.IClient, // @ts-ignore
-    validKey,
-    validTrafficType
+    key,
+    trafficType
   );
 
   const parsedDefaultKey = keyParser(key);

--- a/src/utils/settingsValidation/__tests__/index.spec.ts
+++ b/src/utils/settingsValidation/__tests__/index.spec.ts
@@ -189,6 +189,43 @@ describe('settingsValidation', () => {
     expect(settings.integrations).toBe(integrationsValidatorResult);
     expect(integrationsValidatorMock).toBeCalledWith(settings);
   });
+
+  test('validates and sanitizes key and traffic type in client-side', () => {
+    const clientSideValidationParams = { ...minimalSettingsParams, isClientSide: true };
+
+    const samples = [{
+      key: '  valid-key  ', settingsKey: 'valid-key', // key string is trimmed
+      trafficType: 'VALID-TT', settingsTrafficType: 'valid-tt', // TT is converted to lowercase
+    }, {
+      key: undefined, settingsKey: false, // undefined key is not valid in client-side
+      trafficType: undefined, settingsTrafficType: undefined,
+    }, {
+      key: null, settingsKey: false,
+      trafficType: null, settingsTrafficType: false,
+    }, {
+      key: true, settingsKey: false,
+      trafficType: true, settingsTrafficType: false,
+    }, {
+      key: 1.5, settingsKey: '1.5', // finite number as key is parsed
+      trafficType: 100, settingsTrafficType: false,
+    }, {
+      key: { matchingKey: 100, bucketingKey: ' BUCK ' }, settingsKey: { matchingKey: '100', bucketingKey: 'BUCK' },
+      trafficType: {}, settingsTrafficType: false,
+    }];
+
+    samples.forEach(({ key, trafficType, settingsKey, settingsTrafficType }) => {
+      const settings = settingsValidation({
+        core: {
+          authorizationKey: 'dummy token',
+          key,
+          trafficType
+        }
+      }, clientSideValidationParams);
+
+      expect(settings.core.key).toEqual(settingsKey);
+      expect(settings.core.trafficType).toEqual(settingsTrafficType);
+    });
+  });
 });
 
 test('SETTINGS / urls should be correctly assigned', () => {

--- a/src/utils/settingsValidation/types.ts
+++ b/src/utils/settingsValidation/types.ts
@@ -10,7 +10,9 @@ export interface ISettingsValidationParams {
    * Version and startup properties are required, because they are not defined in the base settings.
    */
   defaults: Partial<ISettings> & { version: string } & { startup: ISettings['startup'] },
-  /** Function to define runtime values (`settings.runtime`) */
+  /** If true, validates core.key and core.trafficType */
+  isClientSide?: boolean,
+  /** Define runtime values (`settings.runtime`) */
   runtime: (settings: ISettings) => ISettings['runtime'],
   /** Storage validator (`settings.storage`) */
   storage?: (settings: ISettings) => ISettings['storage'],


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Validate and sanitize config key and TT in settings, to avoid issues with internal modules that need to read the key/TT
- Fixed a dependency vulnerability

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes