### PR TITLE
[CDN Bypass] Update service API and fetchers

### DIFF
--- a/src/services/__tests__/splitApi.spec.ts
+++ b/src/services/__tests__/splitApi.spec.ts
@@ -24,17 +24,25 @@ describe('splitApi', () => {
     const fetchMock = jest.fn(() => Promise.resolve({ ok: true }));
     const splitApi = splitApiFactory(settings, { getFetch: () => fetchMock }, telemetryTrackerMock);
 
-    splitApi.fetchAuth();
-    assertHeaders(settings, fetchMock.mock.calls[0][1].headers);
+    splitApi.fetchAuth(['key1', 'key2']);
+    let [url, { headers }] = fetchMock.mock.calls[0];
+    assertHeaders(settings, headers);
+    expect(url).toBe('auth/v2/auth?users=key1&users=key2');
 
     splitApi.fetchMySegments('userKey');
-    assertHeaders(settings, fetchMock.mock.calls[1][1].headers);
+    [url, { headers }] = fetchMock.mock.calls[1];
+    assertHeaders(settings, headers);
+    expect(url).toBe('sdk/mySegments/userKey');
 
-    splitApi.fetchSegmentChanges(-1, 'segmentName');
-    assertHeaders(settings, fetchMock.mock.calls[2][1].headers);
+    splitApi.fetchSegmentChanges(-1, 'segmentName', false, 90);
+    [url, { headers }] = fetchMock.mock.calls[2];
+    assertHeaders(settings, headers);
+    expect(url).toBe('sdk/segmentChanges/segmentName?since=-1&till=90');
 
-    splitApi.fetchSplitChanges(-1);
-    assertHeaders(settings, fetchMock.mock.calls[3][1].headers);
+    splitApi.fetchSplitChanges(-1, false, 100);
+    [url, { headers }] = fetchMock.mock.calls[3];
+    assertHeaders(settings, headers);
+    expect(url).toBe('sdk/splitChanges?since=-1&till=100');
 
     splitApi.postEventsBulk('fake-body');
     assertHeaders(settings, fetchMock.mock.calls[4][1].headers);

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -50,13 +50,13 @@ export function splitApiFactory(
       return splitHttpClient(url, undefined, telemetryTracker.trackHttp(TOKEN));
     },
 
-    fetchSplitChanges(since: number, noCache?: boolean) {
-      const url = `${urls.sdk}/splitChanges?since=${since}${filterQueryString || ''}`;
+    fetchSplitChanges(since: number, noCache?: boolean, till?: number) {
+      const url = `${urls.sdk}/splitChanges?since=${since}${till ? + '&till=' + till : ''}${filterQueryString || ''}`;
       return splitHttpClient(url, noCache ? noCacheHeaderOptions : undefined, telemetryTracker.trackHttp(SPLITS));
     },
 
-    fetchSegmentChanges(since: number, segmentName: string, noCache?: boolean) {
-      const url = `${urls.sdk}/segmentChanges/${segmentName}?since=${since}`;
+    fetchSegmentChanges(since: number, segmentName: string, noCache?: boolean, till?: number) {
+      const url = `${urls.sdk}/segmentChanges/${segmentName}?since=${since}${till ? + '&till=' + till : ''}`;
       return splitHttpClient(url, noCache ? noCacheHeaderOptions : undefined, telemetryTracker.trackHttp(SEGMENT));
     },
 

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -51,12 +51,12 @@ export function splitApiFactory(
     },
 
     fetchSplitChanges(since: number, noCache?: boolean, till?: number) {
-      const url = `${urls.sdk}/splitChanges?since=${since}${till ? + '&till=' + till : ''}${filterQueryString || ''}`;
+      const url = `${urls.sdk}/splitChanges?since=${since}${till ? '&till=' + till : ''}${filterQueryString || ''}`;
       return splitHttpClient(url, noCache ? noCacheHeaderOptions : undefined, telemetryTracker.trackHttp(SPLITS));
     },
 
     fetchSegmentChanges(since: number, segmentName: string, noCache?: boolean, till?: number) {
-      const url = `${urls.sdk}/segmentChanges/${segmentName}?since=${since}${till ? + '&till=' + till : ''}`;
+      const url = `${urls.sdk}/segmentChanges/${segmentName}?since=${since}${till ? '&till=' + till : ''}`;
       return splitHttpClient(url, noCache ? noCacheHeaderOptions : undefined, telemetryTracker.trackHttp(SEGMENT));
     },
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -35,9 +35,9 @@ export type ISplitHttpClient = (url: string, options?: IRequestOptions, latencyT
 
 export type IFetchAuth = (userKeys?: string[]) => Promise<IResponse>
 
-export type IFetchSplitChanges = (since: number, noCache?: boolean) => Promise<IResponse>
+export type IFetchSplitChanges = (since: number, noCache?: boolean, till?: number) => Promise<IResponse>
 
-export type IFetchSegmentChanges = (since: number, segmentName: string, noCache?: boolean) => Promise<IResponse>
+export type IFetchSegmentChanges = (since: number, segmentName: string, noCache?: boolean, till?: number) => Promise<IResponse>
 
 export type IFetchMySegments = (userMatchingKey: string, noCache?: boolean) => Promise<IResponse>
 

--- a/src/sync/polling/fetchers/segmentChangesFetcher.ts
+++ b/src/sync/polling/fetchers/segmentChangesFetcher.ts
@@ -27,9 +27,9 @@ export function segmentChangesFetcherFactory(fetchSegmentChanges: IFetchSegmentC
     since: number,
     segmentName: string,
     noCache?: boolean,
+    till?: number,
     // Optional decorator for `fetchMySegments` promise, such as timeout or time tracker
-    decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>,
-    till?: number
+    decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>
   ): Promise<ISegmentChangesResponse[]> {
 
     let segmentsPromise = greedyFetch(fetchSegmentChanges, since, segmentName, noCache, till);

--- a/src/sync/polling/fetchers/segmentChangesFetcher.ts
+++ b/src/sync/polling/fetchers/segmentChangesFetcher.ts
@@ -2,15 +2,15 @@ import { IFetchSegmentChanges } from '../../../services/types';
 import { ISegmentChangesResponse } from '../../../dtos/types';
 import { ISegmentChangesFetcher } from './types';
 
-function greedyFetch(fetchSegmentChanges: IFetchSegmentChanges, since: number, segmentName: string, noCache?: boolean): Promise<ISegmentChangesResponse[]> {
-  return fetchSegmentChanges(since, segmentName, noCache)
+function greedyFetch(fetchSegmentChanges: IFetchSegmentChanges, since: number, segmentName: string, noCache?: boolean, targetTill?: number): Promise<ISegmentChangesResponse[]> {
+  return fetchSegmentChanges(since, segmentName, noCache, targetTill)
     .then(resp => resp.json())
     .then((json: ISegmentChangesResponse) => {
       let { since, till } = json;
       if (since === till) {
         return [json];
       } else {
-        return Promise.all([json, greedyFetch(fetchSegmentChanges, till, segmentName, noCache)]).then(flatMe => {
+        return Promise.all([json, greedyFetch(fetchSegmentChanges, till, segmentName, noCache, targetTill)]).then(flatMe => {
           return [flatMe[0], ...flatMe[1]];
         });
       }
@@ -28,10 +28,11 @@ export function segmentChangesFetcherFactory(fetchSegmentChanges: IFetchSegmentC
     segmentName: string,
     noCache?: boolean,
     // Optional decorator for `fetchMySegments` promise, such as timeout or time tracker
-    decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>
+    decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>,
+    till?: number
   ): Promise<ISegmentChangesResponse[]> {
 
-    let segmentsPromise = greedyFetch(fetchSegmentChanges, since, segmentName, noCache);
+    let segmentsPromise = greedyFetch(fetchSegmentChanges, since, segmentName, noCache, till);
     if (decorator) segmentsPromise = decorator(segmentsPromise);
 
     return segmentsPromise;

--- a/src/sync/polling/fetchers/splitChangesFetcher.ts
+++ b/src/sync/polling/fetchers/splitChangesFetcher.ts
@@ -11,10 +11,11 @@ export function splitChangesFetcherFactory(fetchSplitChanges: IFetchSplitChanges
     since: number,
     noCache?: boolean,
     // Optional decorator for `fetchSplitChanges` promise, such as timeout or time tracker
-    decorator?: (promise: Promise<IResponse>) => Promise<IResponse>
+    decorator?: (promise: Promise<IResponse>) => Promise<IResponse>,
+    till?: number
   ) {
 
-    let splitsPromise = fetchSplitChanges(since, noCache);
+    let splitsPromise = fetchSplitChanges(since, noCache, till);
     if (decorator) splitsPromise = decorator(splitsPromise);
 
     return splitsPromise.then(resp => resp.json());

--- a/src/sync/polling/fetchers/splitChangesFetcher.ts
+++ b/src/sync/polling/fetchers/splitChangesFetcher.ts
@@ -10,9 +10,9 @@ export function splitChangesFetcherFactory(fetchSplitChanges: IFetchSplitChanges
   return function splitChangesFetcher(
     since: number,
     noCache?: boolean,
+    till?: number,
     // Optional decorator for `fetchSplitChanges` promise, such as timeout or time tracker
-    decorator?: (promise: Promise<IResponse>) => Promise<IResponse>,
-    till?: number
+    decorator?: (promise: Promise<IResponse>) => Promise<IResponse>
   ) {
 
     let splitsPromise = fetchSplitChanges(since, noCache, till);

--- a/src/sync/polling/fetchers/types.ts
+++ b/src/sync/polling/fetchers/types.ts
@@ -4,16 +4,16 @@ import { IResponse } from '../../../services/types';
 export type ISplitChangesFetcher = (
   since: number,
   noCache?: boolean,
-  decorator?: (promise: Promise<IResponse>) => Promise<IResponse>,
-  till?: number
+  till?: number,
+  decorator?: (promise: Promise<IResponse>) => Promise<IResponse>
 ) => Promise<ISplitChangesResponse>
 
 export type ISegmentChangesFetcher = (
   since: number,
   segmentName: string,
   noCache?: boolean,
-  decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>,
-  till?: number
+  till?: number,
+  decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>
 ) => Promise<ISegmentChangesResponse[]>
 
 export type IMySegmentsFetcher = (

--- a/src/sync/polling/fetchers/types.ts
+++ b/src/sync/polling/fetchers/types.ts
@@ -4,14 +4,16 @@ import { IResponse } from '../../../services/types';
 export type ISplitChangesFetcher = (
   since: number,
   noCache?: boolean,
-  decorator?: (promise: Promise<IResponse>) => Promise<IResponse>
+  decorator?: (promise: Promise<IResponse>) => Promise<IResponse>,
+  till?: number
 ) => Promise<ISplitChangesResponse>
 
 export type ISegmentChangesFetcher = (
   since: number,
   segmentName: string,
   noCache?: boolean,
-  decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>
+  decorator?: (promise: Promise<ISegmentChangesResponse[]>) => Promise<ISegmentChangesResponse[]>,
+  till?: number
 ) => Promise<ISegmentChangesResponse[]>
 
 export type IMySegmentsFetcher = (

--- a/src/sync/polling/updaters/splitChangesUpdater.ts
+++ b/src/sync/polling/updaters/splitChangesUpdater.ts
@@ -8,7 +8,7 @@ import { SDK_SPLITS_ARRIVED, SDK_SPLITS_CACHE_LOADED } from '../../../readiness/
 import { ILogger } from '../../../logger/types';
 import { SYNC_SPLITS_FETCH, SYNC_SPLITS_NEW, SYNC_SPLITS_REMOVED, SYNC_SPLITS_SEGMENTS, SYNC_SPLITS_FETCH_FAILS, SYNC_SPLITS_FETCH_RETRY } from '../../../logger/constants';
 
-type ISplitChangesUpdater = (noCache?: boolean) => Promise<boolean>
+type ISplitChangesUpdater = (noCache?: boolean, till?: number) => Promise<boolean>
 
 // Checks that all registered segments have been fetched (changeNumber !== -1 for every segment).
 // Returns a promise that could be rejected.
@@ -119,7 +119,7 @@ export function splitChangesUpdaterFactory(
     function _splitChangesUpdater(since: number, retry = 0): Promise<boolean> {
       log.debug(SYNC_SPLITS_FETCH, [since]);
 
-      const fetcherPromise = splitChangesFetcher(since, noCache, _promiseDecorator)
+      const fetcherPromise = splitChangesFetcher(since, noCache, undefined, _promiseDecorator)
         .then((splitChanges: ISplitChangesResponse) => {
           startingUp = false;
 


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Update Service API and fetchers for splits and segment changes, to support the `till` query param.

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes