### PR TITLE
Update dependencies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-1.3.1 (TBD)
+1.3.1 (April 19, 2022)
+ - Bugfixing - Added peer dependencies to avoid issues when requiring some third-party dependencies used by modules of the package (Related to issue https://github.com/splitio/javascript-client/issues/662).
  - Bugfixing - Updated `ready` method to rejects the promise with an Error object instead of a string value (Related to issue https://github.com/splitio/javascript-client/issues/654).
 
 1.3.0 (April 6, 2022)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.3.1-rc.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.3.0",
+  "version": "1.3.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.3.0",
+  "version": "1.3.1-rc.0",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -46,6 +46,18 @@
   "dependencies": {
     "tslib": "^2.3.1"
   },
+  "peerDependencies": {
+    "js-yaml": "^3.13.1",
+    "ioredis": "^4.28.0"
+  },
+  "peerDependenciesMeta": {
+    "js-yaml": {
+      "optional": true
+    },
+    "ioredis": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/google.analytics": "0.0.40",
     "@types/ioredis": "^4.28.0",
@@ -62,7 +74,7 @@
     "ioredis": "^4.28.0",
     "jest": "^27.2.3",
     "jest-localstorage-mock": "^2.4.3",
-    "js-yaml": "^3.14.0",
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "redis-server": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.3.1-rc.0",
+  "version": "1.3.1",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added `js-yaml` and `ioredis` as peerDependencies, since they are only required by JS SDK for Nodejs (Redis storage and localhost mode based on Yaml files).

## How do we test the changes introduced in this PR?

## Extra Notes

Related to https://github.com/splitio/javascript-client/issues/662