### PR TITLE
[CDN Bypass] SplitChanges retries and bypass

### DIFF
--- a/src/sync/polling/types.ts
+++ b/src/sync/polling/types.ts
@@ -3,7 +3,7 @@ import { IStorageSync } from '../../storages/types';
 import { SegmentsData } from '../streaming/SSEHandler/types';
 import { ITask, ISyncTask } from '../types';
 
-export interface ISplitsSyncTask extends ISyncTask<[noCache?: boolean], boolean> { }
+export interface ISplitsSyncTask extends ISyncTask<[noCache?: boolean, till?: number], boolean> { }
 
 export interface ISegmentsSyncTask extends ISyncTask<[segmentNames?: SegmentsData, noCache?: boolean, fetchOnlyNew?: boolean], boolean> { }
 

--- a/src/sync/polling/updaters/splitChangesUpdater.ts
+++ b/src/sync/polling/updaters/splitChangesUpdater.ts
@@ -109,8 +109,9 @@ export function splitChangesUpdaterFactory(
    * Returned promise will not be rejected.
    *
    * @param {boolean | undefined} noCache true to revalidate data to fetch
+   * @param {boolean | undefined} till query param to bypass CDN requests
    */
-  return function splitChangesUpdater(noCache?: boolean) {
+  return function splitChangesUpdater(noCache?: boolean, till?: number) {
 
     /**
      * @param {number} since current changeNumber at splitsCache
@@ -119,7 +120,7 @@ export function splitChangesUpdaterFactory(
     function _splitChangesUpdater(since: number, retry = 0): Promise<boolean> {
       log.debug(SYNC_SPLITS_FETCH, [since]);
 
-      const fetcherPromise = splitChangesFetcher(since, noCache, undefined, _promiseDecorator)
+      const fetcherPromise = splitChangesFetcher(since, noCache, till, _promiseDecorator)
         .then((splitChanges: ISplitChangesResponse) => {
           startingUp = false;
 

--- a/src/sync/streaming/UpdateWorkers/__tests__/SplitsUpdateWorker.spec.ts
+++ b/src/sync/streaming/UpdateWorkers/__tests__/SplitsUpdateWorker.spec.ts
@@ -2,13 +2,16 @@
 import { SDK_SPLITS_ARRIVED } from '../../../../readiness/constants';
 import { SplitsCacheInMemory } from '../../../../storages/inMemory/SplitsCacheInMemory';
 import { SplitsUpdateWorker } from '../SplitsUpdateWorker';
+import { FETCH_BACKOFF_MAX_RETRIES } from '../constants';
+import { loggerMock } from '../../../../logger/__tests__/sdkLogger.mock';
 
-function splitsSyncTaskMock(splitStorage) {
+function splitsSyncTaskMock(splitStorage, changeNumbers: number[]) {
 
   const __splitsUpdaterCalls = [];
 
-  function __splitsUpdater() {
-    return new Promise((res, rej) => { __splitsUpdaterCalls.push({ res, rej }); });
+  function __resolveSplitsUpdaterCall(changeNumber) {
+    splitStorage.setChangeNumber(changeNumber); // update changeNumber in storage
+    __splitsUpdaterCalls.shift().res(); // resolve `execute` call
   }
 
   let __isSynchronizingSplits = false;
@@ -19,7 +22,10 @@ function splitsSyncTaskMock(splitStorage) {
 
   function execute() {
     __isSynchronizingSplits = true;
-    return __splitsUpdater().then(function () {
+    return new Promise((res) => {
+      __splitsUpdaterCalls.push({ res });
+      if (changeNumbers && changeNumbers.length) __resolveSplitsUpdaterCall(changeNumbers.shift());
+    }).then(function () {
     }).finally(function () {
       __isSynchronizingSplits = false;
     });
@@ -29,10 +35,7 @@ function splitsSyncTaskMock(splitStorage) {
     isExecuting: jest.fn(isExecuting),
     execute: jest.fn(execute),
 
-    __resolveSplitsUpdaterCall(index, changeNumber) {
-      splitStorage.setChangeNumber(changeNumber); // update changeNumber in storage
-      __splitsUpdaterCalls[index].res(); // resolve previous call
-    },
+    __resolveSplitsUpdaterCall
   };
 }
 
@@ -49,13 +52,13 @@ function assertKilledSplit(cache, changeNumber, splitName, defaultTreatment) {
 
 describe('SplitsUpdateWorker', () => {
 
-  test('put', (done) => {
+  test('put', async () => {
 
     // setup
     const cache = new SplitsCacheInMemory();
     const splitsSyncTask = splitsSyncTaskMock(cache);
 
-    const splitUpdateWorker = new SplitsUpdateWorker(cache, splitsSyncTask);
+    const splitUpdateWorker = new SplitsUpdateWorker(loggerMock, cache, splitsSyncTask);
     splitUpdateWorker.backoff.baseMillis = 0; // retry immediately
 
     expect(splitUpdateWorker.maxChangeNumber).toBe(0); // inits with not queued changeNumber (maxChangeNumber equals to 0)
@@ -76,44 +79,82 @@ describe('SplitsUpdateWorker', () => {
     expect(splitUpdateWorker.maxChangeNumber).toBe(106); // queues changeNumber if it is mayor than currently maxChangeNumber and storage changeNumber
 
     // assert calling `splitsSyncTask.execute` if previous call is resolved and a new changeNumber in queue
-    splitsSyncTask.__resolveSplitsUpdaterCall(0, 100);
-    setTimeout(() => {
-      expect(splitsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes splits if `isExecuting` is false and queue is not empty
-      expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
-      expect(splitUpdateWorker.backoff.attempts).toBe(0); // no retry scheduled if synchronization success (changeNumber is the expected)
+    splitsSyncTask.__resolveSplitsUpdaterCall(100);
 
-      // assert reschedule synchronization if changeNumber is not updated as expected
-      splitsSyncTask.__resolveSplitsUpdaterCall(1, 100);
-      setTimeout(() => {
-        expect(splitsSyncTask.execute).toBeCalledTimes(3); // re-synchronizes splits if synchronization fail (changeNumber is not the expected)
-        expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
-        expect(splitUpdateWorker.backoff.attempts).toBe(1); // retry scheduled if synchronization fail (changeNumber is not the expected)
+    await new Promise(res => setTimeout(res));
+    expect(splitsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes splits if `isExecuting` is false and queue is not empty
+    expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
+    expect(splitUpdateWorker.backoff.attempts).toBe(0); // no retry scheduled if synchronization success (changeNumber is the expected)
 
-        // assert dequeueing changeNumber
-        splitsSyncTask.__resolveSplitsUpdaterCall(2, 106);
-        setTimeout(() => {
-          expect(splitsSyncTask.execute).toBeCalledTimes(3); // doesn't synchronize splits again
-          expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
+    // assert reschedule synchronization if changeNumber is not updated as expected
+    splitsSyncTask.__resolveSplitsUpdaterCall(100);
+    await new Promise(res => setTimeout(res, 10)); // wait a little bit until `splitsSyncTask.execute` is called in next event-loop cycle
+    expect(splitsSyncTask.execute).toBeCalledTimes(3); // re-synchronizes splits if synchronization fail (changeNumber is not the expected)
+    expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
+    expect(splitUpdateWorker.backoff.attempts).toBe(1); // retry scheduled if synchronization fail (changeNumber is not the expected)
 
-          // assert restarting retries, when a newer event is queued
-          splitUpdateWorker.put({ changeNumber: 107 }); // queued
-          expect(splitUpdateWorker.backoff.attempts).toBe(0); // backoff scheduler for retries is reset if a new event is queued
+    // assert dequeueing changeNumber
+    splitsSyncTask.__resolveSplitsUpdaterCall(106);
+    await new Promise(res => setTimeout(res));
+    expect(splitsSyncTask.execute).toBeCalledTimes(3); // doesn't synchronize splits again
+    expect(splitUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
 
-          done();
-        });
+    // assert restarting retries, when a newer event is queued
+    splitUpdateWorker.put({ changeNumber: 107 }); // queued
+    expect(splitUpdateWorker.backoff.attempts).toBe(0); // backoff scheduler for retries is reset if a new event is queued
 
-      }, 10); // wait a little bit until `splitsSyncTask.execute` is called in next event-loop cycle
-    });
+    expect(loggerMock.debug).lastCalledWith('Refresh completed in 2 attempts.');
   });
 
-  test('killSplit', (done) => {
+  test('put, completed with CDN bypass', async () => {
+
+    // setup
+    const cache = new SplitsCacheInMemory();
+    const splitsSyncTask = splitsSyncTaskMock(cache, [...Array(FETCH_BACKOFF_MAX_RETRIES).fill(90), 90, 100]); // 12 executions. Last one is valid
+    const splitUpdateWorker = new SplitsUpdateWorker(loggerMock, cache, splitsSyncTask);
+    splitUpdateWorker.backoff.baseMillis /= 1000; // 10 millis instead of 10 sec
+    splitUpdateWorker.backoff.maxMillis /= 1000; // 60 millis instead of 1 min
+
+    splitUpdateWorker.put({ changeNumber: 100 }); // queued
+
+    await new Promise(res => setTimeout(res, 540)); // 440 + some delay
+
+    expect(loggerMock.debug).lastCalledWith('Refresh completed bypassing the CDN in 2 attempts.');
+    expect(splitsSyncTask.execute.mock.calls).toEqual([
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, undefined]),
+      [true, 100], [true, 100],
+    ]); // `execute` was called 12 times. Last 2 with CDN bypass
+  });
+
+
+  test('put, not completed with CDN bypass', async () => {
+
+    // setup
+    const cache = new SplitsCacheInMemory();
+    const splitsSyncTask = splitsSyncTaskMock(cache, Array(FETCH_BACKOFF_MAX_RETRIES * 2).fill(90)); // 20 executions. No one is valid
+    const splitUpdateWorker = new SplitsUpdateWorker(loggerMock, cache, splitsSyncTask);
+    splitUpdateWorker.backoff.baseMillis /= 1000; // 10 millis instead of 10 sec
+    splitUpdateWorker.backoff.maxMillis /= 1000; // 60 millis instead of 1 min
+
+    splitUpdateWorker.put({ changeNumber: 100 }); // queued
+
+    await new Promise(res => setTimeout(res, 960)); // 860 + some delay
+
+    expect(loggerMock.debug).lastCalledWith('No changes fetched after 10 attempts with CDN bypassed.');
+    expect(splitsSyncTask.execute.mock.calls).toEqual([
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, undefined]),
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, 100]),
+    ]); // `execute` was called 20 times. Last 10 with CDN bypass
+  });
+
+  test('killSplit', async () => {
     // setup
     const cache = new SplitsCacheInMemory();
     cache.addSplit('lol1', '{ "name": "something"}');
     cache.addSplit('lol2', '{ "name": "something else"}');
 
     const splitsSyncTask = splitsSyncTaskMock(cache);
-    const splitUpdateWorker = new SplitsUpdateWorker(cache, splitsSyncTask, splitsEventEmitterMock);
+    const splitUpdateWorker = new SplitsUpdateWorker(loggerMock, cache, splitsSyncTask, splitsEventEmitterMock);
 
     // assert killing split locally, emitting SDK_SPLITS_ARRIVED event, and synchronizing splits if changeNumber is new
     splitUpdateWorker.killSplit({ changeNumber: 100, splitName: 'lol1', defaultTreatment: 'off' }); // splitsCache.killLocally is synchronous
@@ -123,21 +164,18 @@ describe('SplitsUpdateWorker', () => {
     assertKilledSplit(cache, 100, 'lol1', 'off');
 
     // assert not killing split locally, not emitting SDK_SPLITS_ARRIVED event, and not synchronizes splits, if changeNumber is old
-    splitsSyncTask.__resolveSplitsUpdaterCall(0, 100);
-    setTimeout(() => {
-      splitsSyncTask.execute.mockClear();
-      splitsEventEmitterMock.emit.mockClear();
-      splitUpdateWorker.killSplit({ changeNumber: 90, splitName: 'lol1', defaultTreatment: 'on' });
+    splitsSyncTask.__resolveSplitsUpdaterCall(100);
+    await new Promise(res => setTimeout(res));
+    splitsSyncTask.execute.mockClear();
+    splitsEventEmitterMock.emit.mockClear();
+    splitUpdateWorker.killSplit({ changeNumber: 90, splitName: 'lol1', defaultTreatment: 'on' });
 
-      setTimeout(() => {
-        expect(splitUpdateWorker.maxChangeNumber).toBe(100); // doesn't queues changeNumber if killLocally resolved without update (its changeNumber was minor than the split changeNumber
-        expect(splitsSyncTask.execute).toBeCalledTimes(0); // doesn't synchronize splits if killLocally resolved without update
-        expect(splitsEventEmitterMock.emit).toBeCalledTimes(0); // doesn't emit `SDK_SPLITS_ARRIVED` if killLocally resolved without update
+    await new Promise(res => setTimeout(res));
+    expect(splitUpdateWorker.maxChangeNumber).toBe(100); // doesn't queues changeNumber if killLocally resolved without update (its changeNumber was minor than the split changeNumber
+    expect(splitsSyncTask.execute).toBeCalledTimes(0); // doesn't synchronize splits if killLocally resolved without update
+    expect(splitsEventEmitterMock.emit).toBeCalledTimes(0); // doesn't emit `SDK_SPLITS_ARRIVED` if killLocally resolved without update
 
-        assertKilledSplit(cache, 100, 'lol1', 'off'); // calling `killLocally` with an old changeNumber made no effect
-        done();
-      });
-    });
+    assertKilledSplit(cache, 100, 'lol1', 'off'); // calling `killLocally` with an old changeNumber made no effect
   });
 
 });

--- a/src/sync/streaming/UpdateWorkers/constants.ts
+++ b/src/sync/streaming/UpdateWorkers/constants.ts
@@ -1,0 +1,3 @@
+export const FETCH_BACKOFF_BASE = 10000;  // backoff base starting at 10 seconds
+export const FETCH_BACKOFF_MAX_WAIT = 60000;  // don't wait for more than 1 minute
+export const FETCH_BACKOFF_MAX_RETRIES = 10; // max retries

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -57,7 +57,7 @@ export function pushManagerFactory(
   // MySegmentsUpdateWorker (client-side) are initiated in `add` method
   const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(pollingManager.segmentsSyncTask, storage.segments);
   // For server-side we pass the segmentsSyncTask, used by SplitsUpdateWorker to fetch new segments
-  const splitsUpdateWorker = new SplitsUpdateWorker(storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask);
+  const splitsUpdateWorker = new SplitsUpdateWorker(log, storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask);
 
   // [Only for client-side] map of hashes to user keys, to dispatch MY_SEGMENTS_UPDATE events to the corresponding MySegmentsUpdateWorker
   const userKeyHashes: Record<string, string> = {};


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Updated retry logic of SplitsUpdateWorker, including CDN bypass.

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes