### PR TITLE
[CDN Bypass] Update on segmentChangesUpdater (granularity per segment)

### DIFF
--- a/src/sync/polling/syncTasks/segmentsSyncTask.ts
+++ b/src/sync/polling/syncTasks/segmentsSyncTask.ts
@@ -6,6 +6,7 @@ import { segmentChangesFetcherFactory } from '../fetchers/segmentChangesFetcher'
 import { IFetchSegmentChanges } from '../../../services/types';
 import { ISettings } from '../../../types';
 import { segmentChangesUpdaterFactory } from '../updaters/segmentChangesUpdater';
+import { objectAssign } from '../../../utils/lang/objectAssign';
 
 /**
  * Creates a sync task that periodically executes a `segmentChangesUpdater` task
@@ -16,15 +17,18 @@ export function segmentsSyncTaskFactory(
   readiness: IReadinessManager,
   settings: ISettings,
 ): ISegmentsSyncTask {
-  return syncTaskFactory(
+
+  const segmentChangesUpdater = segmentChangesUpdaterFactory(
     settings.log,
-    segmentChangesUpdaterFactory(
-      settings.log,
-      segmentChangesFetcherFactory(fetchSegmentChanges),
-      storage.segments,
-      readiness,
-    ),
+    segmentChangesFetcherFactory(fetchSegmentChanges),
+    storage.segments,
+    readiness,
+  );
+
+  return objectAssign(syncTaskFactory(
+    settings.log,
+    segmentChangesUpdater.updateSegments,
     settings.scheduler.segmentsRefreshRate,
     'segmentChangesUpdater'
-  );
+  ), segmentChangesUpdater);
 }

--- a/src/sync/polling/types.ts
+++ b/src/sync/polling/types.ts
@@ -4,7 +4,9 @@ import { ITask, ISyncTask } from '../types';
 
 export interface ISplitsSyncTask extends ISyncTask<[noCache?: boolean, till?: number], boolean> { }
 
-export interface ISegmentsSyncTask extends ISyncTask<[segmentName?: string, noCache?: boolean, fetchOnlyNew?: boolean, till?: number], boolean> { }
+export interface ISegmentsSyncTask extends ISyncTask<[fetchOnlyNew?: boolean], boolean> {
+  updateSegment(segmentName: string): ISyncTask<[noCache?: boolean, fetchOnlyIfNew?: boolean, till?: number], number>
+}
 
 export type MySegmentsData = string[] | {
   /* segment name */
@@ -17,7 +19,7 @@ export interface IMySegmentsSyncTask extends ISyncTask<[segmentsData?: MySegment
 
 export interface IPollingManager extends ITask {
   syncAll(): Promise<any>
-  splitsSyncTask: ISyncTask
+  splitsSyncTask: ISplitsSyncTask
   segmentsSyncTask: ISyncTask
 }
 

--- a/src/sync/polling/types.ts
+++ b/src/sync/polling/types.ts
@@ -5,7 +5,7 @@ import { ITask, ISyncTask } from '../types';
 export interface ISplitsSyncTask extends ISyncTask<[noCache?: boolean, till?: number], boolean> { }
 
 export interface ISegmentsSyncTask extends ISyncTask<[fetchOnlyNew?: boolean], boolean> {
-  updateSegment(segmentName: string): ISyncTask<[noCache?: boolean, fetchOnlyIfNew?: boolean, till?: number], number>
+  updateSegment(segmentName: string, noCache?: boolean, fetchOnlyNew?: boolean, till?: number): Promise<number>
 }
 
 export type MySegmentsData = string[] | {

--- a/src/sync/polling/updaters/segmentChangesUpdater.ts
+++ b/src/sync/polling/updaters/segmentChangesUpdater.ts
@@ -7,8 +7,13 @@ import { SDK_SEGMENTS_ARRIVED } from '../../../readiness/constants';
 import { ILogger } from '../../../logger/types';
 import { LOG_PREFIX_INSTANTIATION, LOG_PREFIX_SYNC_SEGMENTS } from '../../../logger/constants';
 import { thenable } from '../../../utils/promise/thenable';
+import { ISyncTask } from '../../types';
+import { syncTaskFactory } from '../../syncTask';
 
-type ISegmentChangesUpdater = (segmentName?: string, noCache?: boolean, fetchOnlyNew?: boolean, till?: number) => Promise<boolean>
+type ISegmentChangesUpdater = {
+  updateSegment(segmentName: string): ISyncTask<[noCache?: boolean, fetchOnlyIfNew?: boolean, till?: number], number>
+  updateSegments(fetchOnlyNew?: boolean): Promise<boolean>,
+}
 
 /**
  * Factory of SegmentChanges updater, a task that:
@@ -30,79 +35,96 @@ export function segmentChangesUpdaterFactory(
 
   let readyOnAlreadyExistentState = true;
 
-  /**
-   * Segments updater returns a promise that resolves with a `false` boolean value if it fails at least to fetch a segment or synchronize it with the storage.
-   * Thus, a false result doesn't imply that SDK_SEGMENTS_ARRIVED was not emitted.
-   * Returned promise will not be rejected.
-   *
-   * @param {string | undefined} segmentName segment name to fetch. By passing `undefined` it fetches the list of segments registered at the storage
-   * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
-   * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists, i.e., which `changeNumber` is equal to -1.
-   * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
-   * @param {number | undefined} tills till target for the provided segmentName, for CDN bypass.
-   */
-  return function segmentChangesUpdater(segmentName?: string, noCache?: boolean, fetchOnlyNew?: boolean, till?: number) {
-    log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Started segments update`);
+  function segmentChangesUpdater(segmentName: string, noCache?: boolean, fetchOnlyIfNew?: boolean, till?: number): Promise<number> {
+    log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processing segment ${segmentName}`);
+    let sincePromise = Promise.resolve(segments.getChangeNumber(segmentName));
 
-    // If not a segment name provided, read list of available segments names to be updated.
-    let segmentsPromise = Promise.resolve(segmentName ? [segmentName] : segments.getRegisteredSegments());
+    return sincePromise.then(since => {
+      // if fetchOnlyNew flag, avoid processing already fetched segments
+      if (fetchOnlyIfNew && since !== -1) return -1;
 
-    return segmentsPromise.then(segmentNames => {
-      // Async fetchers are collected here.
-      const updaters: Promise<number>[] = [];
+      return segmentChangesFetcher(since, segmentName, noCache, till).then(function (changes) {
+        let changeNumber = -1;
+        const results: MaybeThenable<boolean | void>[] = [];
+        changes.forEach(x => {
+          if (x.added.length > 0) results.push(segments.addToSegment(segmentName, x.added));
+          if (x.removed.length > 0) results.push(segments.removeFromSegment(segmentName, x.removed));
+          if (x.added.length > 0 || x.removed.length > 0) {
+            results.push(segments.setChangeNumber(segmentName, x.till));
+            changeNumber = x.till;
+          }
 
-      for (let index = 0; index < segmentNames.length; index++) {
-        const segmentName = segmentNames[index];
-        log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processing segment ${segmentName}`);
-        let sincePromise = Promise.resolve(segments.getChangeNumber(segmentName));
-
-        updaters.push(sincePromise.then(since => {
-          // if fetchOnlyNew flag, avoid processing already fetched segments
-          if (fetchOnlyNew && since !== -1) return -1;
-
-          return segmentChangesFetcher(since, segmentName, noCache, till).then(function (changes) {
-            let changeNumber = -1;
-            const results: MaybeThenable<boolean | void>[] = [];
-            changes.forEach(x => {
-              if (x.added.length > 0) results.push(segments.addToSegment(segmentName, x.added));
-              if (x.removed.length > 0) results.push(segments.removeFromSegment(segmentName, x.removed));
-              if (x.added.length > 0 || x.removed.length > 0) {
-                results.push(segments.setChangeNumber(segmentName, x.till));
-                changeNumber = x.till;
-              }
-
-              log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`);
-            });
-            // If at least one storage operation result is a promise, join all in a single promise.
-            if (results.some(result => thenable(result))) return Promise.all(results).then(() => changeNumber);
-            return changeNumber;
-          });
-        }));
-
-      }
-
-      return Promise.all(updaters).then(shouldUpdateFlags => {
-        // if at least one segment fetch succeeded, mark segments ready
-        if (findIndex(shouldUpdateFlags, v => v !== -1) !== -1 || readyOnAlreadyExistentState) {
-          readyOnAlreadyExistentState = false;
-          if (readiness) readiness.segments.emit(SDK_SEGMENTS_ARRIVED);
-        }
-        return true;
+          log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`);
+        });
+        // If at least one storage operation result is a promise, join all in a single promise.
+        if (results.some(result => thenable(result))) return Promise.all(results).then(() => changeNumber);
+        return changeNumber;
       });
-    })
-      // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
-      .catch(error => {
-        if (error && error.statusCode === 403) {
-          // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
-          // @TODO although factory status is destroyed, synchronization is not stopped
-          if (readiness) readiness.destroy();
-          log.error(`${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an Api Key from the Split web console that is of type Server-side.`);
-        } else {
-          log.warn(`${LOG_PREFIX_SYNC_SEGMENTS}Error while doing fetch of segments. ${error}`);
+    });
+  }
+
+  const segmentsTasks: Record<string, ISyncTask<[noCache?: boolean, fetchOnlyIfNew?: boolean, till?: number], number>> = {};
+
+  function updateSegment(segmentName: string) {
+    return (segmentsTasks[segmentName] = segmentsTasks[segmentName] || syncTaskFactory(log /* @TODO dummy log */, segmentChangesUpdater.bind(null, segmentName)));
+  }
+
+  return {
+    /**
+     * Used by SegmentsUpdateWorker to update single segments (SEGMENT_UPDATE events).
+     *
+     * @param {string} segmentName segment to fetch.
+     * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
+     * @param {boolean | undefined} fetchOnlyIfNew if true, only fetch the segment if it doesn't exists (changeNumber is -1).
+     * @param {number | undefined} till till target for the provided segmentName, for CDN bypass.
+     */
+    updateSegment,
+
+    /**
+     * Used by pollingManager to update all segments on syncAll and periodic fetch, and by SplitsUpdateWorker to update new segments.
+     * Returns a promise that never rejects, and resolves with a `false` boolean value if it fails to fetch a segment or synchronize it with the storage.
+     *
+     * @param {boolean | undefined} fetchOnlyNew if true, only fetch the segments that not exists (changeNumber is -1).
+     * This param is used by SplitUpdateWorker on server-side SDK, to fetch new registered segments on SPLIT_UPDATE notifications.
+     */
+    updateSegments(fetchOnlyNew?: boolean) {
+      log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Started segments update`);
+
+      // read list of available segments names to be updated.
+      let segmentsPromise = Promise.resolve(segments.getRegisteredSegments());
+
+      return segmentsPromise.then(segmentNames => {
+        // Async fetchers are collected here.
+        const updaters: Promise<number>[] = [];
+
+        for (let index = 0; index < segmentNames.length; index++) {
+          const segmentName = segmentNames[index];
+          // if (!segmentsTasks[segmentName]) segmentsTasks[segmentName] = syncTaskFactory(log /* @TODO dummy log */, segmentChangesUpdater);
+          updaters.push(updateSegment(segmentName).execute(undefined, fetchOnlyNew, undefined));
         }
 
-        return false;
-      });
+        return Promise.all(updaters).then(shouldUpdateFlags => {
+          // if at least one segment fetch succeeded, mark segments ready
+          if (findIndex(shouldUpdateFlags, v => v !== -1) !== -1 || readyOnAlreadyExistentState) {
+            readyOnAlreadyExistentState = false;
+            if (readiness) readiness.segments.emit(SDK_SEGMENTS_ARRIVED);
+          }
+          return true;
+        });
+      })
+        // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
+        .catch(error => {
+          if (error && error.statusCode === 403) {
+            // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
+            // @TODO although factory status is destroyed, synchronization is not stopped
+            if (readiness) readiness.destroy();
+            log.error(`${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an Api Key from the Split web console that is of type Server-side.`);
+          } else {
+            log.warn(`${LOG_PREFIX_SYNC_SEGMENTS}Error while doing fetch of segments. ${error}`);
+          }
+
+          return false;
+        });
+    }
   };
-
 }

--- a/src/sync/streaming/UpdateWorkers/SegmentsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/SegmentsUpdateWorker.ts
@@ -6,116 +6,88 @@ import { ISegmentUpdateData } from '../SSEHandler/types';
 import { FETCH_BACKOFF_BASE, FETCH_BACKOFF_MAX_RETRIES, FETCH_BACKOFF_MAX_WAIT } from './constants';
 import { IUpdateWorker } from './types';
 
-// Handles retries and CDN bypass per segment name
-class SegmentUpdateWorker {
-
-  private readonly log: ILogger;
-  private readonly segmentsCache: ISegmentsCacheSync;
-  private readonly segmentSyncTask: ReturnType<ISegmentsSyncTask['updateSegment']>;
-  private readonly segment: string;
-  private maxChangeNumber: number;
-  private handleNewEvent: boolean;
-  private isHandlingEvent?: boolean;
-  private cdnBypass?: boolean;
-  readonly backoff: Backoff;
-
-  constructor(log: ILogger, segmentSyncTask: ReturnType<ISegmentsSyncTask['updateSegment']>, segmentsCache: ISegmentsCacheSync, segment: string) {
-    this.log = log;
-    this.segmentsCache = segmentsCache;
-    this.segmentSyncTask = segmentSyncTask;
-    this.segment = segment;
-    this.maxChangeNumber = 0;
-    this.handleNewEvent = false;
-    this.__handleSegmentUpdateCall = this.__handleSegmentUpdateCall.bind(this);
-    this.backoff = new Backoff(this.__handleSegmentUpdateCall, FETCH_BACKOFF_BASE, FETCH_BACKOFF_MAX_WAIT);
-  }
-
-  __handleSegmentUpdateCall() {
-    this.isHandlingEvent = true;
-    if (this.maxChangeNumber > this.segmentsCache.getChangeNumber(this.segment)) {
-      this.handleNewEvent = false;
-
-      // fetch segments revalidating data if cached
-      this.segmentSyncTask.execute(true, false, this.cdnBypass ? this.maxChangeNumber : undefined).then(() => {
-        if (this.handleNewEvent) {
-          this.__handleSegmentUpdateCall();
-        } else {
-          const attemps = this.backoff.attempts + 1;
-
-          if (this.maxChangeNumber <= this.segmentsCache.getChangeNumber(this.segment)) {
-            this.log.debug(`Refresh completed${this.cdnBypass ? ' bypassing the CDN' : ''} in ${attemps} attempts.`);
-            return;
-          }
-
-          if (attemps < FETCH_BACKOFF_MAX_RETRIES) {
-            this.backoff.scheduleCall();
-            return;
-          }
-
-          if (this.cdnBypass) {
-            this.log.debug(`No changes fetched after ${attemps} attempts with CDN bypassed.`);
-          } else {
-            this.backoff.reset();
-            this.cdnBypass = true;
-            this.__handleSegmentUpdateCall();
-          }
-        }
-      });
-    } else {
-      this.isHandlingEvent = false;
-    }
-  }
-
-  put(changeNumber: number) {
-    const currentChangeNumber = this.segmentsCache.getChangeNumber(this.segment);
-
-    if (changeNumber <= currentChangeNumber || changeNumber <= this.maxChangeNumber) return;
-
-    this.maxChangeNumber = changeNumber;
-    this.handleNewEvent = true;
-    this.backoff.reset();
-    this.cdnBypass = false;
-
-    if (!this.isHandlingEvent) this.__handleSegmentUpdateCall();
-  }
-
-}
-
 /**
- * SegmentUpdateWorker class
+ * SegmentsUpdateWorker handles SEGMENT_UPDATE events
  */
-export class SegmentsUpdateWorker implements IUpdateWorker {
+export function SegmentsUpdateWorker(log: ILogger, segmentsSyncTask: ISegmentsSyncTask, segmentsCache: ISegmentsCacheSync): IUpdateWorker {
 
-  private readonly log: ILogger;
-  private readonly segmentsCache: ISegmentsCacheSync;
-  private readonly segmentsSyncTask: ISegmentsSyncTask;
-  private readonly segments: Record<string, SegmentUpdateWorker>;
+  // Handles retries with CDN bypass per segment name
+  function SegmentUpdateWorker(segment: string) {
+    let maxChangeNumber = 0;
+    let handleNewEvent = false;
+    let isHandlingEvent: boolean, cdnBypass: boolean;
+    const backoff = new Backoff(__handleSegmentUpdateCall, FETCH_BACKOFF_BASE, FETCH_BACKOFF_MAX_WAIT);
 
-  /**
-   * @param {Object} segmentsCache segments data cache
-   * @param {Object} segmentsSyncTask task for syncing segments data
-   */
-  constructor(log: ILogger, segmentsSyncTask: ISegmentsSyncTask, segmentsCache: ISegmentsCacheSync) {
-    this.log = log;
-    this.segmentsSyncTask = segmentsSyncTask;
-    this.segmentsCache = segmentsCache;
-    this.segments = {};
-    this.put = this.put.bind(this);
+    function __handleSegmentUpdateCall() {
+      isHandlingEvent = true;
+      if (maxChangeNumber > segmentsCache.getChangeNumber(segment)) {
+        handleNewEvent = false;
+
+        // fetch segments revalidating data if cached
+        segmentsSyncTask.updateSegment(segment, true, false, cdnBypass ? maxChangeNumber : undefined).then(() => {
+          if (handleNewEvent) {
+            __handleSegmentUpdateCall();
+          } else {
+            const attemps = backoff.attempts + 1;
+
+            if (maxChangeNumber <= segmentsCache.getChangeNumber(segment)) {
+              log.debug(`Refresh completed${cdnBypass ? ' bypassing the CDN' : ''} in ${attemps} attempts.`);
+              return;
+            }
+
+            if (attemps < FETCH_BACKOFF_MAX_RETRIES) {
+              backoff.scheduleCall();
+              return;
+            }
+
+            if (cdnBypass) {
+              log.debug(`No changes fetched after ${attemps} attempts with CDN bypassed.`);
+            } else {
+              backoff.reset();
+              cdnBypass = true;
+              __handleSegmentUpdateCall();
+            }
+          }
+        });
+      } else {
+        isHandlingEvent = false;
+      }
+    }
+
+    return {
+      put(changeNumber: number) {
+        const currentChangeNumber = segmentsCache.getChangeNumber(segment);
+
+        if (changeNumber <= currentChangeNumber || changeNumber <= maxChangeNumber) return;
+
+        maxChangeNumber = changeNumber;
+        handleNewEvent = true;
+        backoff.reset();
+        cdnBypass = false;
+
+        if (!isHandlingEvent) __handleSegmentUpdateCall();
+      },
+      backoff
+    };
+
   }
 
-  /**
-   * Invoked by NotificationProcessor on SEGMENT_UPDATE event
-   *
-   * @param {number} changeNumber change number of the SEGMENT_UPDATE notification
-   * @param {string} segmentName segment name of the SEGMENT_UPDATE notification
-   */
-  put({ changeNumber, segmentName }: ISegmentUpdateData) {
-    if (!this.segments[segmentName]) this.segments[segmentName] = new SegmentUpdateWorker(this.log, this.segmentsSyncTask.updateSegment(segmentName), this.segmentsCache, segmentName);
-    this.segments[segmentName].put(changeNumber);
-  }
+  const segments: Record<string, ReturnType<typeof SegmentUpdateWorker>> = {};
 
-  reset() {
-    Object.keys(this.segments).forEach(segmentName => this.segments[segmentName].backoff.reset());
-  }
+  return {
+    /**
+     * Invoked by NotificationProcessor on SEGMENT_UPDATE event
+     *
+     * @param {number} changeNumber change number of the SEGMENT_UPDATE notification
+     * @param {string} segmentName segment name of the SEGMENT_UPDATE notification
+     */
+    put({ changeNumber, segmentName }: ISegmentUpdateData) {
+      if (!segments[segmentName]) segments[segmentName] = SegmentUpdateWorker(segmentName);
+      segments[segmentName].put(changeNumber);
+    },
 
+    reset() {
+      Object.keys(segments).forEach(segmentName => segments[segmentName].backoff.reset());
+    }
+  };
 }

--- a/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
@@ -54,7 +54,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
           this.__handleSplitUpdateCall();
         } else {
           // fetch new registered segments for server-side API. Not retrying on error
-          if (this.segmentsSyncTask) this.segmentsSyncTask.execute(undefined, false, true);
+          if (this.segmentsSyncTask) this.segmentsSyncTask.execute(true);
 
           const attemps = this.backoff.attempts + 1;
 

--- a/src/sync/streaming/UpdateWorkers/__tests__/SegmentsUpdateWorker.spec.ts
+++ b/src/sync/streaming/UpdateWorkers/__tests__/SegmentsUpdateWorker.spec.ts
@@ -3,39 +3,29 @@ import { SegmentsCacheInMemory } from '../../../../storages/inMemory/SegmentsCac
 import { SegmentsUpdateWorker } from '../SegmentsUpdateWorker';
 import { FETCH_BACKOFF_MAX_RETRIES } from '../constants';
 import { loggerMock } from '../../../../logger/__tests__/sdkLogger.mock';
+import { Backoff } from '../../../../utils/Backoff';
 
-function segmentsSyncTaskMock(segmentsStorage, changeNumbers: Record<string, number>[]) {
+function segmentsSyncTaskMock(segmentsStorage: SegmentsCacheInMemory, changeNumbers?: [segmentName: string, changeNumber: number][]) {
 
   const __segmentsUpdaterCalls = [];
 
-  function __resolveSegmentsUpdaterCall(changeNumber: Record<string, number>) {
-    Object.keys(changeNumber).forEach(segmentName => {
-      segmentsStorage.setChangeNumber(segmentName, changeNumber[segmentName]); // update changeNumber in storage
-    });
-    __segmentsUpdaterCalls.shift().res(); // resolve `execute` call
+  function __resolveUpdateSegmentCall(segmentName: string, changeNumber: number) {
+    segmentsStorage.setChangeNumber(segmentName, changeNumber); // update changeNumber in storage
+
+    __segmentsUpdaterCalls.shift().res(); // resolve `updateSegment` call
   }
 
-  let __isSynchronizingSegments = false;
-
-  function isExecuting() {
-    return __isSynchronizingSegments;
-  }
-
-  function execute() {
-    __isSynchronizingSegments = true;
+  function updateSegment() {
     return new Promise((res) => {
       __segmentsUpdaterCalls.push({ res });
-      if (changeNumbers && changeNumbers.length) __resolveSegmentsUpdaterCall(changeNumbers.shift());
-    }).then(function () {
-      __isSynchronizingSegments = false;
+      if (changeNumbers && changeNumbers.length) __resolveUpdateSegmentCall(...changeNumbers.shift());
     });
   }
 
   return {
-    isExecuting: jest.fn(isExecuting),
-    execute: jest.fn(execute),
+    updateSegment: jest.fn(updateSegment),
 
-    __resolveSegmentsUpdaterCall
+    __resolveUpdateSegmentCall
   };
 }
 
@@ -45,104 +35,94 @@ describe('SegmentsUpdateWorker ', () => {
 
     // setup
     const cache = new SegmentsCacheInMemory();
-    cache.addToSegment('mocked_segment_1', ['a', 'b', 'c']);
-    cache.addToSegment('mocked_segment_2', ['d']);
-    cache.addToSegment('mocked_segment_3', ['e']);
     const segmentsSyncTask = segmentsSyncTaskMock(cache);
 
-    const segmentsUpdateWorker = new SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
-    segmentsUpdateWorker.backoff.baseMillis = 0; // retry immediately
+    Backoff.__TEST__BASE_MILLIS = 1; // retry immediately
+    const segmentsUpdateWorker = SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
 
-    expect(segmentsUpdateWorker.maxChangeNumbers).toEqual({}); // inits with not queued events;
-
-    // assert calling `segmentsSyncTask.execute` if `isExecuting` is false
-    expect(segmentsSyncTask.isExecuting()).toBe(false);
+    // assert calling `updateSegment`
     segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_1' });
-    expect(segmentsUpdateWorker.maxChangeNumbers).toEqual({ 'mocked_segment_1': 100 }); // queues events (changeNumbers) if they are mayor than storage changeNumbers and maxChangeNumbers
-    expect(segmentsSyncTask.execute).toBeCalledTimes(1); // synchronizes segment if `isExecuting` is false
-    expect(segmentsSyncTask.execute.mock.calls).toEqual([[['mocked_segment_1'], true, false, undefined]]); // synchronizes segment with given name
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(1);
+    expect(segmentsSyncTask.updateSegment).toBeCalledWith('mocked_segment_1', true, false, undefined); // synchronizes segment if `isExecuting` is false
 
-    // assert queueing items if `isExecuting` is true
-    expect(segmentsSyncTask.isExecuting()).toBe(true);
+    // assert calling `updateSegment` for other segments while 1st `updateSegment` call is pending
     segmentsUpdateWorker.put({ changeNumber: 95, segmentName: 'mocked_segment_1' });
     segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_2' });
     segmentsUpdateWorker.put({ changeNumber: 105, segmentName: 'mocked_segment_1' });
     segmentsUpdateWorker.put({ changeNumber: 94, segmentName: 'mocked_segment_1' });
     segmentsUpdateWorker.put({ changeNumber: 94, segmentName: 'mocked_segment_3' });
 
-    expect(segmentsUpdateWorker.maxChangeNumbers).toEqual({ 'mocked_segment_1': 105, 'mocked_segment_2': 100, 'mocked_segment_3': 94 }); // queues events
-    expect(segmentsSyncTask.execute).toBeCalledTimes(1); // doesn't synchronize segment if `isExecuting` is true
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(3); // synchronize 2 new segments: mocked_segment_2 and mocked_segment_3
+    expect(segmentsSyncTask.updateSegment).toHaveBeenNthCalledWith(2, 'mocked_segment_2', true, false, undefined);
+    expect(segmentsSyncTask.updateSegment).toHaveBeenNthCalledWith(3, 'mocked_segment_3', true, false, undefined);
 
-    // assert dequeueing and recalling to `segmentsSyncTask.execute`
-    segmentsSyncTask.__resolveSegmentsUpdaterCall({ 'mocked_segment_1': 100 }); // resolve first call to `segmentsSyncTask.execute`
+    // assert recalling `updateSegment` for mocked_segment_1, if max changeNumber (105) is greater than stored one (100)
+    segmentsSyncTask.__resolveUpdateSegmentCall('mocked_segment_1', 100); // resolve first call to `updateSegment`
     await new Promise(res => setTimeout(res));
     expect(cache.getChangeNumber('mocked_segment_1')).toBe(100); // 100
-    expect(segmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes segment if `isExecuting` is false and queue is not empty
-    expect(segmentsSyncTask.execute).toHaveBeenLastCalledWith(['mocked_segment_1', 'mocked_segment_2', 'mocked_segment_3'], true, false, undefined); // synchronizes segments with given names
-    expect(segmentsUpdateWorker.backoff.attempts).toBe(0); // no retry scheduled if synchronization success (changeNumbers are the expected)
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(4);
+    expect(segmentsSyncTask.updateSegment).toHaveBeenLastCalledWith('mocked_segment_1', true, false, undefined);
 
     // assert not rescheduling synchronization if some changeNumber is not updated as expected,
     // but rescheduling if a new item was queued with a greater changeNumber while the fetch was pending.
     segmentsUpdateWorker.put({ changeNumber: 110, segmentName: 'mocked_segment_1' });
-    segmentsSyncTask.__resolveSegmentsUpdaterCall({ 'mocked_segment_1': 100, 'mocked_segment_2': 100, 'mocked_segment_3': 94 });
-    await new Promise(res => setTimeout(res));
-    expect(segmentsSyncTask.execute).toBeCalledTimes(3); // re-synchronizes segment if a new item was queued with a greater changeNumber while the fetch was pending
-    expect(segmentsSyncTask.execute).toHaveBeenLastCalledWith(['mocked_segment_1'], true, false, undefined); // synchronizes segment that was queued with a greater changeNumber while the fetch was pending
-    expect(segmentsUpdateWorker.backoff.attempts).toBe(0); // doesn't retry backoff schedule since a new item was queued
 
-    // assert dequeueing remaining events
-    segmentsSyncTask.__resolveSegmentsUpdaterCall({ 'mocked_segment_1': 105 }); // resolve third call to `segmentsSyncTask.execute`
-    await new Promise(res => setTimeout(res));
-    expect(segmentsSyncTask.execute).toBeCalledTimes(3); // doesn't re-synchronize segment if fetched changeNumbers are not the expected (i.e., are different from the queued items)
-    expect(segmentsUpdateWorker.maxChangeNumbers).toEqual({ 'mocked_segment_1': 110, 'mocked_segment_2': 100, 'mocked_segment_3': 94 }); // maxChangeNumbers were cleaned
+    segmentsSyncTask.__resolveUpdateSegmentCall('mocked_segment_2', 100);
+    segmentsSyncTask.__resolveUpdateSegmentCall('mocked_segment_3', 94);
+    segmentsSyncTask.__resolveUpdateSegmentCall('mocked_segment_1', 100);
 
-    // assert restarting retries, when a newer event is queued
-    segmentsUpdateWorker.put({ changeNumber: 115, segmentName: 'mocked_segment_1' }); // queued
-    expect(segmentsUpdateWorker.backoff.attempts).toBe(0); // backoff scheduler for retries is reset if a new event is queued
+    await new Promise(res => setTimeout(res));
+    // `updateSegment` for mocked_segment_1 was called a 3rd time
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(5); // re-synchronizes segment if a new item was queued with a greater changeNumber while the fetch was pending
+    expect(segmentsSyncTask.updateSegment).toHaveBeenLastCalledWith('mocked_segment_1', true, false, undefined); // synchronizes segment that was queued with a greater changeNumber while the fetch was pending
+
+    segmentsSyncTask.__resolveUpdateSegmentCall('mocked_segment_1', 110); // resolve last call with target changeNumber
+    await new Promise(res => setTimeout(res, 20)); // Wait with a short delay to assert no more calls with backoff to `updateSegment`
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(5); // doesn't re-synchronize segments if fetched changeNumbers are the expected (i.e., are equal to queued changeNumbers)
   });
 
   test('put, completed with CDN bypass', async () => {
 
     // setup
+    Backoff.__TEST__BASE_MILLIS = 10; // 10 millis instead of 10 sec
+    Backoff.__TEST__MAX_MILLIS = 60; // 60 millis instead of 1 min
     const cache = new SegmentsCacheInMemory();
     const segmentsSyncTask = segmentsSyncTaskMock(cache, [
-      ...Array(FETCH_BACKOFF_MAX_RETRIES + 1).fill({ 'mocked_segment_1': 90 }),
-      { 'mocked_segment_1': 100 }
+      ...Array(FETCH_BACKOFF_MAX_RETRIES + 1).fill(['mocked_segment_1', 90]),
+      ['mocked_segment_1', 100]
     ]); // 12 executions. Last one is valid
-    const segmentsUpdateWorker = new SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
-    segmentsUpdateWorker.backoff.baseMillis /= 1000; // 10 millis instead of 10 sec
-    segmentsUpdateWorker.backoff.maxMillis /= 1000; // 60 millis instead of 1 min
+    const segmentsUpdateWorker = SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
 
     segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_1' }); // queued
 
     await new Promise(res => setTimeout(res, 540)); // 440 + some delay
 
     expect(loggerMock.debug).lastCalledWith('Refresh completed bypassing the CDN in 2 attempts.');
-    expect(segmentsSyncTask.execute.mock.calls).toEqual([
-      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([['mocked_segment_1'], true, false, undefined]),
-      ...Array(2).fill([['mocked_segment_1'], true, false, [100]])
-    ]); // `execute` was called 12 times. Last 2 with CDN bypass
+    expect(segmentsSyncTask.updateSegment.mock.calls).toEqual([
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill(['mocked_segment_1', true, false, undefined]),
+      ...Array(2).fill(['mocked_segment_1', true, false, 100])
+    ]); // `updateSegment` was called 12 times. Last 2 with CDN bypass
   });
 
 
   test('put, not completed with CDN bypass', async () => {
 
     // setup
+    Backoff.__TEST__BASE_MILLIS = 10; // 10 millis instead of 10 sec
+    Backoff.__TEST__MAX_MILLIS = 60; // 60 millis instead of 1 min
     const cache = new SegmentsCacheInMemory();
-    const segmentsSyncTask = segmentsSyncTaskMock(cache, Array(FETCH_BACKOFF_MAX_RETRIES * 2).fill({ 'mocked_segment_1': 90 })); // 20 executions. No one is valid
-    const segmentsUpdateWorker = new SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
-    segmentsUpdateWorker.backoff.baseMillis /= 1000; // 10 millis instead of 10 sec
-    segmentsUpdateWorker.backoff.maxMillis /= 1000; // 60 millis instead of 1 min
+    const segmentsSyncTask = segmentsSyncTaskMock(cache, Array(FETCH_BACKOFF_MAX_RETRIES * 2).fill(['mocked_segment_1', 90])); // 20 executions. No one is valid
+    const segmentsUpdateWorker = SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
 
     segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_1' }); // queued
 
     await new Promise(res => setTimeout(res, 960)); // 860 + some delay
 
     expect(loggerMock.debug).lastCalledWith('No changes fetched after 10 attempts with CDN bypassed.');
-    expect(segmentsSyncTask.execute.mock.calls).toEqual([
-      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([['mocked_segment_1'], true, false, undefined]),
-      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([['mocked_segment_1'], true, false, [100]]),
-    ]); // `execute` was called 20 times. Last 10 with CDN bypass
+    expect(segmentsSyncTask.updateSegment.mock.calls).toEqual([
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill(['mocked_segment_1', true, false, undefined]),
+      ...Array(FETCH_BACKOFF_MAX_RETRIES).fill(['mocked_segment_1', true, false, 100]),
+    ]); // `updateSegment` was called 20 times. Last 10 with CDN bypass
   });
 
 });

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -1,6 +1,6 @@
 import { IPushEventEmitter, IPushManager } from './types';
 import { ISSEClient } from './SSEClient/types';
-import { IMySegmentsSyncTask, IPollingManager } from '../polling/types';
+import { IMySegmentsSyncTask, IPollingManager, ISegmentsSyncTask } from '../polling/types';
 import { objectAssign } from '../../utils/lang/objectAssign';
 import { Backoff } from '../../utils/Backoff';
 import { SSEHandlerFactory } from './SSEHandler';
@@ -55,9 +55,9 @@ export function pushManagerFactory(
 
   // init workers
   // MySegmentsUpdateWorker (client-side) are initiated in `add` method
-  const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(log, pollingManager.segmentsSyncTask, storage.segments);
+  const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(log, pollingManager.segmentsSyncTask as ISegmentsSyncTask, storage.segments);
   // For server-side we pass the segmentsSyncTask, used by SplitsUpdateWorker to fetch new segments
-  const splitsUpdateWorker = new SplitsUpdateWorker(log, storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask);
+  const splitsUpdateWorker = new SplitsUpdateWorker(log, storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask as ISegmentsSyncTask);
 
   // [Only for client-side] map of hashes to user keys, to dispatch MY_SEGMENTS_UPDATE events to the corresponding MySegmentsUpdateWorker
   const userKeyHashes: Record<string, string> = {};
@@ -315,7 +315,7 @@ export function pushManagerFactory(
         if (disabled || disconnected === false) return;
         disconnected = false;
 
-        if (userKey) this.add(userKey, pollingManager.segmentsSyncTask); // client-side
+        if (userKey) this.add(userKey, pollingManager.segmentsSyncTask as IMySegmentsSyncTask); // client-side
         else setTimeout(connectPush); // server-side runs in next cycle as in client-side, for consistency with client-side
       },
 

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -55,7 +55,7 @@ export function pushManagerFactory(
 
   // init workers
   // MySegmentsUpdateWorker (client-side) are initiated in `add` method
-  const segmentsUpdateWorker = userKey ? undefined : new SegmentsUpdateWorker(log, pollingManager.segmentsSyncTask as ISegmentsSyncTask, storage.segments);
+  const segmentsUpdateWorker = userKey ? undefined : SegmentsUpdateWorker(log, pollingManager.segmentsSyncTask as ISegmentsSyncTask, storage.segments);
   // For server-side we pass the segmentsSyncTask, used by SplitsUpdateWorker to fetch new segments
   const splitsUpdateWorker = new SplitsUpdateWorker(log, storage.splits, pollingManager.splitsSyncTask, readiness.splits, userKey ? undefined : pollingManager.segmentsSyncTask as ISegmentsSyncTask);
 

--- a/src/sync/syncTask.ts
+++ b/src/sync/syncTask.ts
@@ -13,7 +13,7 @@ import { ISyncTask } from './types';
  * @param taskName  Optional task name for logging.
  * @returns A sync task that wraps the given task.
  */
-export function syncTaskFactory<Input extends any[], Output = any>(log: ILogger, task: (...args: Input) => Promise<Output>, period: number, taskName = 'task'): ISyncTask<Input, Output> {
+export function syncTaskFactory<Input extends any[], Output = any>(log: ILogger, task: (...args: Input) => Promise<Output>, period?: number, taskName = 'task'): ISyncTask<Input, Output> {
 
   // Task promise while it is pending. Undefined once the promise is resolved
   let pendingTask: Promise<Output> | undefined;

--- a/src/utils/Backoff.ts
+++ b/src/utils/Backoff.ts
@@ -1,5 +1,9 @@
 export class Backoff {
 
+  // For testing purposes, assign to overwrite the provided value by param
+  static __TEST__BASE_MILLIS?: number;
+  static __TEST__MAX_MILLIS?: number;
+
   static DEFAULT_BASE_MILLIS = 1000; // 1 second
   static DEFAULT_MAX_MILLIS = 1800000; // 30 minutes
 
@@ -17,8 +21,8 @@ export class Backoff {
    * @param {number} maxMillis
    */
   constructor(cb: (...args: any[]) => any, baseMillis?: number, maxMillis?: number) {
-    this.baseMillis = baseMillis || Backoff.DEFAULT_BASE_MILLIS;
-    this.maxMillis = maxMillis || Backoff.DEFAULT_MAX_MILLIS;
+    this.baseMillis = Backoff.__TEST__BASE_MILLIS || baseMillis || Backoff.DEFAULT_BASE_MILLIS;
+    this.maxMillis = Backoff.__TEST__MAX_MILLIS || maxMillis || Backoff.DEFAULT_MAX_MILLIS;
     this.attempts = 0;
     this.cb = cb;
   }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

Refactor `segmentChangesUpdater`: it now returns an object with 2 methods
- updateSegments: to synchronize all segments, used by pollingManager
- updateSegment: to synchronize a single segment, used by SegmentsUpdateWorker

## How do we test the changes introduced in this PR?

- [TODO] unit tests

## Extra Notes