### PR TITLE
Telemetry track evaluation stats

### DIFF
--- a/src/__tests__/testUtils/index.ts
+++ b/src/__tests__/testUtils/index.ts
@@ -1,0 +1,14 @@
+const DEFAULT_ERROR_MARGIN = 50; // 0.05 secs if numbers are timestamps in milliseconds
+
+/**
+ * Assert if an `actual` and `expected` numeric values are nearly equal.
+ *
+ * @param {number} actual actual time lapse in millis
+ * @param {number} expected expected time lapse in millis
+ * @param {number} epsilon error margin in millis
+ * @returns {boolean} whether the absolute difference is minor to epsilon value or not
+ */
+export function nearlyEqual(actual: number, expected: number, epsilon = DEFAULT_ERROR_MARGIN) {
+  const diff = Math.abs(actual - expected);
+  return diff <= epsilon;
+}

--- a/src/sdkClient/client.ts
+++ b/src/sdkClient/client.ts
@@ -4,7 +4,7 @@ import { getMatching, getBucketing } from '../utils/key';
 import { validateSplitExistance } from '../utils/inputValidation/splitExistance';
 import { validateTrafficTypeExistance } from '../utils/inputValidation/trafficTypeExistance';
 import { SDK_NOT_READY } from '../utils/labels';
-import { CONTROL } from '../utils/constants';
+import { CONTROL, TREATMENT, TREATMENTS, TREATMENT_WITH_CONFIG, TREATMENTS_WITH_CONFIG, TRACK } from '../utils/constants';
 import { IEvaluationResult } from '../evaluator/types';
 import { SplitIO, ImpressionDTO } from '../types';
 import { IMPRESSION, IMPRESSION_QUEUEING } from '../logger/constants';
@@ -19,7 +19,7 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
   const { log, mode } = settings;
 
   function getTreatment(key: SplitIO.SplitKey, splitName: string, attributes: SplitIO.Attributes | undefined, withConfig = false) {
-    const stopTelemetryTracker = telemetryTracker.start(withConfig ? 'tc' : 't');
+    const stopTelemetryTracker = telemetryTracker.trackEval(withConfig ? TREATMENT_WITH_CONFIG : TREATMENT);
 
     const wrapUp = (evaluationResult: IEvaluationResult) => {
       const queue: ImpressionDTO[] = [];
@@ -40,7 +40,7 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
   }
 
   function getTreatments(key: SplitIO.SplitKey, splitNames: string[], attributes: SplitIO.Attributes | undefined, withConfig = false) {
-    const stopTelemetryTracker = telemetryTracker.start(withConfig ? 'tcs' : 'ts');
+    const stopTelemetryTracker = telemetryTracker.trackEval(withConfig ? TREATMENTS_WITH_CONFIG : TREATMENTS);
 
     const wrapUp = (evaluationResults: Record<string, IEvaluationResult>) => {
       const queue: ImpressionDTO[] = [];
@@ -109,7 +109,7 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
   }
 
   function track(key: SplitIO.SplitKey, trafficTypeName: string, eventTypeId: string, value?: number, properties?: SplitIO.Properties, size = 1024) {
-    const stopTelemetryTracker = telemetryTracker.start('tr');
+    const stopTelemetryTracker = telemetryTracker.trackEval(TRACK);
 
     const matchingKey = getMatching(key);
     const timestamp = Date.now();

--- a/src/sdkClient/client.ts
+++ b/src/sdkClient/client.ts
@@ -125,8 +125,17 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
     // This may be async but we only warn, we don't actually care if it is valid or not in terms of queueing the event.
     validateTrafficTypeExistance(log, readinessManager, storage.splits, mode, trafficTypeName, 'track');
 
-    stopTelemetryTracker();
-    return eventTracker.track(eventData, size);
+    const result = eventTracker.track(eventData, size);
+
+    if (thenable(result)) {
+      return result.then((result) => {
+        stopTelemetryTracker();
+        return result;
+      });
+    } else {
+      stopTelemetryTracker();
+      return result;
+    }
   }
 
   return {

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -6,7 +6,7 @@ import { IFetch, ISplitApi, IEventSourceConstructor } from '../services/types';
 import { IStorageAsync, IStorageSync, ISplitsCacheSync, ISplitsCacheAsync, IStorageFactoryParams } from '../storages/types';
 import { ISyncManager, ISyncManagerFactoryParams } from '../sync/types';
 import { IImpressionObserver } from '../trackers/impressionObserver/types';
-import { IImpressionsTracker, IEventTracker } from '../trackers/types';
+import { IImpressionsTracker, IEventTracker, ITelemetryTracker } from '../trackers/types';
 import { SplitIO, ISettings, IEventEmitter } from '../types';
 
 export interface ISdkFactoryContext {
@@ -15,6 +15,7 @@ export interface ISdkFactoryContext {
   settings: ISettings
   impressionsTracker: IImpressionsTracker,
   eventTracker: IEventTracker,
+  telemetryTracker: ITelemetryTracker
   signalListener?: ISignalListener
   syncManager?: ISyncManager,
 }
@@ -27,7 +28,8 @@ export interface IPlatform {
   getOptions?: () => object
   getFetch?: () => (IFetch | undefined)
   getEventSource?: () => (IEventSourceConstructor | undefined)
-  EventEmitter: new () => IEventEmitter
+  EventEmitter: new () => IEventEmitter,
+  now?: () => number
 }
 
 /**

--- a/src/trackers/__tests__/telemetryTracker.spec.ts
+++ b/src/trackers/__tests__/telemetryTracker.spec.ts
@@ -1,0 +1,43 @@
+import { EXCEPTION, SDK_NOT_READY } from '../../utils/labels';
+import { telemetryTrackerFactory } from '../telemetryTracker';
+
+test('Telemetry Tracker', async () => {
+
+  const fakeNow = jest.fn(() => { return Date.now(); });
+  const fakeTelemetryCache = {
+    recordLatency: jest.fn(),
+    recordException: jest.fn(),
+    recordNonReadyUsage: jest.fn()
+  };
+
+  const tracker = telemetryTrackerFactory(fakeTelemetryCache, fakeNow);
+
+  let stopTracker = tracker.start('t');
+  stopTracker();
+
+  stopTracker = tracker.start('ts');
+  stopTracker(EXCEPTION);
+
+  stopTracker = tracker.start('tc');
+  stopTracker(SDK_NOT_READY);
+
+  stopTracker = tracker.start('tcs');
+
+  await new Promise(res => setTimeout(res, 200));
+  stopTracker();
+
+  expect(fakeTelemetryCache.recordException).toBeCalledTimes(1);
+  expect(fakeTelemetryCache.recordNonReadyUsage).toBeCalledTimes(1);
+  expect(fakeTelemetryCache.recordLatency).toBeCalledTimes(4);
+
+  const latency = fakeTelemetryCache.recordLatency.mock.calls[3][1];
+  expect(latency > 200 && latency < 250).toBeTruthy(); // last tracked latency is around 200 ms
+});
+
+test('Telemetry Tracker no-op', () => {
+  // The instance must implement the TelemetryTracker API even if no cache is provided
+  const tracker = telemetryTrackerFactory();
+
+  const stopTracker = tracker.start('tr');
+  expect(stopTracker()).toBe(undefined);
+});

--- a/src/trackers/__tests__/telemetryTracker.spec.ts
+++ b/src/trackers/__tests__/telemetryTracker.spec.ts
@@ -1,4 +1,5 @@
 import { EXCEPTION, SDK_NOT_READY } from '../../utils/labels';
+import { nearlyEqual } from '../../__tests__/testUtils';
 import { telemetryTrackerFactory } from '../telemetryTracker';
 
 describe('Telemetry Tracker', () => {
@@ -9,7 +10,7 @@ describe('Telemetry Tracker', () => {
     recordException: jest.fn(),
     recordNonReadyUsage: jest.fn(),
   };
-  // @ts-ignore
+
   const tracker = telemetryTrackerFactory(fakeTelemetryCache, fakeNow);
 
   test('trackEval', async () => {
@@ -25,7 +26,7 @@ describe('Telemetry Tracker', () => {
 
     stopTracker = tracker.trackEval('tcs');
 
-    await new Promise(res => setTimeout(res, 50));
+    await new Promise(res => setTimeout(res, 100));
     stopTracker();
 
     expect(fakeTelemetryCache.recordException).toBeCalledTimes(1);
@@ -33,7 +34,7 @@ describe('Telemetry Tracker', () => {
     expect(fakeTelemetryCache.recordLatency).toBeCalledTimes(3);
 
     const latency = fakeTelemetryCache.recordLatency.mock.calls[2][1];
-    expect(latency >= 50 && latency < 100).toBeTruthy(); // last tracked latency is around 200 ms
+    expect(nearlyEqual(latency, 100)).toBeTruthy(); // last tracked latency is around 100 ms
   });
 
 });

--- a/src/trackers/__tests__/telemetryTracker.spec.ts
+++ b/src/trackers/__tests__/telemetryTracker.spec.ts
@@ -30,9 +30,9 @@ describe('Telemetry Tracker', () => {
 
     expect(fakeTelemetryCache.recordException).toBeCalledTimes(1);
     expect(fakeTelemetryCache.recordNonReadyUsage).toBeCalledTimes(1);
-    expect(fakeTelemetryCache.recordLatency).toBeCalledTimes(4);
+    expect(fakeTelemetryCache.recordLatency).toBeCalledTimes(3);
 
-    const latency = fakeTelemetryCache.recordLatency.mock.calls[3][1];
+    const latency = fakeTelemetryCache.recordLatency.mock.calls[2][1];
     expect(latency >= 50 && latency < 100).toBeTruthy(); // last tracked latency is around 200 ms
   });
 

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -1,11 +1,11 @@
-import { TelemetryCacheAsync, TelemetryCacheSync } from '../storages/types';
+import { TelemetryCacheSync, TelemetryCacheAsync } from '../storages/types';
 import { Method } from '../sync/submitters/types';
 import { EXCEPTION, SDK_NOT_READY } from '../utils/labels';
 import { ITelemetryTracker } from './types';
 import { timer } from '../utils/timeTracker/timer';
 
 export function telemetryTrackerFactory(
-  telemetryCache?: TelemetryCacheAsync | TelemetryCacheSync,
+  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync,
   now?: () => number
 ): ITelemetryTracker {
 
@@ -28,11 +28,10 @@ export function telemetryTrackerFactory(
       }
     };
 
-  } else { // If there is not `telemetryCache` or `now` time tracker, return a mock telemetry tracker
+  } else { // If there is not `telemetryCache` or `now` time tracker, return a no-op telemetry tracker
+    const noopTrack = () => () => { };
     return {
-      trackEval() {
-        return () => { };
-      }
+      trackEval: noopTrack
     };
   }
 }

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -13,17 +13,17 @@ export function telemetryTrackerFactory(
 
     return {
       trackEval(method: Method) {
-        const timeTracker = timer(now);
+        const stopTimer = timer(now);
 
         return (label?: string) => {
-          telemetryCache.recordLatency(method, timeTracker());
-
           switch (label) {
             case EXCEPTION:
-              telemetryCache.recordException(method); break;
+              telemetryCache.recordException(method);
+              return; // Don't track latency on exceptions
             case SDK_NOT_READY: // @ts-ignore. TelemetryCacheAsync doesn't implement the method
               telemetryCache?.recordNonReadyUsage();
           }
+          telemetryCache.recordLatency(method, stopTimer());
         };
       }
     };

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -1,5 +1,4 @@
 import { TelemetryCacheSync, TelemetryCacheAsync } from '../storages/types';
-import { Method } from '../sync/submitters/types';
 import { EXCEPTION, SDK_NOT_READY } from '../utils/labels';
 import { ITelemetryTracker } from './types';
 import { timer } from '../utils/timeTracker/timer';
@@ -12,10 +11,10 @@ export function telemetryTrackerFactory(
   if (telemetryCache && now) {
 
     return {
-      trackEval(method: Method) {
-        const stopTimer = timer(now);
+      trackEval(method) {
+        const evalTime = timer(now);
 
-        return (label?: string) => {
+        return (label) => {
           switch (label) {
             case EXCEPTION:
               telemetryCache.recordException(method);
@@ -23,15 +22,15 @@ export function telemetryTrackerFactory(
             case SDK_NOT_READY: // @ts-ignore. TelemetryCacheAsync doesn't implement the method
               telemetryCache?.recordNonReadyUsage();
           }
-          telemetryCache.recordLatency(method, stopTimer());
+          telemetryCache.recordLatency(method, evalTime());
         };
-      }
+      },
     };
 
   } else { // If there is not `telemetryCache` or `now` time tracker, return a no-op telemetry tracker
     const noopTrack = () => () => { };
     return {
-      trackEval: noopTrack
+      trackEval: noopTrack,
     };
   }
 }

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -1,0 +1,38 @@
+import { TelemetryCacheAsync, TelemetryCacheSync } from '../storages/types';
+import { Method } from '../sync/submitters/types';
+import { EXCEPTION, SDK_NOT_READY } from '../utils/labels';
+import { ITelemetryTracker } from './types';
+import { timer } from '../utils/timeTracker/timer';
+
+export function telemetryTrackerFactory(
+  telemetryCache?: TelemetryCacheAsync | TelemetryCacheSync,
+  now?: () => number
+): ITelemetryTracker {
+
+  if (telemetryCache && now) {
+
+    return {
+      start(method: Method) {
+        const timeTracker = timer(now);
+
+        return (label?: string) => {
+          telemetryCache.recordLatency(method, timeTracker());
+
+          switch (label) {
+            case EXCEPTION:
+              telemetryCache.recordException(method); break;
+            case SDK_NOT_READY: // @ts-ignore. TelemetryCacheAsync doesn't implement the method
+              telemetryCache?.recordNonReadyUsage();
+          }
+        };
+      }
+    };
+
+  } else { // If there is not `telemetryCache` or `now` time tracker, return a mock telemetry tracker
+    return {
+      start() {
+        return () => { };
+      }
+    };
+  }
+}

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -12,7 +12,7 @@ export function telemetryTrackerFactory(
   if (telemetryCache && now) {
 
     return {
-      start(method: Method) {
+      trackEval(method: Method) {
         const timeTracker = timer(now);
 
         return (label?: string) => {
@@ -30,7 +30,7 @@ export function telemetryTrackerFactory(
 
   } else { // If there is not `telemetryCache` or `now` time tracker, return a mock telemetry tracker
     return {
-      start() {
+      trackEval() {
         return () => { };
       }
     };

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -1,4 +1,5 @@
 import { SplitIO, ImpressionDTO } from '../types';
+import { Method } from '../sync/submitters/types';
 import { IEventsCacheBase } from '../storages/types';
 
 /** Events tracker */
@@ -17,4 +18,13 @@ export interface IImpressionsHandler {
 
 export interface IImpressionsTracker {
   track(impressions: ImpressionDTO[], attributes?: SplitIO.Attributes): void
+}
+
+/** Telemetry tracker */
+
+export interface ITelemetryTracker {
+  /**
+   * Creates a telemetry evaluator tracker, to record Latencies, Exceptions and NonReadyUsage of client operations (getTreatments and track method calls)
+   */
+  start(method: Method): (label?: string) => void
 }

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -26,5 +26,5 @@ export interface ITelemetryTracker {
   /**
    * Creates a telemetry evaluator tracker, to record Latencies, Exceptions and NonReadyUsage of client operations (getTreatments and track method calls)
    */
-  start(method: Method): (label?: string) => void
+  trackEval(method: Method): (label?: string) => void
 }

--- a/src/utils/timeTracker/__tests__/index.spec.ts
+++ b/src/utils/timeTracker/__tests__/index.spec.ts
@@ -5,7 +5,7 @@ import { IResponse } from '../../../services/types';
 
 test('TIMER / should count the time between two tasks', (done) => {
   const timerDuration = Math.floor(Math.random() * 1000); // In millis
-  const stopTimer = timer();
+  const stopTimer = timer(Date.now);
 
   setTimeout(() => {
     const elapsedTime = stopTimer();

--- a/src/utils/timeTracker/index.ts
+++ b/src/utils/timeTracker/index.ts
@@ -148,7 +148,7 @@ export const TrackerAPI = {
    * @param {Promise} promise - (optional) The promise we are tracking.
    * @return {Function | Promise} The stop function for this specific task or the promise received with the callbacks registered.
    */
-  start(log: ILogger, task: string, collectors?: Record<string, MetricsCollector>, promise?: Promise<IResponse>, now?: () => number): Promise<IResponse> | (() => number) {
+  start(log: ILogger, task: string, collectors?: Record<string, MetricsCollector>, promise?: Promise<IResponse>, now: () => number = Date.now): Promise<IResponse> | (() => number) {
     const taskUniqueId = uniqueId();
     const taskCollector = getCollectorForTask(task, collectors);
     let result;

--- a/src/utils/timeTracker/timer.ts
+++ b/src/utils/timeTracker/timer.ts
@@ -1,7 +1,7 @@
-export function timer(now?: () => number) {
-  const st = now ? now() : Date.now();
+export function timer(now: () => number) {
+  const st = now();
 
   return function stop() {
-    return Math.round(now ? now() : Date.now() - st);
+    return Math.round(now() - st);
   };
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added `telemetryTracker`. Similar to the events and impressions trackers, it simplify the usage of the producer methods of the telemetry cache to record latency and exceptions of client methods.
- Updated client to track evaluation telemetry using the `telemetryTracker`.
- Updated timers utils for performance.

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes

Open question: should we stop the latency tracker when cache `track` promise is settled?