### PR TITLE
Telemetry submitter for metrics/usage

### DIFF
--- a/src/listeners/browser.ts
+++ b/src/listeners/browser.ts
@@ -2,8 +2,8 @@
 // @TODO eventually migrate to JS-Browser-SDK package.
 import { ISignalListener } from './types';
 import { IRecorderCacheProducerSync, IStorageSync } from '../storages/types';
-import { fromImpressionsCollector } from '../sync/submitters/impressionsSyncTask';
-import { fromImpressionCountsCollector } from '../sync/submitters/impressionCountsSyncTask';
+import { fromImpressionsCollector } from '../sync/submitters/impressionsSubmitter';
+import { fromImpressionCountsCollector } from '../sync/submitters/impressionCountsSubmitter';
 import { IResponse, ISplitApi } from '../services/types';
 import { ImpressionDTO, ISettings } from '../types';
 import { ImpressionsPayload } from '../sync/submitters/types';

--- a/src/logger/messages/info.ts
+++ b/src/logger/messages/info.ts
@@ -24,7 +24,7 @@ export const codesInfo: [number, string][] = codesWarn.concat([
   [c.POLLING_STOP, c.LOG_PREFIX_SYNC_POLLING + 'Stopping polling'],
   [c.SYNC_SPLITS_FETCH_RETRY, c.LOG_PREFIX_SYNC_SPLITS + 'Retrying download of splits #%s. Reason: %s'],
   [c.SUBMITTERS_PUSH_FULL_QUEUE, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Flushing full %s queue and reseting timer.'],
-  [c.SUBMITTERS_PUSH, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Pushing %s %s.'],
+  [c.SUBMITTERS_PUSH, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Pushing %s.'],
   [c.STREAMING_REFRESH_TOKEN, c.LOG_PREFIX_SYNC_STREAMING + 'Refreshing streaming token in %s seconds, and connecting streaming in %s seconds.'],
   [c.STREAMING_RECONNECT, c.LOG_PREFIX_SYNC_STREAMING + 'Attempting to reconnect streaming in %s seconds.'],
   [c.STREAMING_CONNECTING, c.LOG_PREFIX_SYNC_STREAMING + 'Connecting streaming.'],

--- a/src/logger/messages/warn.ts
+++ b/src/logger/messages/warn.ts
@@ -11,8 +11,8 @@ export const codesWarn: [number, string][] = codesError.concat([
   [c.STREAMING_PARSING_ERROR_FAILS, c.LOG_PREFIX_SYNC_STREAMING + 'Error parsing SSE error notification: %s'],
   [c.STREAMING_PARSING_MESSAGE_FAILS, c.LOG_PREFIX_SYNC_STREAMING + 'Error parsing SSE message notification: %s'],
   [c.STREAMING_FALLBACK, c.LOG_PREFIX_SYNC_STREAMING + 'Falling back to polling mode. Reason: %s'],
-  [c.SUBMITTERS_PUSH_FAILS, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Droping %s %s after retry. Reason: %s.'],
-  [c.SUBMITTERS_PUSH_RETRY, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Failed to push %s %s, keeping data to retry on next iteration. Reason: %s.'],
+  [c.SUBMITTERS_PUSH_FAILS, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Droping %s after retry. Reason: %s.'],
+  [c.SUBMITTERS_PUSH_RETRY, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Failed to push %s, keeping data to retry on next iteration. Reason: %s.'],
   // client status
   [c.CLIENT_NOT_READY, '%s: the SDK is not ready, results may be incorrect. Make sure to wait for SDK readiness before using this method.'],
   [c.CLIENT_NO_LISTENER, 'No listeners for SDK Readiness detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet ready.'],

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -1,6 +1,6 @@
 import { ImpressionDataType, EventDataType, LastSync, HttpErrors, HttpLatencies, StreamingEvent, Method, OperationType, MethodExceptions, MethodLatencies } from '../../sync/submitters/types';
 import { findLatencyIndex } from '../findLatencyIndex';
-import { TelemetryCacheSync } from '../types';
+import { ITelemetryCacheSync } from '../types';
 
 const MAX_STREAMING_EVENTS = 20;
 const MAX_TAGS = 10;
@@ -10,7 +10,7 @@ function newBuckets() {
   return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 }
 
-export class TelemetryCacheInMemory implements TelemetryCacheSync {
+export class TelemetryCacheInMemory implements ITelemetryCacheSync {
 
   private timeUntilReady?: number;
 

--- a/src/storages/inRedis/TelemetryCacheInRedis.ts
+++ b/src/storages/inRedis/TelemetryCacheInRedis.ts
@@ -1,11 +1,11 @@
 import { ILogger } from '../../logger/types';
 import { Method } from '../../sync/submitters/types';
 import { KeyBuilderSS } from '../KeyBuilderSS';
-import { TelemetryCacheAsync } from '../types';
+import { ITelemetryCacheAsync } from '../types';
 import { findLatencyIndex } from '../findLatencyIndex';
 import { Redis } from 'ioredis';
 
-export class TelemetryCacheInRedis implements TelemetryCacheAsync {
+export class TelemetryCacheInRedis implements ITelemetryCacheAsync {
 
   /**
    * Create a Telemetry cache that uses Redis as storage.

--- a/src/storages/pluggable/TelemetryCachePluggable.ts
+++ b/src/storages/pluggable/TelemetryCachePluggable.ts
@@ -1,10 +1,10 @@
 import { ILogger } from '../../logger/types';
 import { Method } from '../../sync/submitters/types';
 import { KeyBuilderSS } from '../KeyBuilderSS';
-import { IPluggableStorageWrapper, TelemetryCacheAsync } from '../types';
+import { IPluggableStorageWrapper, ITelemetryCacheAsync } from '../types';
 import { findLatencyIndex } from '../findLatencyIndex';
 
-export class TelemetryCachePluggable implements TelemetryCacheAsync {
+export class TelemetryCachePluggable implements ITelemetryCacheAsync {
 
   /**
    * Create a Telemetry cache that uses a storage wrapper.

--- a/src/sync/submitters/__tests__/eventsSubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/eventsSubmitter.spec.ts
@@ -1,9 +1,9 @@
-import { eventsSyncTaskFactory } from '../eventsSyncTask';
+import { eventsSubmitterFactory } from '../eventsSubmitter';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 
 
 
-describe('Events submitter (eventsSyncTask)', () => {
+describe('Events submitter', () => {
 
   let __onFullQueueCb: () => void;
   const postEventsBulkMock = jest.fn();
@@ -18,7 +18,7 @@ describe('Events submitter (eventsSyncTask)', () => {
 
   test('with eventsFirstPushWindow', async () => {
     const eventsFirstPushWindow = 20; // @ts-ignore
-    const eventsSubmitter = eventsSyncTaskFactory(loggerMock, postEventsBulkMock, eventsCacheMock, 30000, eventsFirstPushWindow);
+    const eventsSubmitter = eventsSubmitterFactory(loggerMock, postEventsBulkMock, eventsCacheMock, 30000, eventsFirstPushWindow);
 
     eventsSubmitter.start();
     expect(eventsSubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running
@@ -41,7 +41,7 @@ describe('Events submitter (eventsSyncTask)', () => {
 
   test('without eventsFirstPushWindow', async () => {
     // @ts-ignore
-    const eventsSubmitter = eventsSyncTaskFactory(loggerMock, postEventsBulkMock, eventsCacheMock, 30000);
+    const eventsSubmitter = eventsSubmitterFactory(loggerMock, postEventsBulkMock, eventsCacheMock, 30000);
 
     eventsSubmitter.start();
     expect(eventsSubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running

--- a/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
@@ -14,7 +14,7 @@ describe('Telemetry submitter', () => {
     splitApi: { postMetricsUsage }, // @ts-ignore
     storage: InMemoryStorageFactory({}),
   };
-  const popLatenciesSpy = jest.spyOn(params.storage.telemetry, 'popLatencies');
+  const popLatenciesSpy = jest.spyOn(params.storage.telemetry!, 'popLatencies');
 
   test('submits metrics/usage periodically', async () => {
     // @ts-ignore

--- a/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
@@ -1,0 +1,41 @@
+import { telemetrySubmitterFactory } from '../telemetrySubmitter';
+import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
+import { InMemoryStorageFactory } from '../../../storages/inMemory/InMemoryStorage';
+
+describe('Telemetry submitter', () => {
+
+  const telemetryRefreshRate = 100; // 100 ms
+  const postMetricsUsage = jest.fn(() => Promise.resolve());
+  const params = {
+    settings: {
+      log: loggerMock,
+      scheduler: { telemetryRefreshRate }
+    },
+    splitApi: { postMetricsUsage }, // @ts-ignore
+    storage: InMemoryStorageFactory({}),
+  };
+  const popLatenciesSpy = jest.spyOn(params.storage.telemetry, 'popLatencies');
+
+  test('submits metrics/usage periodically', async () => {
+    // @ts-ignore
+    const telemetrySubmitter = telemetrySubmitterFactory(params);
+
+    telemetrySubmitter.start();
+    expect(telemetrySubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running
+    expect(telemetrySubmitter.isExecuting()).toEqual(false); // but not executed immediatelly (first push window)
+    expect(popLatenciesSpy).toBeCalledTimes(0);
+
+    // Await first push
+    await new Promise(res => setTimeout(res, params.settings.scheduler.telemetryRefreshRate + 10));
+    // after the first push, telemetry cache should have been used to create the request payload
+    expect(popLatenciesSpy).toBeCalledTimes(1);
+    expect(postMetricsUsage).toBeCalledWith(JSON.stringify({
+      lS: {}, mL: {}, mE: {}, hE: {}, hL: {}, tR: 0, aR: 0, iQ: 0, iDe: 0, iDr: 0, spC: 0, seC: 0, skC: 0, eQ: 0, eD: 0, sE: [], t: []
+    }));
+
+    expect(telemetrySubmitter.isRunning()).toEqual(true);
+    telemetrySubmitter.stop();
+    expect(telemetrySubmitter.isRunning()).toEqual(false);
+  });
+
+});

--- a/src/sync/submitters/eventsSubmitter.ts
+++ b/src/sync/submitters/eventsSubmitter.ts
@@ -1,29 +1,26 @@
 import { IEventsCacheSync } from '../../storages/types';
 import { IPostEventsBulk } from '../../services/types';
-import { ISyncTask, ITimeTracker } from '../types';
-import { submitterSyncTaskFactory } from './submitterSyncTask';
+import { submitterFactory } from './submitter';
 import { ILogger } from '../../logger/types';
 import { SUBMITTERS_PUSH_FULL_QUEUE } from '../../logger/constants';
 
 const DATA_NAME = 'events';
 
 /**
- * Sync task that periodically posts tracked events
+ * Submitter that periodically posts tracked events
  */
-export function eventsSyncTaskFactory(
+export function eventsSubmitterFactory(
   log: ILogger,
   postEventsBulk: IPostEventsBulk,
   eventsCache: IEventsCacheSync,
   eventsPushRate: number,
   eventsFirstPushWindow: number,
-  latencyTracker?: ITimeTracker
-): ISyncTask {
+) {
 
   // don't retry events.
-  const syncTask = submitterSyncTaskFactory(log, postEventsBulk, eventsCache, eventsPushRate, DATA_NAME, latencyTracker);
+  const syncTask = submitterFactory(log, postEventsBulk, eventsCache, eventsPushRate, DATA_NAME);
 
   // Set a timer for the first push window of events.
-  // Not implemented in the base submitter or sync task, since this feature is only used by the events submitter.
   if (eventsFirstPushWindow > 0) {
     let running = false;
     let stopEventPublisherTimeout: ReturnType<typeof setTimeout>;

--- a/src/sync/submitters/eventsSubmitter.ts
+++ b/src/sync/submitters/eventsSubmitter.ts
@@ -1,6 +1,6 @@
 import { IEventsCacheSync } from '../../storages/types';
 import { IPostEventsBulk } from '../../services/types';
-import { submitterFactory } from './submitter';
+import { submitterFactory, firstPushWindowDecorator } from './submitter';
 import { ILogger } from '../../logger/types';
 import { SUBMITTERS_PUSH_FULL_QUEUE } from '../../logger/constants';
 
@@ -18,37 +18,20 @@ export function eventsSubmitterFactory(
 ) {
 
   // don't retry events.
-  const syncTask = submitterFactory(log, postEventsBulk, eventsCache, eventsPushRate, DATA_NAME);
+  let submitter = submitterFactory(log, postEventsBulk, eventsCache, eventsPushRate, DATA_NAME);
 
   // Set a timer for the first push window of events.
-  if (eventsFirstPushWindow > 0) {
-    let running = false;
-    let stopEventPublisherTimeout: ReturnType<typeof setTimeout>;
-    const originalStart = syncTask.start;
-    syncTask.start = () => {
-      running = true;
-      stopEventPublisherTimeout = setTimeout(originalStart, eventsFirstPushWindow);
-    };
-    const originalStop = syncTask.stop;
-    syncTask.stop = () => {
-      running = false;
-      clearTimeout(stopEventPublisherTimeout);
-      originalStop();
-    };
-    syncTask.isRunning = () => {
-      return running;
-    };
-  }
+  if (eventsFirstPushWindow > 0) submitter = firstPushWindowDecorator(submitter, eventsFirstPushWindow);
 
   // register events submitter to be executed when events cache is full
   eventsCache.setOnFullQueueCb(() => {
-    if (syncTask.isRunning()) {
+    if (submitter.isRunning()) {
       log.info(SUBMITTERS_PUSH_FULL_QUEUE, [DATA_NAME]);
-      syncTask.execute();
+      submitter.execute();
     }
     // If submitter is stopped (e.g., user consent declined or unknown, or app state offline), we don't send the data.
     // Data will be sent when submitter is resumed.
   });
 
-  return syncTask;
+  return submitter;
 }

--- a/src/sync/submitters/impressionCountsSubmitter.ts
+++ b/src/sync/submitters/impressionCountsSubmitter.ts
@@ -1,7 +1,6 @@
-import { ISyncTask, ITimeTracker } from '../types';
 import { IPostTestImpressionsCount } from '../../services/types';
 import { IImpressionCountsCacheSync } from '../../storages/types';
-import { submitterSyncTaskFactory } from './submitterSyncTask';
+import { submitterFactory } from './submitter';
 import { ImpressionCountsPayload } from './types';
 import { ILogger } from '../../logger/types';
 
@@ -32,15 +31,14 @@ export function fromImpressionCountsCollector(impressionsCount: Record<string, n
 const IMPRESSIONS_COUNT_RATE = 1800000; // 30 minutes
 
 /**
- * Sync task that periodically posts impression counts
+ * Submitter that periodically posts impression counts
  */
-export function impressionCountsSyncTaskFactory(
+export function impressionCountsSubmitterFactory(
   log: ILogger,
   postTestImpressionsCount: IPostTestImpressionsCount,
   impressionCountsCache: IImpressionCountsCacheSync,
-  latencyTracker?: ITimeTracker
-): ISyncTask {
+) {
 
   // retry impressions counts only once.
-  return submitterSyncTaskFactory(log, postTestImpressionsCount, impressionCountsCache, IMPRESSIONS_COUNT_RATE, 'impression counts', latencyTracker, fromImpressionCountsCollector, 1);
+  return submitterFactory(log, postTestImpressionsCount, impressionCountsCache, IMPRESSIONS_COUNT_RATE, 'impression counts', fromImpressionCountsCollector, 1);
 }

--- a/src/sync/submitters/impressionsSubmitter.ts
+++ b/src/sync/submitters/impressionsSubmitter.ts
@@ -1,9 +1,8 @@
 import { groupBy, forOwn } from '../../utils/lang';
-import { ISyncTask, ITimeTracker } from '../types';
 import { IPostTestImpressionsBulk } from '../../services/types';
 import { IImpressionsCacheSync } from '../../storages/types';
 import { ImpressionDTO } from '../../types';
-import { submitterSyncTaskFactory } from './submitterSyncTask';
+import { submitterFactory } from './submitter';
 import { ImpressionsPayload } from './types';
 import { ILogger } from '../../logger/types';
 import { SUBMITTERS_PUSH_FULL_QUEUE } from '../../logger/constants';
@@ -41,19 +40,18 @@ export function fromImpressionsCollector(sendLabels: boolean, data: ImpressionDT
 }
 
 /**
- * Sync task that periodically posts impressions data
+ * Submitter that periodically posts impressions data
  */
-export function impressionsSyncTaskFactory(
+export function impressionsSubmitterFactory(
   log: ILogger,
   postTestImpressionsBulk: IPostTestImpressionsBulk,
   impressionsCache: IImpressionsCacheSync,
   impressionsRefreshRate: number,
   sendLabels = false,
-  latencyTracker?: ITimeTracker,
-): ISyncTask {
+) {
 
   // retry impressions only once.
-  const syncTask = submitterSyncTaskFactory(log, postTestImpressionsBulk, impressionsCache, impressionsRefreshRate, DATA_NAME, latencyTracker, fromImpressionsCollector.bind(undefined, sendLabels), 1);
+  const syncTask = submitterFactory(log, postTestImpressionsBulk, impressionsCache, impressionsRefreshRate, DATA_NAME, fromImpressionsCollector.bind(undefined, sendLabels), 1);
 
   // register impressions submitter to be executed when impressions cache is full
   impressionsCache.setOnFullQueueCb(() => {

--- a/src/sync/submitters/submitter.ts
+++ b/src/sync/submitters/submitter.ts
@@ -51,3 +51,26 @@ export function submitterFactory<TState>(
 
   return syncTaskFactory(log, postData, postRate, dataName + ' submitter');
 }
+
+/**
+ * Decorates a provided submitter with a first execution window
+ */
+export function firstPushWindowDecorator(submitter: ISyncTask, firstPushWindow: number) {
+  let running = false;
+  let stopEventPublisherTimeout: ReturnType<typeof setTimeout>;
+  const originalStart = submitter.start;
+  submitter.start = () => {
+    running = true;
+    stopEventPublisherTimeout = setTimeout(originalStart, firstPushWindow);
+  };
+  const originalStop = submitter.stop;
+  submitter.stop = () => {
+    running = false;
+    clearTimeout(stopEventPublisherTimeout);
+    originalStop();
+  };
+  submitter.isRunning = () => {
+    return running;
+  };
+  return submitter;
+}

--- a/src/sync/submitters/submitterManager.ts
+++ b/src/sync/submitters/submitterManager.ts
@@ -3,7 +3,7 @@ import { eventsSubmitterFactory } from './eventsSubmitter';
 import { impressionsSubmitterFactory } from './impressionsSubmitter';
 import { impressionCountsSubmitterFactory } from './impressionCountsSubmitter';
 import { ISyncManagerFactoryParams } from '../types';
-import { telemetrySubmitterFactory } from './telemetrySubmitter';
+import { ISyncManagerFactoryParamsWithTelemetry, telemetrySubmitterFactory } from './telemetrySubmitter';
 
 export function submitterManagerFactory(params: ISyncManagerFactoryParams) {
 
@@ -14,6 +14,6 @@ export function submitterManagerFactory(params: ISyncManagerFactoryParams) {
     eventsSubmitterFactory(log, splitApi.postEventsBulk, storage.events, settings.scheduler.eventsPushRate, settings.startup.eventsFirstPushWindow)
   ];
   if (storage.impressionCounts) submitters.push(impressionCountsSubmitterFactory(log, splitApi.postTestImpressionsCount, storage.impressionCounts));
-  if (storage.telemetry) submitters.push(telemetrySubmitterFactory(params));
+  if (storage.telemetry) submitters.push(telemetrySubmitterFactory(params as ISyncManagerFactoryParamsWithTelemetry));
   return syncTaskComposite(submitters);
 }

--- a/src/sync/submitters/submitterManager.ts
+++ b/src/sync/submitters/submitterManager.ts
@@ -1,18 +1,19 @@
 import { syncTaskComposite } from '../syncTaskComposite';
-import { eventsSyncTaskFactory } from './eventsSyncTask';
-import { impressionsSyncTaskFactory } from './impressionsSyncTask';
-import { impressionCountsSyncTaskFactory } from './impressionCountsSyncTask';
+import { eventsSubmitterFactory } from './eventsSubmitter';
+import { impressionsSubmitterFactory } from './impressionsSubmitter';
+import { impressionCountsSubmitterFactory } from './impressionCountsSubmitter';
 import { ISyncManagerFactoryParams } from '../types';
+import { telemetrySubmitterFactory } from './telemetrySubmitter';
 
 export function submitterManagerFactory(params: ISyncManagerFactoryParams) {
 
   const { settings, storage, splitApi } = params;
   const log = settings.log;
   const submitters = [
-    impressionsSyncTaskFactory(log, splitApi.postTestImpressionsBulk, storage.impressions, settings.scheduler.impressionsRefreshRate, settings.core.labelsEnabled),
-    eventsSyncTaskFactory(log, splitApi.postEventsBulk, storage.events, settings.scheduler.eventsPushRate, settings.startup.eventsFirstPushWindow)
-    // @TODO add telemetry submitter
+    impressionsSubmitterFactory(log, splitApi.postTestImpressionsBulk, storage.impressions, settings.scheduler.impressionsRefreshRate, settings.core.labelsEnabled),
+    eventsSubmitterFactory(log, splitApi.postEventsBulk, storage.events, settings.scheduler.eventsPushRate, settings.startup.eventsFirstPushWindow)
   ];
-  if (storage.impressionCounts) submitters.push(impressionCountsSyncTaskFactory(log, splitApi.postTestImpressionsCount, storage.impressionCounts));
+  if (storage.impressionCounts) submitters.push(impressionCountsSubmitterFactory(log, splitApi.postTestImpressionsCount, storage.impressionCounts));
+  if (storage.telemetry) submitters.push(telemetrySubmitterFactory(log, splitApi, storage, settings.scheduler.telemetryRefreshRate));
   return syncTaskComposite(submitters);
 }

--- a/src/sync/submitters/submitterManager.ts
+++ b/src/sync/submitters/submitterManager.ts
@@ -14,6 +14,6 @@ export function submitterManagerFactory(params: ISyncManagerFactoryParams) {
     eventsSubmitterFactory(log, splitApi.postEventsBulk, storage.events, settings.scheduler.eventsPushRate, settings.startup.eventsFirstPushWindow)
   ];
   if (storage.impressionCounts) submitters.push(impressionCountsSubmitterFactory(log, splitApi.postTestImpressionsCount, storage.impressionCounts));
-  if (storage.telemetry) submitters.push(telemetrySubmitterFactory(log, splitApi, storage, settings.scheduler.telemetryRefreshRate));
+  if (storage.telemetry) submitters.push(telemetrySubmitterFactory(params));
   return syncTaskComposite(submitters);
 }

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -1,13 +1,15 @@
-import { IStorageSync } from '../../storages/types';
+import { ITelemetryCacheSync } from '../../storages/types';
 import { submitterFactory, firstPushWindowDecorator } from './submitter';
 import { TelemetryUsageStatsPayload } from './types';
 import { QUEUED, DEDUPED, DROPPED } from '../../utils/constants';
 import { ISyncManagerFactoryParams } from '../types';
 
+export type ISyncManagerFactoryParamsWithTelemetry = ISyncManagerFactoryParams & { storage: { telemetry: ITelemetryCacheSync } }
+
 /**
  * Converts data from telemetry cache into /metrics/usage request payload.
  */
-export function telemetryCacheStatsAdapter({ splits, segments, telemetry }: IStorageSync) {
+export function telemetryCacheStatsAdapter({ splits, segments, telemetry }: ISyncManagerFactoryParamsWithTelemetry['storage']) {
   return {
     isEmpty() { return false; }, // There is always data in telemetry cache
     clear() { }, //  No-op
@@ -41,7 +43,7 @@ export function telemetryCacheStatsAdapter({ splits, segments, telemetry }: ISto
 /**
  * Submitter that periodically posts telemetry data
  */
-export function telemetrySubmitterFactory(params: ISyncManagerFactoryParams) {
+export function telemetrySubmitterFactory(params: ISyncManagerFactoryParamsWithTelemetry) {
   const { settings: { log, scheduler: { telemetryRefreshRate } }, storage, splitApi } = params;
 
   return firstPushWindowDecorator(

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -1,0 +1,52 @@
+import { ISplitApi } from '../../services/types';
+import { IStorageSync } from '../../storages/types';
+import { submitterFactory } from './submitter';
+import { TelemetryUsageStatsPayload } from './types';
+import { QUEUED, DEDUPED, DROPPED } from '../../utils/constants';
+import { ILogger } from '../../logger/types';
+
+/**
+ * Converts data from telemetry cache into request payload.
+ */
+export function telemetryCacheStatsAdapter({ splits, segments, telemetry }: IStorageSync) {
+  return {
+    isEmpty() { return false; }, // There is always data in telemetry cache
+    clear() { }, //  No-op
+
+    // @TODO consider moving inside telemetry cache for code size reduction
+    state(): TelemetryUsageStatsPayload {
+      return {
+        lS: telemetry.getLastSynchronization(),
+        mL: telemetry.popLatencies(),
+        mE: telemetry.popExceptions(),
+        hE: telemetry.popHttpErrors(),
+        hL: telemetry.popHttpLatencies(),
+        tR: telemetry.popTokenRefreshes(),
+        aR: telemetry.popAuthRejections(),
+        iQ: telemetry.getImpressionStats(QUEUED),
+        iDe: telemetry.getImpressionStats(DEDUPED),
+        iDr: telemetry.getImpressionStats(DROPPED),
+        spC: splits.getSplitNames().length,
+        seC: segments.getRegisteredSegments().length,
+        skC: segments.getKeysCount(),
+        sL: telemetry.getSessionLength(),
+        eQ: telemetry.getEventStats(QUEUED),
+        eD: telemetry.getEventStats(DROPPED),
+        sE: telemetry.popStreamingEvents(),
+        t: telemetry.popTags(),
+      };
+    }
+  };
+}
+
+/**
+ * Submitter that periodically posts telemetry data
+ */
+export function telemetrySubmitterFactory(
+  log: ILogger,
+  splitApi: ISplitApi,
+  storage: IStorageSync,
+  telemetryRefreshRate: number,
+) {
+  return submitterFactory(log, splitApi.postMetricsUsage, telemetryCacheStatsAdapter(storage), telemetryRefreshRate, 'telemetry stats', undefined, 0, true);
+}

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -129,7 +129,7 @@ export type TelemetryUsageStatsPayload = {
   spC: number, // splitCount
   seC: number, // segmentCount
   skC: number, // segmentKeyCount
-  sL: number, // sessionLengthMs
+  sL?: number, // sessionLengthMs
   eQ: number, // eventsQueued
   eD: number, // eventsDropped
   sE: Array<StreamingEvent>, // streamingEvents
@@ -180,7 +180,7 @@ export type TelemetryConfigStatsPayload = {
   aF: number, // activeFactories
   rF: number, // redundantActiveFactories
   tR: number, // timeUntilSDKReady
-  tC: number, // timeUntilSDKReadyFromCache
+  tC?: number, // timeUntilSDKReadyFromCache
   nR: number, // SDKNotReadyUsage
   t?: Array<string>, // tags
   i?: Array<string>, // integrations

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -36,10 +36,6 @@ export interface ISyncTask<Input extends any[] = [], Output = any> extends ITask
   isExecuting(): boolean
 }
 
-export interface ITimeTracker {
-  start(): () => void // start tracking time and return a function to call for stopping the tracking
-}
-
 /** SyncManager */
 
 export interface ISyncManager extends ITask {

--- a/src/trackers/eventTracker.ts
+++ b/src/trackers/eventTracker.ts
@@ -1,6 +1,6 @@
 import { objectAssign } from '../utils/lang/objectAssign';
 import { thenable } from '../utils/promise/thenable';
-import { IEventsCacheBase, TelemetryCacheAsync, TelemetryCacheSync } from '../storages/types';
+import { IEventsCacheBase, ITelemetryCacheAsync, ITelemetryCacheSync } from '../storages/types';
 import { IEventsHandler, IEventTracker } from './types';
 import { ISettings, SplitIO } from '../types';
 import { EVENTS_TRACKER_SUCCESS, ERROR_EVENTS_TRACKER } from '../logger/constants';
@@ -17,7 +17,7 @@ export function eventTrackerFactory(
   settings: ISettings,
   eventsCache: IEventsCacheBase,
   integrationsManager?: IEventsHandler,
-  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync
+  telemetryCache?: ITelemetryCacheSync | ITelemetryCacheAsync
 ): IEventTracker {
 
   const log = settings.log;
@@ -60,7 +60,7 @@ export function eventTrackerFactory(
       } else {
         // Record when eventsCache is sync only (standalone mode)
         // @TODO we are not dropping events on full queue yet, so `tracked` is always true ATM
-        if (telemetryCache) (telemetryCache as TelemetryCacheSync).recordEventStats(tracked ? QUEUED : DROPPED, 1);
+        if (telemetryCache) (telemetryCache as ITelemetryCacheSync).recordEventStats(tracked ? QUEUED : DROPPED, 1);
         return queueEventsCallback(eventData, tracked);
       }
     }

--- a/src/trackers/impressionsTracker.ts
+++ b/src/trackers/impressionsTracker.ts
@@ -1,7 +1,7 @@
 import { objectAssign } from '../utils/lang/objectAssign';
 import { thenable } from '../utils/promise/thenable';
 import { truncateTimeFrame } from '../utils/time';
-import { IImpressionCountsCacheSync, IImpressionsCacheBase, TelemetryCacheSync, TelemetryCacheAsync } from '../storages/types';
+import { IImpressionCountsCacheSync, IImpressionsCacheBase, ITelemetryCacheSync, ITelemetryCacheAsync } from '../storages/types';
 import { IImpressionsHandler, IImpressionsTracker } from './types';
 import { SplitIO, ImpressionDTO, ISettings } from '../types';
 import { IImpressionObserver } from './impressionObserver/types';
@@ -26,7 +26,7 @@ export function impressionsTrackerFactory(
   observer?: IImpressionObserver,
   // if countsCache is provided, it implies `isOptimized` flag (i.e., if impressions should be deduped or not)
   countsCache?: IImpressionCountsCacheSync,
-  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync
+  telemetryCache?: ITelemetryCacheSync | ITelemetryCacheAsync
 ): IImpressionsTracker {
 
   const { log, impressionListener, runtime: { ip, hostname }, version } = settings;
@@ -70,8 +70,8 @@ export function impressionsTrackerFactory(
         // Record when impressionsCache is sync only (standalone mode)
         // @TODO we are not dropping impressions on full queue yet, so DROPPED stats are not recorded
         if (telemetryCache) {
-          (telemetryCache as TelemetryCacheSync).recordImpressionStats(QUEUED, impressionsToStore.length);
-          (telemetryCache as TelemetryCacheSync).recordImpressionStats(DEDUPED, impressions.length - impressionsToStore.length);
+          (telemetryCache as ITelemetryCacheSync).recordImpressionStats(QUEUED, impressionsToStore.length);
+          (telemetryCache as ITelemetryCacheSync).recordImpressionStats(DEDUPED, impressions.length - impressionsToStore.length);
         }
       }
 

--- a/src/trackers/telemetryTracker.ts
+++ b/src/trackers/telemetryTracker.ts
@@ -1,11 +1,11 @@
-import { TelemetryCacheSync, TelemetryCacheAsync } from '../storages/types';
+import { ITelemetryCacheSync, ITelemetryCacheAsync } from '../storages/types';
 import { EXCEPTION, SDK_NOT_READY } from '../utils/labels';
 import { ITelemetryTracker } from './types';
 import { timer } from '../utils/timeTracker/timer';
 import { TOKEN_REFRESH, AUTH_REJECTION } from '../utils/constants';
 
 export function telemetryTrackerFactory(
-  telemetryCache?: TelemetryCacheSync | TelemetryCacheAsync,
+  telemetryCache?: ITelemetryCacheSync | ITelemetryCacheAsync,
   now?: () => number
 ): ITelemetryTracker {
 
@@ -21,7 +21,7 @@ export function telemetryTrackerFactory(
             case EXCEPTION:
               telemetryCache.recordException(method);
               return; // Don't track latency on exceptions
-            case SDK_NOT_READY: // @ts-ignore. TelemetryCacheAsync doesn't implement the method
+            case SDK_NOT_READY: // @ts-ignore ITelemetryCacheAsync doesn't implement the method
               telemetryCache?.recordNonReadyUsage();
           }
           telemetryCache.recordLatency(method, evalTime());
@@ -31,22 +31,22 @@ export function telemetryTrackerFactory(
         const httpTime = timer(now);
 
         return (error) => {
-          (telemetryCache as TelemetryCacheSync).recordHttpLatency(operation, httpTime());
-          if (error && error.statusCode) (telemetryCache as TelemetryCacheSync).recordHttpError(operation, error.statusCode);
-          else (telemetryCache as TelemetryCacheSync).recordSuccessfulSync(operation, now());
+          (telemetryCache as ITelemetryCacheSync).recordHttpLatency(operation, httpTime());
+          if (error && error.statusCode) (telemetryCache as ITelemetryCacheSync).recordHttpError(operation, error.statusCode);
+          else (telemetryCache as ITelemetryCacheSync).recordSuccessfulSync(operation, now());
         };
       },
       sessionLength() {
-        (telemetryCache as TelemetryCacheSync).recordSessionLength(startTime());
+        (telemetryCache as ITelemetryCacheSync).recordSessionLength(startTime());
       },
       streamingEvent(e, d) {
         if (e === AUTH_REJECTION) {
-          (telemetryCache as TelemetryCacheSync).recordAuthRejections();
+          (telemetryCache as ITelemetryCacheSync).recordAuthRejections();
         } else {
-          (telemetryCache as TelemetryCacheSync).recordStreamingEvents({
+          (telemetryCache as ITelemetryCacheSync).recordStreamingEvents({
             e, d, t: now()
           });
-          if (e === TOKEN_REFRESH) (telemetryCache as TelemetryCacheSync).recordTokenRefreshes();
+          if (e === TOKEN_REFRESH) (telemetryCache as ITelemetryCacheSync).recordTokenRefreshes();
         }
       }
     };


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added `telemetrySubmitter` to post `metrics/usage` data periodically.
- Refactors: 
  - Renamed some files: `impressions|eventsSyncTask` --> `impressions|eventsSubmitter`
  - Extracted `firstPushWindow` logic into a decorator function, to be reused by `eventsSubmitter` and `telemetrySubmitter`

## How do we test the changes introduced in this PR?

- Unit tests.

## Extra Notes