### PR TITLE
[CDN Bypass] UpdateWorkers improvements

### DIFF
--- a/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
@@ -71,6 +71,7 @@ export class MySegmentsUpdateWorker implements IUpdateWorker {
   }
 
   stop() {
+    this.isHandlingEvent = false;
     this.backoff.reset();
   }
 

--- a/src/sync/streaming/UpdateWorkers/SegmentsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/SegmentsUpdateWorker.ts
@@ -34,6 +34,7 @@ export function SegmentsUpdateWorker(log: ILogger, segmentsSyncTask: ISegmentsSy
 
             if (maxChangeNumber <= segmentsCache.getChangeNumber(segment)) {
               log.debug(`Refresh completed${cdnBypass ? ' bypassing the CDN' : ''} in ${attemps} attempts.`);
+              isHandlingEvent = false;
               return;
             }
 
@@ -44,6 +45,7 @@ export function SegmentsUpdateWorker(log: ILogger, segmentsSyncTask: ISegmentsSy
 
             if (cdnBypass) {
               log.debug(`No changes fetched after ${attemps} attempts with CDN bypassed.`);
+              isHandlingEvent = false;
             } else {
               backoff.reset();
               cdnBypass = true;

--- a/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
@@ -21,6 +21,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
   private maxChangeNumber: number;
   private handleNewEvent: boolean;
   private isHandlingEvent?: boolean;
+  private stopped?: boolean;
   private cdnBypass?: boolean;
   readonly backoff: Backoff;
 
@@ -52,6 +53,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
 
       // fetch splits revalidating data if cached
       this.splitsSyncTask.execute(true, this.cdnBypass ? this.maxChangeNumber : undefined).then(() => {
+        if (this.stopped) return;
         if (this.handleNewEvent) {
           this.__handleSplitUpdateCall();
         } else {
@@ -98,6 +100,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
     this.handleNewEvent = true;
     this.backoff.reset();
     this.cdnBypass = false;
+    this.stopped = false;
 
     if (!this.isHandlingEvent) this.__handleSplitUpdateCall();
   }
@@ -119,6 +122,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
   }
 
   stop() {
+    this.stopped = true;
     this.backoff.reset();
   }
 

--- a/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/SplitsUpdateWorker.ts
@@ -63,6 +63,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
 
           if (this.maxChangeNumber <= this.splitsCache.getChangeNumber()) {
             this.log.debug(`Refresh completed${this.cdnBypass ? ' bypassing the CDN' : ''} in ${attemps} attempts.`);
+            this.isHandlingEvent = false;
             return;
           }
 
@@ -73,6 +74,7 @@ export class SplitsUpdateWorker implements IUpdateWorker {
 
           if (this.cdnBypass) {
             this.log.debug(`No changes fetched after ${attemps} attempts with CDN bypassed.`);
+            this.isHandlingEvent = false;
           } else {
             this.backoff.reset();
             this.cdnBypass = true;

--- a/src/sync/streaming/UpdateWorkers/__tests__/MySegmentsUpdateWorker.spec.ts
+++ b/src/sync/streaming/UpdateWorkers/__tests__/MySegmentsUpdateWorker.spec.ts
@@ -31,7 +31,7 @@ function mySegmentsSyncTaskMock(values?: (boolean | undefined)[]) {
 
 describe('MySegmentsUpdateWorker', () => {
 
-  test('put', (done) => {
+  test('put', async () => {
 
     // setup
     const mySegmentsSyncTask = mySegmentsSyncTaskMock();
@@ -57,69 +57,59 @@ describe('MySegmentsUpdateWorker', () => {
 
     // assert calling `mySegmentsSyncTask.execute` if previous call is resolved and a new changeNumber in queue
     mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-    setTimeout(() => {
-      expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments if `isExecuting` is false and queue is not empty
-      expect(mySegmentUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
-      expect(mySegmentUpdateWorker.backoff.attempts).toBe(0); // no retry scheduled if synchronization success (changeNumbers are the expected)
+    await new Promise(res => setTimeout(res));
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments if `isExecuting` is false and queue is not empty
+    expect(mySegmentUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
+    expect(mySegmentUpdateWorker.backoff.attempts).toBe(0); // no retry scheduled if synchronization success (changeNumbers are the expected)
 
-      // assert reschedule synchronization if fetch fails
-      mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(false); // fetch fail
-      setTimeout(() => {
-        expect(mySegmentsSyncTask.execute).toBeCalledTimes(3); // recalls `synchronizeSegment` if synchronization fail (one changeNumber is not the expected)
-        expect(mySegmentUpdateWorker.backoff.attempts).toBe(1); // retry scheduled since synchronization failed (one changeNumber is not the expected)
+    // assert reschedule synchronization if fetch fails
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(false); // fetch fail
+    await new Promise(res => setTimeout(res, 10)); // wait a little bit until `mySegmentsSyncTask.execute` is called in next event-loop cycle
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(3); // recalls `synchronizeSegment` if synchronization fail (one changeNumber is not the expected)
+    expect(mySegmentUpdateWorker.backoff.attempts).toBe(1); // retry scheduled since synchronization failed (one changeNumber is not the expected)
 
-        // assert dequeueing changeNumber
-        mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-        setTimeout(() => {
-          expect(mySegmentsSyncTask.execute).toBeCalledTimes(3); // doesn't synchronize MySegments while queue is empty
-          expect(mySegmentUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
+    // assert dequeueing changeNumber
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
+    await new Promise(res => setTimeout(res, 10));
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(3); // doesn't synchronize MySegments while queue is empty
+    expect(mySegmentUpdateWorker.maxChangeNumber).toBe(106); // maxChangeNumber
 
-          // assert handling an event with segmentList after an event without segmentList,
-          // to validate the special case than the fetch associated to the first event is resolved after a second event with payload arrives
-          mySegmentsSyncTask.execute.mockClear();
-          expect(mySegmentsSyncTask.isExecuting()).toBe(false);
-          mySegmentUpdateWorker.put(110);
-          expect(mySegmentsSyncTask.isExecuting()).toBe(true);
-          mySegmentUpdateWorker.put(120, ['some_segment']);
-          expect(mySegmentsSyncTask.execute).toBeCalledTimes(1); // doesn't synchronize MySegments if `isExecuting` is true, even if payload (segmentList) is included
+    // assert handling an event with segmentList after an event without segmentList,
+    // to validate the special case than the fetch associated to the first event is resolved after a second event with payload arrives
+    mySegmentsSyncTask.execute.mockClear();
+    expect(mySegmentsSyncTask.isExecuting()).toBe(false);
+    mySegmentUpdateWorker.put(110);
+    expect(mySegmentsSyncTask.isExecuting()).toBe(true);
+    mySegmentUpdateWorker.put(120, ['some_segment']);
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(1); // doesn't synchronize MySegments if `isExecuting` is true, even if payload (segmentList) is included
 
-          mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-          setTimeout(() => {
-            expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments once previous event was handled
-            expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(['some_segment'], true); // synchronizes MySegments with given segmentList
-            mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-            setTimeout(() => {
-              expect(mySegmentUpdateWorker.currentChangeNumber).toBe(120); // currentChangeNumber updated
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
+    await new Promise(res => setTimeout(res, 10));
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments once previous event was handled
+    expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(['some_segment'], true); // synchronizes MySegments with given segmentList
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
+    await new Promise(res => setTimeout(res, 10));
+    expect(mySegmentUpdateWorker.currentChangeNumber).toBe(120); // currentChangeNumber updated
 
-              // assert handling an event without segmentList after one with segmentList,
-              // to validate the special case than the event-loop of a handled event with payload is run after a second event arrives
-              mySegmentsSyncTask.execute.mockClear();
-              mySegmentUpdateWorker.put(130, ['other_segment']);
-              mySegmentUpdateWorker.put(140);
-              expect(mySegmentsSyncTask.execute).toBeCalledTimes(1); // synchronizes MySegments once, until event is handled
-              expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(['other_segment'], true);
+    // assert handling an event without segmentList after one with segmentList,
+    // to validate the special case than the event-loop of a handled event with payload is run after a second event arrives
+    mySegmentsSyncTask.execute.mockClear();
+    mySegmentUpdateWorker.put(130, ['other_segment']);
+    mySegmentUpdateWorker.put(140);
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(1); // synchronizes MySegments once, until event is handled
+    expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(['other_segment'], true);
 
-              mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-              setTimeout(() => {
-                expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments once previous event was handled
-                expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(undefined, true); // synchronizes MySegments without segmentList if the event doesn't have payload
-                mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
-                setTimeout(() => {
-                  expect(mySegmentUpdateWorker.currentChangeNumber).toBe(140); // currentChangeNumber updated
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
+    await new Promise(res => setTimeout(res));
+    expect(mySegmentsSyncTask.execute).toBeCalledTimes(2); // re-synchronizes MySegments once previous event was handled
+    expect(mySegmentsSyncTask.execute).toHaveBeenLastCalledWith(undefined, true); // synchronizes MySegments without segmentList if the event doesn't have payload
+    mySegmentsSyncTask.__resolveMySegmentsUpdaterCall(); // fetch success
+    await new Promise(res => setTimeout(res));
+    expect(mySegmentUpdateWorker.currentChangeNumber).toBe(140); // currentChangeNumber updated
 
-                  // assert restarting retries, when a newer event is queued
-                  mySegmentUpdateWorker.put(150); // queued
-                  expect(mySegmentUpdateWorker.backoff.attempts).toBe(0); // backoff scheduler for retries is reset if a new event is queued
-
-                  done();
-                });
-              });
-            }, 10);
-          }, 10);
-        }, 10);
-
-      }, 10); // wait a little bit until `mySegmentsSyncTask.execute` is called in next event-loop cycle
-    });
+    // assert restarting retries, when a newer event is queued
+    mySegmentUpdateWorker.put(150); // queued
+    expect(mySegmentUpdateWorker.backoff.attempts).toBe(0); // backoff scheduler for retries is reset if a new event is queued
   });
 
   test('stop', async () => {

--- a/src/sync/streaming/UpdateWorkers/__tests__/SegmentsUpdateWorker.spec.ts
+++ b/src/sync/streaming/UpdateWorkers/__tests__/SegmentsUpdateWorker.spec.ts
@@ -123,4 +123,20 @@ describe('SegmentsUpdateWorker ', () => {
     ]); // `updateSegment` was called 20 times. Last 10 with CDN bypass
   });
 
+  test('stop', async () => {
+    // setup
+    const cache = new SegmentsCacheInMemory();
+    const segmentsSyncTask = segmentsSyncTaskMock(cache, [['mocked_segment_1', 95], ['mocked_segment_2', 95]]);
+    Backoff.__TEST__BASE_MILLIS = 1;
+    const segmentsUpdateWorker = SegmentsUpdateWorker(loggerMock, segmentsSyncTask, cache);
+
+    segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_1' });
+    segmentsUpdateWorker.put({ changeNumber: 100, segmentName: 'mocked_segment_2' });
+
+    segmentsUpdateWorker.stop();
+
+    await new Promise(res => setTimeout(res, 20)); // Wait to assert no more calls to `updateSegment` after reseting
+    expect(segmentsSyncTask.updateSegment).toBeCalledTimes(2);
+  });
+
 });

--- a/src/sync/streaming/UpdateWorkers/__tests__/SplitsUpdateWorker.spec.ts
+++ b/src/sync/streaming/UpdateWorkers/__tests__/SplitsUpdateWorker.spec.ts
@@ -119,8 +119,12 @@ describe('SplitsUpdateWorker', () => {
       ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, undefined]),
       [true, 100], [true, 100],
     ]); // `execute` was called 12 times. Last 2 with CDN bypass
-  });
 
+    // Handle new event after previous is completed
+    splitsSyncTask.execute.mockClear();
+    splitUpdateWorker.put({ changeNumber: 105 });
+    expect(splitsSyncTask.execute).toBeCalledTimes(1);
+  });
 
   test('put, not completed with CDN bypass', async () => {
 
@@ -140,6 +144,11 @@ describe('SplitsUpdateWorker', () => {
       ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, undefined]),
       ...Array(FETCH_BACKOFF_MAX_RETRIES).fill([true, 100]),
     ]); // `execute` was called 20 times. Last 10 with CDN bypass
+
+    // Handle new event after previous ends (not completed)
+    splitsSyncTask.execute.mockClear();
+    splitUpdateWorker.put({ changeNumber: 105 });
+    expect(splitsSyncTask.execute).toBeCalledTimes(1);
   });
 
   test('killSplit', async () => {

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -180,7 +180,6 @@ export function pushManagerFactory(
   // Otherwise it is unnecessary (e.g, STREAMING_RESUMED).
   pushEmitter.on(PUSH_SUBSYSTEM_UP, () => {
     connectPushRetryBackoff.reset();
-    stopWorkers();
   });
 
   /** Fallback to polling without retry due to: STREAMING_DISABLED control event, or 'pushEnabled: false', or non-recoverable SSE and Authentication errors */


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Update `stop` methods of update workers, to properly clean scheduled tasks for SDK destroy

## How do we test the changes introduced in this PR?

- Added test for `stop` method

## Extra Notes