### PR TITLE
Telemetry track runtime stats: trackers, streaming and session length

### DIFF
--- a/src/__tests__/testUtils/index.ts
+++ b/src/__tests__/testUtils/index.ts
@@ -1,0 +1,14 @@
+const DEFAULT_ERROR_MARGIN = 50; // 0.05 secs if numbers are timestamps in milliseconds
+
+/**
+ * Assert if an `actual` and `expected` numeric values are nearly equal.
+ *
+ * @param {number} actual actual time lapse in millis
+ * @param {number} expected expected time lapse in millis
+ * @param {number} epsilon error margin in millis
+ * @returns {boolean} whether the absolute difference is minor to epsilon value or not
+ */
+export function nearlyEqual(actual: number, expected: number, epsilon = DEFAULT_ERROR_MARGIN) {
+  const diff = Math.abs(actual - expected);
+  return diff <= epsilon;
+}

--- a/src/sdkClient/__tests__/sdkClientMethod.spec.ts
+++ b/src/sdkClient/__tests__/sdkClientMethod.spec.ts
@@ -2,6 +2,7 @@ import { loggerMock } from '../../logger/__tests__/sdkLogger.mock';
 import { CONSUMER_MODE, STANDALONE_MODE } from '../../utils/constants';
 import { sdkClientMethodFactory } from '../sdkClientMethod';
 import { assertClientApi } from './testUtils';
+import { telemetryTrackerFactory } from '../../trackers/telemetryTracker';
 
 const errorMessage = 'Shared Client not supported by the storage mechanism. Create isolated instances instead.';
 
@@ -12,7 +13,8 @@ const paramMocks = [
     syncManager: undefined,
     sdkReadinessManager: { sdkStatus: jest.fn(), readinessManager: { destroy: jest.fn() } },
     signalListener: undefined,
-    settings: { mode: CONSUMER_MODE, log: loggerMock, core: { authorizationKey: 'api key '} }
+    settings: { mode: CONSUMER_MODE, log: loggerMock, core: { authorizationKey: 'api key '} },
+    telemetryTracker: telemetryTrackerFactory()
   },
   // SyncManager (i.e., Sync SDK) and Signal listener
   {
@@ -20,7 +22,8 @@ const paramMocks = [
     syncManager: { stop: jest.fn(), flush: jest.fn(() => Promise.resolve()) },
     sdkReadinessManager: { sdkStatus: jest.fn(), readinessManager: { destroy: jest.fn() } },
     signalListener: { stop: jest.fn() },
-    settings: { mode: STANDALONE_MODE, log: loggerMock, core: { authorizationKey: 'api key '} }
+    settings: { mode: STANDALONE_MODE, log: loggerMock, core: { authorizationKey: 'api key '} },
+    telemetryTracker: telemetryTrackerFactory()
   }
 ];
 

--- a/src/sdkClient/__tests__/sdkClientMethodCS.spec.ts
+++ b/src/sdkClient/__tests__/sdkClientMethodCS.spec.ts
@@ -1,7 +1,7 @@
 import { sdkClientMethodCSFactory as sdkClientMethodCSWithTTFactory } from '../sdkClientMethodCSWithTT';
 import { sdkClientMethodCSFactory } from '../sdkClientMethodCS';
 import { assertClientApi } from './testUtils';
-
+import { telemetryTrackerFactory } from '../../trackers/telemetryTracker';
 import { settingsWithKey, settingsWithKeyAndTT, settingsWithKeyObject } from '../../utils/settingsValidation/__tests__/settings.mocks';
 
 const partialStorages: { destroy: jest.Mock }[] = [];
@@ -44,7 +44,8 @@ const params = {
   sdkReadinessManager: sdkReadinessManagerMock,
   syncManager: syncManagerMock,
   signalListener: { stop: jest.fn() },
-  settings: settingsWithKey
+  settings: settingsWithKey,
+  telemetryTracker: telemetryTrackerFactory()
 };
 
 const invalidAttributes = [

--- a/src/sdkClient/sdkClient.ts
+++ b/src/sdkClient/sdkClient.ts
@@ -26,7 +26,7 @@ export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: bo
     {
       destroy() {
         // record stat before flushing data
-        if (!isSharedClient) params.telemetryTracker.trackSessionLength();
+        if (!isSharedClient) params.telemetryTracker.sessionLength();
 
         // Stop background jobs
         syncManager && syncManager.stop();

--- a/src/sdkClient/sdkClient.ts
+++ b/src/sdkClient/sdkClient.ts
@@ -25,6 +25,9 @@ export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: bo
     // Sdk destroy
     {
       destroy() {
+        // record stat before flushing data
+        if (!isSharedClient) params.telemetryTracker.trackSessionLength();
+
         // Stop background jobs
         syncManager && syncManager.stop();
         const flush = syncManager ? syncManager.flush() : Promise.resolve();

--- a/src/sdkClient/sdkClient.ts
+++ b/src/sdkClient/sdkClient.ts
@@ -9,7 +9,7 @@ import { ISdkFactoryContext } from '../sdkFactory/types';
  * Creates an Sdk client, i.e., a base client with status and destroy interface
  */
 export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: boolean): SplitIO.IClient | SplitIO.IAsyncClient {
-  const { sdkReadinessManager, syncManager, storage, signalListener, settings } = params;
+  const { sdkReadinessManager, syncManager, storage, signalListener, settings, telemetryTracker } = params;
 
   return objectAssign(
     // Proto-linkage of the readiness Event Emitter
@@ -26,7 +26,7 @@ export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: bo
     {
       destroy() {
         // record stat before flushing data
-        if (!isSharedClient) params.telemetryTracker.sessionLength();
+        if (!isSharedClient) telemetryTracker.sessionLength();
 
         // Stop background jobs
         syncManager && syncManager.stop();

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -61,6 +61,14 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   const storage = storageFactory(storageFactoryParams);
   // @TODO add support for dataloader: `if (params.dataLoader) params.dataLoader(storage);`
 
+  const integrationsManager = integrationsManagerFactory && integrationsManagerFactory({ settings, storage });
+
+  // trackers
+  const observer = impressionsObserverFactory && impressionsObserverFactory();
+  const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, integrationsManager, observer, storage.impressionCounts, storage.telemetry);
+  const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager, storage.telemetry);
+  const telemetryTracker = telemetryTrackerFactory(storage.telemetry, platform.now);
+
   // splitApi is used by SyncManager and Browser signal listener
   const splitApi = splitApiFactory && splitApiFactory(settings, platform);
 
@@ -69,16 +77,9 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
     splitApi: splitApi as ISplitApi,
     storage: storage as IStorageSync,
     readiness: sdkReadinessManager.readinessManager,
-    platform
+    platform,
+    telemetryTracker
   });
-
-  const integrationsManager = integrationsManagerFactory && integrationsManagerFactory({ settings, storage });
-
-  // trackers
-  const observer = impressionsObserverFactory && impressionsObserverFactory();
-  const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, integrationsManager, observer, storage.impressionCounts, storage.telemetry);
-  const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager, storage.telemetry);
-  const telemetryTracker = telemetryTrackerFactory(storage.telemetry, platform.now);
 
   // signal listener
   const signalListener = SignalListener && new SignalListener(syncManager, settings, storage, splitApi);

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -76,8 +76,8 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
 
   // trackers
   const observer = impressionsObserverFactory && impressionsObserverFactory();
-  const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, integrationsManager, observer, storage.impressionCounts);
-  const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager);
+  const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, integrationsManager, observer, storage.impressionCounts, storage.telemetry);
+  const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager, storage.telemetry);
   const telemetryTracker = telemetryTrackerFactory(storage.telemetry, platform.now);
 
   // signal listener

--- a/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
+++ b/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
@@ -34,12 +34,14 @@ const controlStreamingDisabledSec = { ...controlStreamingDisabled, data: control
 
 // streaming reset message, from `{orgHash}_{envHash}_control` channel
 import streamingReset from '../../../../__tests__/mocks/message.STREAMING_RESET.json';
+import { ABLY_ERROR, NON_REQUESTED, SSE_CONNECTION_ERROR } from '../../../../utils/constants';
 
 const pushEmitter = { emit: jest.fn() };
+const telemetryTracker = { streamingEvent: jest.fn() };
 
 test('`handleOpen` and `handlerMessage` for OCCUPANCY notifications (NotificationKeeper)', () => {
   pushEmitter.emit.mockClear();
-  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
 
   // handleOpen
 
@@ -86,7 +88,7 @@ test('`handleOpen` and `handlerMessage` for OCCUPANCY notifications (Notificatio
 
 test('`handlerMessage` for CONTROL notifications (NotificationKeeper)', () => {
   pushEmitter.emit.mockClear();
-  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
   sseHandler.handleOpen();
 
   // CONTROL messages
@@ -119,7 +121,7 @@ test('`handlerMessage` for CONTROL notifications (NotificationKeeper)', () => {
   sseHandler.handleMessage(controlStreamingDisabledSec); // testing STREAMING_DISABLED with second region
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_NONRETRYABLE_ERROR); // must emit PUSH_NONRETRYABLE_ERROR if received a STREAMING_DISABLED control message
 
-  const sseHandler2 = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler2 = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
   sseHandler2.handleOpen();
 
   sseHandler2.handleMessage(controlStreamingPausedSec); // testing STREAMING_PAUSED with second region
@@ -131,7 +133,7 @@ test('`handlerMessage` for CONTROL notifications (NotificationKeeper)', () => {
 });
 
 test('`handlerMessage` for update notifications (NotificationProcessor) and streaming reset', () => {
-  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
   sseHandler.handleOpen();
   pushEmitter.emit.mockClear();
 
@@ -173,38 +175,44 @@ test('`handlerMessage` for update notifications (NotificationProcessor) and stre
 });
 
 test('handleError', () => {
-  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
   sseHandler.handleOpen();
   pushEmitter.emit.mockClear();
 
   const error = 'some error';
   sseHandler.handleError(error);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_RETRYABLE_ERROR); // A network error must emit PUSH_RETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(SSE_CONNECTION_ERROR, NON_REQUESTED);
 
   const errorWithData = { data: '{ "message": "error message"}' };
   sseHandler.handleError(errorWithData);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_RETRYABLE_ERROR); // An error without Ably code must emit PUSH_RETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(SSE_CONNECTION_ERROR, NON_REQUESTED);
 
   const errorWithBadData = { data: '{"message"error"' };
   sseHandler.handleError(errorWithBadData);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_RETRYABLE_ERROR); // An error that cannot be parsed must emit PUSH_RETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(SSE_CONNECTION_ERROR, NON_REQUESTED);
 
   const ably4XXRecoverableError = { data: '{"message":"Token expired","code":40142,"statusCode":401}' };
   sseHandler.handleError(ably4XXRecoverableError);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_RETRYABLE_ERROR); // An Ably recoverable error must emit PUSH_RETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(ABLY_ERROR, 40142);
 
   const ably4XXNonRecoverableError = { data: '{"message":"Token expired","code":42910,"statusCode":429}' };
   sseHandler.handleError(ably4XXNonRecoverableError);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_NONRETRYABLE_ERROR); // An Ably non-recoverable error must emit PUSH_NONRETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(ABLY_ERROR, 42910);
 
   const ably5XXError = { data: '{"message":"...","code":50000,"statusCode":500}' };
   sseHandler.handleError(ably5XXError);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(PUSH_RETRYABLE_ERROR); // An Ably recoverable error must emit PUSH_RETRYABLE_ERROR
+  expect(telemetryTracker.streamingEvent).toHaveBeenLastCalledWith(ABLY_ERROR, 50000);
 
 });
 
 test('handlerMessage: ignore invalid events', () => {
-  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter);
+  const sseHandler = SSEHandlerFactory(loggerMock, pushEmitter, telemetryTracker);
   sseHandler.handleOpen();
   pushEmitter.emit.mockClear();
 

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -31,7 +31,7 @@ export function pushManagerFactory(
   pollingManager: IPollingManager,
 ): IPushManager | undefined {
 
-  const { settings, storage: { segments, splits }, splitApi, readiness, platform, telemetryTracker } = params;
+  const { settings, storage, splitApi, readiness, platform, telemetryTracker } = params;
 
   // `userKey` is the matching key of main client in client-side SDK.
   // It can be used to check if running on client-side or server-side SDK.
@@ -55,9 +55,9 @@ export function pushManagerFactory(
 
   // init workers
   // MySegmentsUpdateWorker (client-side) are initiated in `add` method
-  const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(pollingManager.segmentsSyncTask, segments);
+  const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(pollingManager.segmentsSyncTask, storage.segments);
   // For server-side we pass the segmentsSyncTask, used by SplitsUpdateWorker to fetch new segments
-  const splitsUpdateWorker = new SplitsUpdateWorker(splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask);
+  const splitsUpdateWorker = new SplitsUpdateWorker(storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask);
 
   // [Only for client-side] map of hashes to user keys, to dispatch MY_SEGMENTS_UPDATE events to the corresponding MySegmentsUpdateWorker
   const userKeyHashes: Record<string, string> = {};

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -19,7 +19,7 @@ import { ISet, _Set } from '../../utils/lang/sets';
 import { Hash64, hash64 } from '../../utils/murmur3/murmur3_64';
 import { IAuthTokenPushEnabled } from './AuthClient/types';
 import { ISyncManagerFactoryParams } from '../types';
-import { TOKEN_REFRESH } from '../../utils/constants';
+import { TOKEN_REFRESH, AUTH_REJECTION } from '../../utils/constants';
 
 /**
  * PushManager factory:
@@ -31,7 +31,7 @@ export function pushManagerFactory(
   pollingManager: IPollingManager,
 ): IPushManager | undefined {
 
-  const { settings, storage: { segments, splits, telemetry }, splitApi, readiness, platform } = params;
+  const { settings, storage: { segments, splits }, splitApi, readiness, platform, telemetryTracker } = params;
 
   // `userKey` is the matching key of main client in client-side SDK.
   // It can be used to check if running on client-side or server-side SDK.
@@ -50,7 +50,7 @@ export function pushManagerFactory(
 
   // init feedback loop
   const pushEmitter = new platform.EventEmitter() as IPushEventEmitter;
-  const sseHandler = SSEHandlerFactory(log, pushEmitter);
+  const sseHandler = SSEHandlerFactory(log, pushEmitter, telemetryTracker);
   sseClient.setEventHandler(sseHandler);
 
   // init workers
@@ -103,14 +103,7 @@ export function pushManagerFactory(
       sseClient.open(authData);
     }, connDelay * 1000);
 
-    if (telemetry) {
-      telemetry.recordTokenRefreshes();
-      telemetry.recordStreamingEvents({
-        e: TOKEN_REFRESH,
-        d: decodedToken.exp,
-        t: Date.now()
-      });
-    }
+    telemetryTracker.streamingEvent(TOKEN_REFRESH, decodedToken.exp);
   }
 
   function connectPush() {
@@ -147,7 +140,7 @@ export function pushManagerFactory(
 
         // Handle 4XX HTTP errors: 401 (invalid API Key) or 400 (using incorrect API Key, i.e., client-side API Key on server-side)
         if (error.statusCode >= 400 && error.statusCode < 500) {
-          if (telemetry) telemetry.recordAuthRejections();
+          telemetryTracker.streamingEvent(AUTH_REJECTION);
           pushEmitter.emit(PUSH_NONRETRYABLE_ERROR);
           return;
         }

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -110,7 +110,7 @@ export type EventType = CONNECTION_ESTABLISHED | OCCUPANCY_PRI | OCCUPANCY_SEC |
 
 export type StreamingEvent = {
   e: EventType, // eventType
-  d: number, // eventData
+  d?: number, // eventData
   t: number, // timestamp
 }
 

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -106,10 +106,10 @@ export type SSE_CONNECTION_ERROR = 40;
 export type TOKEN_REFRESH = 50;
 export type ABLY_ERROR = 60;
 export type SYNC_MODE_UPDATE = 70;
-export type EventType = CONNECTION_ESTABLISHED | OCCUPANCY_PRI | OCCUPANCY_SEC | STREAMING_STATUS | SSE_CONNECTION_ERROR | TOKEN_REFRESH | ABLY_ERROR | SYNC_MODE_UPDATE;
+export type StreamingEventType = CONNECTION_ESTABLISHED | OCCUPANCY_PRI | OCCUPANCY_SEC | STREAMING_STATUS | SSE_CONNECTION_ERROR | TOKEN_REFRESH | ABLY_ERROR | SYNC_MODE_UPDATE;
 
 export type StreamingEvent = {
-  e: EventType, // eventType
+  e: StreamingEventType, // eventType
   d?: number, // eventData
   t: number, // timestamp
 }

--- a/src/sync/syncManagerOnline.ts
+++ b/src/sync/syncManagerOnline.ts
@@ -27,7 +27,7 @@ export function syncManagerOnlineFactory(
    */
   return function (params: ISyncManagerFactoryParams): ISyncManagerCS {
 
-    const { settings, settings: { log, streamingEnabled }, storage: { telemetry } } = params;
+    const { settings, settings: { log, streamingEnabled }, telemetryTracker } = params;
 
     /** Polling Manager */
     const pollingManager = pollingManagerFactory && pollingManagerFactory(params);
@@ -49,11 +49,7 @@ export function syncManagerOnlineFactory(
       } else {
         log.info(SYNC_START_POLLING);
         pollingManager!.start();
-        if (telemetry) telemetry.recordStreamingEvents({
-          e: SYNC_MODE_UPDATE,
-          d: POLLING,
-          t: Date.now()
-        });
+        telemetryTracker.streamingEvent(SYNC_MODE_UPDATE, POLLING);
       }
     }
 
@@ -62,11 +58,7 @@ export function syncManagerOnlineFactory(
       // if polling, stop
       if (pollingManager!.isRunning()) {
         pollingManager!.stop();
-        if (telemetry) telemetry.recordStreamingEvents({
-          e: SYNC_MODE_UPDATE,
-          d: STREAMING,
-          t: Date.now()
-        });
+        telemetryTracker.streamingEvent(SYNC_MODE_UPDATE, STREAMING);
       }
 
       // fetch splits and segments. There is no need to catch this promise (it is always resolved)

--- a/src/sync/syncManagerOnline.ts
+++ b/src/sync/syncManagerOnline.ts
@@ -7,6 +7,7 @@ import { IPollingManager, IPollingManagerCS } from './polling/types';
 import { PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN } from './streaming/constants';
 import { SYNC_START_POLLING, SYNC_CONTINUE_POLLING, SYNC_STOP_POLLING } from '../logger/constants';
 import { isConsentGranted } from '../consent';
+import { POLLING, STREAMING, SYNC_MODE_UPDATE } from '../utils/constants';
 
 /**
  * Online SyncManager factory.
@@ -26,7 +27,7 @@ export function syncManagerOnlineFactory(
    */
   return function (params: ISyncManagerFactoryParams): ISyncManagerCS {
 
-    const { settings, settings: { log, streamingEnabled } } = params;
+    const { settings, settings: { log, streamingEnabled }, storage: { telemetry } } = params;
 
     /** Polling Manager */
     const pollingManager = pollingManagerFactory && pollingManagerFactory(params);
@@ -48,13 +49,25 @@ export function syncManagerOnlineFactory(
       } else {
         log.info(SYNC_START_POLLING);
         pollingManager!.start();
+        if (telemetry) telemetry.recordStreamingEvents({
+          e: SYNC_MODE_UPDATE,
+          d: POLLING,
+          t: Date.now()
+        });
       }
     }
 
     function stopPollingAndSyncAll() {
       log.info(SYNC_STOP_POLLING);
       // if polling, stop
-      if (pollingManager!.isRunning()) pollingManager!.stop();
+      if (pollingManager!.isRunning()) {
+        pollingManager!.stop();
+        if (telemetry) telemetry.recordStreamingEvents({
+          e: SYNC_MODE_UPDATE,
+          d: STREAMING,
+          t: Date.now()
+        });
+      }
 
       // fetch splits and segments. There is no need to catch this promise (it is always resolved)
       pollingManager!.syncAll();

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -2,6 +2,7 @@ import { IReadinessManager } from '../readiness/types';
 import { IPlatform } from '../sdkFactory/types';
 import { ISplitApi } from '../services/types';
 import { IStorageSync } from '../storages/types';
+import { ITelemetryTracker } from '../trackers/types';
 import { ISettings } from '../types';
 import { IPollingManager } from './polling/types';
 import { IPushManager } from './streaming/types';
@@ -58,5 +59,6 @@ export interface ISyncManagerFactoryParams {
   readiness: IReadinessManager,
   storage: IStorageSync,
   splitApi: ISplitApi,
-  platform: IPlatform
+  platform: IPlatform,
+  telemetryTracker: ITelemetryTracker
 }

--- a/src/trackers/__tests__/impressionsTracker.spec.ts
+++ b/src/trackers/__tests__/impressionsTracker.spec.ts
@@ -4,11 +4,15 @@ import { impressionObserverSSFactory } from '../impressionObserver/impressionObs
 import { impressionObserverCSFactory } from '../impressionObserver/impressionObserverCS';
 import { ImpressionDTO } from '../../types';
 import { fullSettings } from '../../utils/settingsValidation/__tests__/settings.mocks';
+import { DEDUPED, QUEUED } from '../../utils/constants';
 
 /* Mocks */
 
 const fakeImpressionsCache = {
   track: jest.fn()
+};
+const fakeTelemetryCache = {
+  recordImpressionStats: jest.fn()
 };
 const fakeListener = {
   logImpression: jest.fn()
@@ -168,8 +172,8 @@ describe('Impressions Tracker', () => {
     impression2.time = Date.now();
     impression3.time = Date.now();
 
-    const impressionCountsCache = new ImpressionCountsCacheInMemory();
-    const tracker = impressionsTrackerFactory(fakeSettings, fakeImpressionsCache, undefined, impressionObserverCSFactory(), impressionCountsCache);
+    const impressionCountsCache = new ImpressionCountsCacheInMemory(); // @ts-ignore
+    const tracker = impressionsTrackerFactory(fakeSettings, fakeImpressionsCache, undefined, impressionObserverCSFactory(), impressionCountsCache, fakeTelemetryCache);
 
     expect(fakeImpressionsCache.track).not.toBeCalled(); // cache method should not be called by just creating a tracker
 
@@ -185,6 +189,8 @@ describe('Impressions Tracker', () => {
     expect(lastArgs[0][1].feature).toBe('qc_team_2');
 
     expect(Object.keys(impressionCountsCache.state()).length).toBe(2);
+    expect(fakeTelemetryCache.recordImpressionStats.mock.calls).toEqual([[QUEUED, 2], [DEDUPED, 1]]);
+
   });
 
   test('Should track or not impressions depending on user consent status', () => {

--- a/src/trackers/__tests__/telemetryTracker.spec.ts
+++ b/src/trackers/__tests__/telemetryTracker.spec.ts
@@ -11,7 +11,8 @@ describe('Telemetry Tracker', () => {
     recordNonReadyUsage: jest.fn(),
     recordHttpLatency: jest.fn(),
     recordHttpError: jest.fn(),
-    recordSessionLength: jest.fn()
+    recordSessionLength: jest.fn(),
+    recordStreamingEvents: jest.fn(),
   };
   // @ts-ignore
   const tracker = telemetryTrackerFactory(fakeTelemetryCache, fakeNow);
@@ -62,12 +63,17 @@ describe('Telemetry Tracker', () => {
   });
 
   test('trackSessionLength', () => {
-    tracker.trackSessionLength();
+    tracker.sessionLength();
     expect(fakeTelemetryCache.recordSessionLength).toBeCalledTimes(1);
 
     const expectedSessionLength = Date.now() - startTimestamp;
     const sessionLength = fakeTelemetryCache.recordSessionLength.mock.calls[0][0];
     expect(nearlyEqual(sessionLength, expectedSessionLength)).toBeTruthy();
+  });
+
+  test('streamingEvent', () => {
+    tracker.streamingEvent(10, 1);
+    expect(fakeTelemetryCache.recordStreamingEvents).toBeCalledTimes(1);
   });
 
 });
@@ -81,4 +87,7 @@ test('Telemetry Tracker no-op', () => {
 
   const stopHttpTracker = tracker.trackHttp('ev');
   expect(stopHttpTracker()).toBe(undefined);
+
+  expect(tracker.sessionLength()).toBe(undefined);
+  expect(tracker.streamingEvent(10, 1)).toBe(undefined);
 });

--- a/src/trackers/eventTracker.ts
+++ b/src/trackers/eventTracker.ts
@@ -1,10 +1,10 @@
 import { objectAssign } from '../utils/lang/objectAssign';
 import { thenable } from '../utils/promise/thenable';
-import { IEventsCacheBase } from '../storages/types';
+import { IEventsCacheBase, TelemetryCacheAsync, TelemetryCacheSync } from '../storages/types';
 import { IEventsHandler, IEventTracker } from './types';
 import { ISettings, SplitIO } from '../types';
 import { EVENTS_TRACKER_SUCCESS, ERROR_EVENTS_TRACKER } from '../logger/constants';
-import { CONSENT_DECLINED } from '../utils/constants';
+import { CONSENT_DECLINED, DROPPED, QUEUED } from '../utils/constants';
 import { isStorageSync } from './impressionObserver/utils';
 
 /**
@@ -16,7 +16,8 @@ import { isStorageSync } from './impressionObserver/utils';
 export function eventTrackerFactory(
   settings: ISettings,
   eventsCache: IEventsCacheBase,
-  integrationsManager?: IEventsHandler
+  integrationsManager?: IEventsHandler,
+  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync
 ): IEventTracker {
 
   const log = settings.log;
@@ -57,6 +58,9 @@ export function eventTrackerFactory(
       if (thenable(tracked)) {
         return tracked.then(queueEventsCallback.bind(null, eventData));
       } else {
+        // Record when eventsCache is sync only (standalone mode)
+        // @TODO we are not dropping events on full queue yet, so `tracked` is always true ATM
+        if (telemetryCache) (telemetryCache as TelemetryCacheSync).recordEventStats(tracked ? QUEUED : DROPPED, 1);
         return queueEventsCallback(eventData, tracked);
       }
     }

--- a/src/trackers/impressionsTracker.ts
+++ b/src/trackers/impressionsTracker.ts
@@ -1,12 +1,12 @@
 import { objectAssign } from '../utils/lang/objectAssign';
 import { thenable } from '../utils/promise/thenable';
 import { truncateTimeFrame } from '../utils/time';
-import { IImpressionCountsCacheSync, IImpressionsCacheBase } from '../storages/types';
+import { IImpressionCountsCacheSync, IImpressionsCacheBase, TelemetryCacheSync, TelemetryCacheAsync } from '../storages/types';
 import { IImpressionsHandler, IImpressionsTracker } from './types';
 import { SplitIO, ImpressionDTO, ISettings } from '../types';
 import { IImpressionObserver } from './impressionObserver/types';
 import { IMPRESSIONS_TRACKER_SUCCESS, ERROR_IMPRESSIONS_TRACKER, ERROR_IMPRESSIONS_LISTENER } from '../logger/constants';
-import { CONSENT_DECLINED } from '../utils/constants';
+import { CONSENT_DECLINED, DEDUPED, QUEUED } from '../utils/constants';
 
 /**
  * Impressions tracker stores impressions in cache and pass them to the listener and integrations manager if provided.
@@ -25,7 +25,8 @@ export function impressionsTrackerFactory(
   // if observer is provided, it implies `shouldAddPreviousTime` flag (i.e., if impressions previous time should be added or not)
   observer?: IImpressionObserver,
   // if countsCache is provided, it implies `isOptimized` flag (i.e., if impressions should be deduped or not)
-  countsCache?: IImpressionCountsCacheSync
+  countsCache?: IImpressionCountsCacheSync,
+  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync
 ): IImpressionsTracker {
 
   const { log, impressionListener, runtime: { ip, hostname }, version } = settings;
@@ -65,6 +66,13 @@ export function impressionsTrackerFactory(
         }).catch(err => {
           log.error(ERROR_IMPRESSIONS_TRACKER, [impressionsCount, err]);
         });
+      } else {
+        // Record when impressionsCache is sync only (standalone mode)
+        // @TODO we are not dropping impressions on full queue yet, so DROPPED stats are not recorded
+        if (telemetryCache) {
+          (telemetryCache as TelemetryCacheSync).recordImpressionStats(QUEUED, impressionsToStore.length);
+          (telemetryCache as TelemetryCacheSync).recordImpressionStats(DEDUPED, impressions.length - impressionsToStore.length);
+        }
       }
 
       // @TODO next block might be handled by the integration manager. In that case, the metadata object doesn't need to be passed in the constructor

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -11,6 +11,7 @@ export function telemetryTrackerFactory(
 ): ITelemetryTracker {
 
   if (telemetryCache && now) {
+    const startTime = timer(now);
 
     return {
       trackEval(method: Method) {
@@ -35,13 +36,17 @@ export function telemetryTrackerFactory(
           if (error && error.statusCode) (telemetryCache as TelemetryCacheSync).recordHttpError(operation, error.statusCode);
         };
       },
+      trackSessionLength() { // @ts-ignore
+        telemetryCache?.recordSessionLength(startTime());
+      }
     };
 
   } else { // If there is not `telemetryCache` or `now` time tracker, return a no-op telemetry tracker
     const noopTrack = () => () => { };
     return {
       trackEval: noopTrack,
-      trackHttp: noopTrack
+      trackHttp: noopTrack,
+      trackSessionLength: noopTrack
     };
   }
 }

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -36,7 +36,7 @@ export interface ITelemetryTracker {
   /**
    * Records session length
    */
-  sessionLength(): void,
+  sessionLength(): void
   /**
    * Records streaming event
    */

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -32,4 +32,8 @@ export interface ITelemetryTracker {
    * Creates a telemetry runtime tracker, to record Latencies and Exceptions of HTTP requests
    */
   trackHttp(method: OperationType): (error?: NetworkError) => void
+  /**
+   * Records session length
+   */
+  trackSessionLength(): void
 }

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -1,5 +1,5 @@
 import { SplitIO, ImpressionDTO } from '../types';
-import { Method, OperationType } from '../sync/submitters/types';
+import { StreamingEventType, Method, OperationType } from '../sync/submitters/types';
 import { IEventsCacheBase } from '../storages/types';
 import { NetworkError } from '../services/types';
 
@@ -22,6 +22,7 @@ export interface IImpressionsTracker {
 }
 
 /** Telemetry tracker */
+export type AUTH_REJECTION = 80;
 
 export interface ITelemetryTracker {
   /**
@@ -35,5 +36,9 @@ export interface ITelemetryTracker {
   /**
    * Records session length
    */
-  trackSessionLength(): void
+  sessionLength(): void,
+  /**
+   * Records streaming event
+   */
+  streamingEvent(e: StreamingEventType | AUTH_REJECTION, d?: number): void
 }

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -64,3 +64,20 @@ export const TREATMENTS = 'ts';
 export const TREATMENT_WITH_CONFIG = 'tc';
 export const TREATMENTS_WITH_CONFIG = 'tcs';
 export const TRACK = 'tr';
+
+export const CONNECTION_ESTABLISHED = 0;
+export const OCCUPANCY_PRI = 10;
+export const OCCUPANCY_SEC = 20;
+export const STREAMING_STATUS = 30;
+export const SSE_CONNECTION_ERROR = 40;
+export const TOKEN_REFRESH = 50;
+export const ABLY_ERROR = 60;
+export const SYNC_MODE_UPDATE = 70;
+
+export const STREAMING = 0;
+export const POLLING = 1;
+export const REQUESTED = 0;
+export const NON_REQUESTED = 1;
+export const DISABLED = 0;
+export const ENABLED = 1;
+export const PAUSED = 2;

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -73,6 +73,7 @@ export const SSE_CONNECTION_ERROR = 40;
 export const TOKEN_REFRESH = 50;
 export const ABLY_ERROR = 60;
 export const SYNC_MODE_UPDATE = 70;
+export const AUTH_REJECTION = 80;
 
 export const STREAMING = 0;
 export const POLLING = 1;


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- impressions and events stats
- streaming: auth rejections, token refreshes and streaming events
- session length

## How do we test the changes introduced in this PR?

## Extra Notes