### PR TITLE
[SDKS-5963] Add uniqueKeysSubmitter, add methods to uniqueKeysTracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.0",
+  "version": "1.6.2-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.1",
+  "version": "1.6.2-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.1",
+  "version": "1.6.2-rc.0",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.0",
+  "version": "1.6.2-rc.1",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -81,7 +81,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   // splitApi is used by SyncManager and Browser signal listener
   const splitApi = splitApiFactory && splitApiFactory(settings, platform, telemetryTracker);
 
-  const ctx: ISdkFactoryContext = { splitApi, eventTracker, impressionsTracker, telemetryTracker, sdkReadinessManager, readiness, settings, storage, platform };
+  const ctx: ISdkFactoryContext = { splitApi, eventTracker, impressionsTracker, telemetryTracker, uniqueKeysTracker, sdkReadinessManager, readiness, settings, storage, platform };
 
   const syncManager = syncManagerFactory && syncManagerFactory(ctx as ISdkFactoryContextSync);
   ctx.syncManager = syncManager;

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -29,6 +29,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
     integrationsManagerFactory, sdkManagerFactory, sdkClientMethodFactory,
     filterAdapterFactory } = params;
   const log = settings.log;
+  const impressionsMode = settings.sync.impressionsMode;
 
   // @TODO handle non-recoverable errors, such as, global `fetch` not available, invalid API Key, etc.
   // On non-recoverable errors, we should mark the SDK as destroyed and not start synchronization.
@@ -69,10 +70,9 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   const integrationsManager = integrationsManagerFactory && integrationsManagerFactory({ settings, storage });
 
   const observer = impressionsObserverFactory();
-  const filterAdapter = filterAdapterFactory && filterAdapterFactory();
-  const uniqueKeysTracker = uniqueKeysTrackerFactory(log, filterAdapter);
+  const uniqueKeysTracker = impressionsMode === NONE ? uniqueKeysTrackerFactory(log, filterAdapterFactory && filterAdapterFactory()) : undefined;
   const strategy = (storageFactoryParams.optimize) ? strategyOptimizedFactory(observer, storage.impressionCounts!) :
-    (settings.sync.impressionsMode === NONE) ? strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker) : strategyDebugFactory(observer);
+    (impressionsMode === NONE) ? strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker!) : strategyDebugFactory(observer);
 
   const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, strategy, integrationsManager, storage.telemetry);
   const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager, storage.telemetry);

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -6,7 +6,7 @@ import { IFetch, ISplitApi, IEventSourceConstructor } from '../services/types';
 import { IStorageAsync, IStorageSync, ISplitsCacheSync, ISplitsCacheAsync, IStorageFactoryParams } from '../storages/types';
 import { ISyncManager } from '../sync/types';
 import { IImpressionObserver } from '../trackers/impressionObserver/types';
-import { IImpressionsTracker, IEventTracker, ITelemetryTracker, IFilterAdapter } from '../trackers/types';
+import { IImpressionsTracker, IEventTracker, ITelemetryTracker, IFilterAdapter, IUniqueKeysTracker } from '../trackers/types';
 import { SplitIO, ISettings, IEventEmitter } from '../types';
 
 /**
@@ -43,6 +43,7 @@ export interface ISdkFactoryContext {
   impressionsTracker: IImpressionsTracker,
   eventTracker: IEventTracker,
   telemetryTracker: ITelemetryTracker,
+  uniqueKeysTracker: IUniqueKeysTracker,
   storage: IStorageSync | IStorageAsync,
   signalListener?: ISignalListener
   splitApi?: ISplitApi

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -43,8 +43,8 @@ export interface ISdkFactoryContext {
   impressionsTracker: IImpressionsTracker,
   eventTracker: IEventTracker,
   telemetryTracker: ITelemetryTracker,
-  uniqueKeysTracker: IUniqueKeysTracker,
   storage: IStorageSync | IStorageAsync,
+  uniqueKeysTracker?: IUniqueKeysTracker,
   signalListener?: ISignalListener
   splitApi?: ISplitApi
   syncManager?: ISyncManager,

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -108,14 +108,25 @@ export function splitApiFactory(
     },
     
     /**
-     * Post unique keys.
+     * Post unique keys for client side.
      *
      * @param body  unique keys payload
      * @param headers  Optionals headers to overwrite default ones. For example, it is used in producer mode to overwrite metadata headers.
      */
-    postUniqueKeysBulk(body: string, headers?: Record<string, string>) {
-      const url = `${urls.events}/uniqueKeys/bulk`;
-      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(IMPRESSIONS));
+    postUniqueKeysBulkCs(body: string, headers?: Record<string, string>) {
+      const url = `${urls.telemetry}/api/v1/keys/cs`;
+      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY));
+    },
+    
+    /**
+     * Post unique keys for server side.
+     *
+     * @param body  unique keys payload
+     * @param headers  Optionals headers to overwrite default ones. For example, it is used in producer mode to overwrite metadata headers.
+     */
+    postUniqueKeysBulkSs(body: string, headers?: Record<string, string>) {
+      const url = `${urls.telemetry}/api/v1/keys/ss`;
+      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY));
     },
 
     postMetricsConfig(body: string) {

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -106,6 +106,17 @@ export function splitApiFactory(
       const url = `${urls.events}/testImpressions/count`;
       return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(IMPRESSIONS_COUNT));
     },
+    
+    /**
+     * Post unique keys.
+     *
+     * @param body  unique keys payload
+     * @param headers  Optionals headers to overwrite default ones. For example, it is used in producer mode to overwrite metadata headers.
+     */
+    postUniqueKeysBulk(body: string, headers?: Record<string, string>) {
+      const url = `${urls.events}/uniqueKeys/bulk`;
+      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(IMPRESSIONS));
+    },
 
     postMetricsConfig(body: string) {
       const url = `${urls.telemetry}/v1/metrics/config`;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -43,7 +43,9 @@ export type IFetchMySegments = (userMatchingKey: string, noCache?: boolean) => P
 
 export type IPostEventsBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
-export type IPostUniqueKeysBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
+export type IPostUniqueKeysBulkCs = (body: string, headers?: Record<string, string>) => Promise<IResponse>
+
+export type IPostUniqueKeysBulkSs = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
 export type IPostTestImpressionsBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
@@ -61,7 +63,8 @@ export interface ISplitApi {
 	fetchSegmentChanges: IFetchSegmentChanges
 	fetchMySegments: IFetchMySegments
 	postEventsBulk: IPostEventsBulk
-	postUniqueKeysBulk: IPostUniqueKeysBulk
+	postUniqueKeysBulkCs: IPostUniqueKeysBulkCs
+	postUniqueKeysBulkSs: IPostUniqueKeysBulkSs
 	postTestImpressionsBulk: IPostTestImpressionsBulk
 	postTestImpressionsCount: IPostTestImpressionsCount
 	postMetricsConfig: IPostMetricsConfig

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -43,6 +43,8 @@ export type IFetchMySegments = (userMatchingKey: string, noCache?: boolean) => P
 
 export type IPostEventsBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
+export type IPostUniqueKeysBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
+
 export type IPostTestImpressionsBulk = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
 export type IPostTestImpressionsCount = (body: string, headers?: Record<string, string>) => Promise<IResponse>
@@ -59,6 +61,7 @@ export interface ISplitApi {
 	fetchSegmentChanges: IFetchSegmentChanges
 	fetchMySegments: IFetchMySegments
 	postEventsBulk: IPostEventsBulk
+	postUniqueKeysBulk: IPostUniqueKeysBulk
 	postTestImpressionsBulk: IPostTestImpressionsBulk
 	postTestImpressionsCount: IPostTestImpressionsCount
 	postMetricsConfig: IPostMetricsConfig

--- a/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
@@ -1,0 +1,51 @@
+import { uniqueKeysSubmitterFactory } from '../uniqueKeysSubmitter';
+import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
+import { uniqueKeysTrackerFactory } from '../../../trackers/uniqueKeysTracker';
+
+const imp1 = {
+  feature: 'someFeature',
+  keyName: 'k1',
+  changeNumber: 123,
+  label: 'someLabel',
+  treatment: 'someTreatment',
+  time: 0
+};
+const imp2 = { ...imp1, keyName: 'k2' };
+const imp3 = { ...imp1, keyName: 'k3' };
+
+describe('uniqueKeys submitter', () => {
+
+  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock);
+  const params: any = {
+    settings: { log: loggerMock, scheduler: { uniqueKeysRefreshRate: 200 }, core: {} },
+    storage: { uniqueKeys: uniqueKeysTracker },
+    splitApi: { postUniqueKeysBulk: jest.fn(() => Promise.resolve()) },
+  };
+
+  beforeEach(() => {
+    params.splitApi.postUniqueKeysBulk.mockClear();
+  });
+
+  test('doesn\'t drop items from cache when POST is resolved', (done) => {
+    const uniqueKeysSubmitter = uniqueKeysSubmitterFactory(params);
+    uniqueKeysTracker.track(imp1.feature, imp1.keyName);
+    uniqueKeysSubmitter.start();
+
+    // Tracking unique keys when POST is pending
+    uniqueKeysTracker.track(imp2.feature, imp2.keyName);
+    // Tracking unique keys after POST is resolved
+    setTimeout(() => { uniqueKeysTracker.track(imp3.feature, imp3.keyName); });
+
+    setTimeout(() => {
+      expect(params.splitApi.postUniqueKeysBulk.mock.calls).toEqual([
+        // POST with imp1
+        ['[{"f":"someFeature","k":["k1"]}]'],
+        // POST with imp2 and imp3
+        ['[{"f":"someFeature","k":["k2","k3"]}]']]);
+      uniqueKeysSubmitter.stop();
+
+      done();
+    }, params.settings.scheduler.uniqueKeysRefreshRate + 10);
+  });
+  
+});

--- a/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
@@ -12,36 +12,67 @@ const imp1 = {
 };
 const imp2 = { ...imp1, keyName: 'k2' };
 const imp3 = { ...imp1, keyName: 'k3' };
+const imp4 = { ...imp1, keyName: 'k3', feature: 'anotherFeature' };
 
 describe('uniqueKeys submitter', () => {
 
   const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock);
   const params: any = {
-    settings: { log: loggerMock, scheduler: { uniqueKeysRefreshRate: 200 }, core: {} },
+    settings: { log: loggerMock, scheduler: { uniqueKeysRefreshRate: 200 }, core: { key: undefined} },
     storage: { uniqueKeys: uniqueKeysTracker },
-    splitApi: { postUniqueKeysBulk: jest.fn(() => Promise.resolve()) },
+    splitApi: { 
+      postUniqueKeysBulkCs: jest.fn(() => Promise.resolve()),
+      postUniqueKeysBulkSs: jest.fn(() => Promise.resolve()) }
   };
 
   beforeEach(() => {
-    params.splitApi.postUniqueKeysBulk.mockClear();
+    params.splitApi.postUniqueKeysBulkCs.mockClear();
+    params.splitApi.postUniqueKeysBulkSs.mockClear();
   });
 
-  test('doesn\'t drop items from cache when POST is resolved', (done) => {
+  test('doesn\'t drop items from cache when POST is resolved SS', (done) => {
     const uniqueKeysSubmitter = uniqueKeysSubmitterFactory(params);
     uniqueKeysTracker.track(imp1.feature, imp1.keyName);
     uniqueKeysSubmitter.start();
 
     // Tracking unique keys when POST is pending
     uniqueKeysTracker.track(imp2.feature, imp2.keyName);
+    uniqueKeysTracker.track(imp3.feature, imp3.keyName);
     // Tracking unique keys after POST is resolved
-    setTimeout(() => { uniqueKeysTracker.track(imp3.feature, imp3.keyName); });
+    setTimeout(() => { uniqueKeysTracker.track(imp4.feature, imp4.keyName); });
 
     setTimeout(() => {
-      expect(params.splitApi.postUniqueKeysBulk.mock.calls).toEqual([
+      expect(params.splitApi.postUniqueKeysBulkCs.mock.calls).toEqual([]);
+      expect(params.splitApi.postUniqueKeysBulkSs.mock.calls).toEqual([
         // POST with imp1
-        ['[{"f":"someFeature","k":["k1"]}]'],
+        ['{"keys":[{"f":"someFeature","ks":["k1"]}]}'],
         // POST with imp2 and imp3
-        ['[{"f":"someFeature","k":["k2","k3"]}]']]);
+        ['{"keys":[{"f":"someFeature","ks":["k2","k3"]},{"f":"anotherFeature","ks":["k3"]}]}']]);
+      uniqueKeysSubmitter.stop();
+
+      done();
+    }, params.settings.scheduler.uniqueKeysRefreshRate + 10);
+  });
+  
+  test('doesn\'t drop items from cache when POST is resolved CS', (done) => {
+    params.settings.core.key = 'emma';
+    const uniqueKeysSubmitter = uniqueKeysSubmitterFactory(params);
+    uniqueKeysTracker.track(imp1.feature, imp1.keyName);
+    uniqueKeysSubmitter.start();
+
+    // Tracking unique keys when POST is pending
+    uniqueKeysTracker.track(imp2.feature, imp2.keyName);
+    uniqueKeysTracker.track(imp3.feature, imp3.keyName);
+    // Tracking unique keys after POST is resolved
+    setTimeout(() => { uniqueKeysTracker.track(imp4.feature, imp4.keyName); });
+
+    setTimeout(() => {
+      expect(params.splitApi.postUniqueKeysBulkSs.mock.calls).toEqual([]);
+      expect(params.splitApi.postUniqueKeysBulkCs.mock.calls).toEqual([
+        // POST with imp1
+        ['{"keys":[{"k":"k1","fs":["someFeature"]}]}'],
+        // POST with imp2 and imp3
+        ['{"keys":[{"k":"k2","fs":["someFeature"]},{"k":"k3","fs":["someFeature","anotherFeature"]}]}']]);
       uniqueKeysSubmitter.stop();
 
       done();

--- a/src/sync/submitters/submitterManager.ts
+++ b/src/sync/submitters/submitterManager.ts
@@ -4,6 +4,7 @@ import { impressionCountsSubmitterFactory } from './impressionCountsSubmitter';
 import { telemetrySubmitterFactory } from './telemetrySubmitter';
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 import { ISubmitterManager } from './types';
+import { uniqueKeysSubmitterFactory } from './uniqueKeysSubmitter';
 
 export function submitterManagerFactory(params: ISdkFactoryContextSync): ISubmitterManager {
 
@@ -15,6 +16,7 @@ export function submitterManagerFactory(params: ISdkFactoryContextSync): ISubmit
   const impressionCountsSubmitter = impressionCountsSubmitterFactory(params);
   if (impressionCountsSubmitter) submitters.push(impressionCountsSubmitter);
   const telemetrySubmitter = telemetrySubmitterFactory(params);
+  if (params.uniqueKeysTracker) submitters.push(uniqueKeysSubmitterFactory(params));
 
   return {
     // `onlyTelemetry` true if SDK is created with userConsent not GRANTED

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -35,6 +35,13 @@ export type ImpressionCountsPayload = {
   }[]
 }
 
+export type UniqueKeysPayload = {
+  /** Split name */
+  f: string
+  /** keyNames */
+  k: string[]
+}[]
+
 export type StoredImpressionWithMetadata = {
   /** Metadata */
   m: IMetadata,

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -35,12 +35,23 @@ export type ImpressionCountsPayload = {
   }[]
 }
 
-export type UniqueKeysPayload = {
-  /** Split name */
-  f: string
-  /** keyNames */
-  k: string[]
-}[]
+export type UniqueKeysPayloadSs = {
+  keys: {
+    /** Split name */
+    f: string
+    /** keyNames */
+    ks: string[]
+  }[]
+}
+
+export type UniqueKeysPayloadCs = {
+  keys: {
+    /** keyNames */
+    k: string
+    /** Split name */
+    fs: string[]
+  }[]
+}
 
 export type StoredImpressionWithMetadata = {
   /** Metadata */

--- a/src/sync/submitters/uniqueKeysSubmitter.ts
+++ b/src/sync/submitters/uniqueKeysSubmitter.ts
@@ -1,0 +1,37 @@
+import { ISdkFactoryContextSync } from '../../sdkFactory/types';
+import { ISet, setToArray } from '../../utils/lang/sets';
+import { submitterFactory } from './submitter';
+import { UniqueKeysPayload } from './types';
+
+/**
+ * Converts `uniqueKeys` data from cache into request payload.
+ */
+export function fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayload {
+  const payload = [];
+  const keys = Object.keys(uniqueKeys);
+  for (let i = 0; i < keys.length; i++) {
+    const featureName = keys[i];
+    const featureKeys = setToArray(uniqueKeys[featureName]);
+    const uniqueKeysPayload = {
+      f: featureName,
+      k: featureKeys
+    };
+
+    payload.push(uniqueKeysPayload);
+  }
+  return payload;
+}
+
+/**
+ * Submitter that periodically posts impression counts
+ */
+export function uniqueKeysSubmitterFactory(params: ISdkFactoryContextSync) {
+
+  const {
+    settings: { log, scheduler: { uniqueKeysRefreshRate } },
+    splitApi: { postUniqueKeysBulk },
+    storage: { uniqueKeys }
+  } = params;
+
+  return submitterFactory(log, postUniqueKeysBulk, uniqueKeys!, uniqueKeysRefreshRate, 'unique keys', fromUniqueKeysCollector, 1);
+}

--- a/src/sync/submitters/uniqueKeysSubmitter.ts
+++ b/src/sync/submitters/uniqueKeysSubmitter.ts
@@ -1,25 +1,62 @@
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 import { ISet, setToArray } from '../../utils/lang/sets';
 import { submitterFactory } from './submitter';
-import { UniqueKeysPayload } from './types';
+import { UniqueKeysPayloadCs, UniqueKeysPayloadSs } from './types';
+
+/** 
+ * Invert keys for feature to features for key
+ */
+function invertUniqueKeys(uniqueKeys: { [featureName: string]: ISet<string> }): { [key: string]: string[] } {
+  const featureNames = Object.keys(uniqueKeys);
+  const inverted: { [key: string]: string[] } = {};
+  for (let i = 0; i < featureNames.length; i++) {
+    const featureName = featureNames[i];
+    const featureKeys = setToArray(uniqueKeys[featureName]);
+    for (let j = 0; j< featureKeys.length; j++) {
+      const featureKey = featureKeys[j];
+      if (!inverted[featureKey]) inverted[featureKey] = []; 
+      inverted[featureKey].push(featureName);
+    }
+  }
+  return inverted;
+}
 
 /**
- * Converts `uniqueKeys` data from cache into request payload.
+ * Converts `uniqueKeys` data from cache into request payload for CS.
  */
-export function fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayload {
+export function fromUniqueKeysCollectorCs(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadCs {
   const payload = [];
-  const keys = Object.keys(uniqueKeys);
-  for (let i = 0; i < keys.length; i++) {
-    const featureName = keys[i];
-    const featureKeys = setToArray(uniqueKeys[featureName]);
+  const featuresPerKey = invertUniqueKeys(uniqueKeys);
+  const keys = Object.keys(featuresPerKey);
+  for (let k = 0; k < keys.length; k++) {
+    const key = keys[k];
     const uniqueKeysPayload = {
-      f: featureName,
-      k: featureKeys
+      k: key,
+      fs: featuresPerKey[key]
     };
 
     payload.push(uniqueKeysPayload);
   }
-  return payload;
+  return { keys: payload };
+}
+
+/**
+ * Converts `uniqueKeys` data from cache into request payload for SS.
+ */
+export function fromUniqueKeysCollectorSs(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadSs {
+  const payload = [];
+  const featureNames = Object.keys(uniqueKeys);
+  for (let i = 0; i < featureNames.length; i++) {
+    const featureName = featureNames[i];
+    const featureKeys = setToArray(uniqueKeys[featureName]);
+    const uniqueKeysPayload = {
+      f: featureName,
+      ks: featureKeys
+    };
+
+    payload.push(uniqueKeysPayload);
+  }
+  return { keys: payload };
 }
 
 /**
@@ -28,10 +65,15 @@ export function fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISe
 export function uniqueKeysSubmitterFactory(params: ISdkFactoryContextSync) {
 
   const {
-    settings: { log, scheduler: { uniqueKeysRefreshRate } },
-    splitApi: { postUniqueKeysBulk },
+    settings: { log, scheduler: { uniqueKeysRefreshRate }, core: {key}},
+    splitApi: { postUniqueKeysBulkCs, postUniqueKeysBulkSs },
     storage: { uniqueKeys }
   } = params;
+  
+  const isClientSide = key !== undefined;
+  const postUniqueKeysBulk = isClientSide ? postUniqueKeysBulkCs : postUniqueKeysBulkSs;
+  const fromUniqueKeysCollector = isClientSide ? fromUniqueKeysCollectorCs : fromUniqueKeysCollectorSs;
 
-  return submitterFactory(log, postUniqueKeysBulk, uniqueKeys!, uniqueKeysRefreshRate, 'unique keys', fromUniqueKeysCollector, 1);
+  return submitterFactory(log, postUniqueKeysBulk, uniqueKeys!, uniqueKeysRefreshRate, 'unique keys', fromUniqueKeysCollector);
 }
+

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -4,11 +4,6 @@ import { LOG_PREFIX_UNIQUE_KEYS_TRACKER } from '../../logger/constants';
 
 describe('Unique keys tracker', () => {
 
-  const fakeSenderAdapter = {
-    recordUniqueKeys: jest.fn(() => {}),
-    recordImpressionCounts: jest.fn(() => {})
-  };
-  
   const fakeFilter = {
     add: jest.fn(() => { return true; }),
     contains: jest.fn(() => { return true; }),
@@ -17,7 +12,7 @@ describe('Unique keys tracker', () => {
 
   test('With filter', () => { 
     
-    const simpleTracker = uniqueKeysTrackerFactory(loggerMock, fakeFilter, 4, fakeSenderAdapter);
+    const simpleTracker = uniqueKeysTrackerFactory(loggerMock, fakeFilter, 4);
     
     simpleTracker.track('feature1', 'key1');
     simpleTracker.track('feature1', 'key2');
@@ -26,16 +21,9 @@ describe('Unique keys tracker', () => {
     simpleTracker.track('feature1', 'key1');
     simpleTracker.track('feature2', 'key3');
     
-    expect(fakeSenderAdapter.recordUniqueKeys).not.toBeCalled();
-    
     fakeFilter.add = jest.fn(() => { return true; });
     simpleTracker.track('feature2', 'key4');
     
-    expect(fakeSenderAdapter.recordUniqueKeys)
-      .toBeCalledWith({
-        'feature1': new Set (['key1','key2']),
-        'feature2': new Set (['key3','key4'])
-      });
     expect(loggerMock.warn).toBeCalledWith(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The UniqueKeysTracker size reached the maximum limit`);
     
   });

--- a/src/trackers/strategy/__tests__/strategyNone.spec.ts
+++ b/src/trackers/strategy/__tests__/strategyNone.spec.ts
@@ -5,11 +5,6 @@ import { impression1, impression2, processStrategy } from './testUtils';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { LOG_PREFIX_UNIQUE_KEYS_TRACKER } from '../../../logger/constants';
 
-const fakeSenderAdapter = {
-  recordUniqueKeys: jest.fn(() => {}),
-  recordImpressionCounts: jest.fn(() => {})
-};
-
 const fakeFilter = {
   add: jest.fn(() => { return true; }),
   contains: jest.fn(() => { return true; }),
@@ -18,7 +13,7 @@ const fakeFilter = {
 
 test('strategyNone', () => {
   const impressionCountsCache = new ImpressionCountsCacheInMemory();
-  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeFilter, 4, fakeSenderAdapter);
+  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeFilter, 4);
   
   let impressions = [
     impression1, 
@@ -37,11 +32,6 @@ test('strategyNone', () => {
   expect(impressionsToListener).toStrictEqual(impressions);
   expect(deduped).toStrictEqual(0);
   
-  expect(fakeSenderAdapter.recordUniqueKeys)
-    .toBeCalledWith({
-      'qc_team': new Set (['emma@split.io','nico@split.io','emi@split.io']),
-      'qc_team_2': new Set (['emma@split.io'])
-    });
   expect(loggerMock.warn).toBeCalledWith(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The UniqueKeysTracker size reached the maximum limit`);
     
   

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -2,6 +2,7 @@ import { SplitIO, ImpressionDTO } from '../types';
 import { StreamingEventType, Method, OperationType } from '../sync/submitters/types';
 import { IEventsCacheBase } from '../storages/types';
 import { NetworkError } from '../services/types';
+import { ISet } from '../utils/lang/sets';
 
 /** Events tracker */
 
@@ -56,9 +57,10 @@ export interface IImpressionSenderAdapter {
 
 /** Unique keys tracker */
 export interface IUniqueKeysTracker {
-  track(key: string, featureName: string): void;
-  start(): void;
-  stop(): void;
+  track(featureName: string, key: string): void;
+  pop(toMerge?: { [featureName: string]: ISet<string> }): { [featureName: string]: ISet<string>; };
+  clear(): void;
+  isEmpty(): boolean;
 }
 
 export interface IStrategyResult {

--- a/src/trackers/uniqueKeysTracker.ts
+++ b/src/trackers/uniqueKeysTracker.ts
@@ -55,16 +55,9 @@ export function uniqueKeysTrackerFactory(
     /**
      * Pop the collected data, used as payload for posting.
      */
-    pop(toMerge?: { [featureName: string]: ISet<string> }) {
+    pop() {
       const data = uniqueKeysTracker;
       uniqueKeysTracker = {};
-      if (toMerge) {
-        Object.keys(data).forEach((key) => {
-          if (toMerge[key]) toMerge[key] = {...toMerge[key],...data[key]};
-          else toMerge[key] = data[key];
-        });
-        return toMerge;
-      }
       return data;
     },
 

--- a/src/trackers/uniqueKeysTracker.ts
+++ b/src/trackers/uniqueKeysTracker.ts
@@ -1,7 +1,7 @@
 import { LOG_PREFIX_UNIQUE_KEYS_TRACKER } from '../logger/constants';
 import { ILogger } from '../logger/types';
 import { ISet, _Set } from '../utils/lang/sets';
-import { IFilterAdapter, IImpressionSenderAdapter, IUniqueKeysTracker } from './types';
+import { IFilterAdapter, IUniqueKeysTracker } from './types';
 
 const noopFilterAdapter = {
   add() {return true;},
@@ -16,23 +16,19 @@ const DEFAULT_CACHE_SIZE = 30000;
  *  or schedule to be sent; if not it will be added in an internal cache and sent in the next post. 
  * 
  * @param log Logger instance
- * @param senderAdapter Impressions sender adapter
  * @param filterAdapter filter adapter
  * @param cacheSize optional internal cache size
  * @param maxBulkSize optional max MTKs bulk size
- * @param taskRefreshRate optional task refresh rate
  */
 export function uniqueKeysTrackerFactory(
   log: ILogger,
   filterAdapter: IFilterAdapter = noopFilterAdapter,
   cacheSize = DEFAULT_CACHE_SIZE,
-  senderAdapter?: IImpressionSenderAdapter,
   // @TODO
   // maxBulkSize: number = 5000,
-  // taskRefreshRate: number = 15,
 ): IUniqueKeysTracker {
   
-  const uniqueKeysTracker: { [featureName: string]: ISet<string> } = {};
+  let uniqueKeysTracker: { [featureName: string]: ISet<string> } = {};
   let uniqueTrackerSize = 0;
   
   return {
@@ -51,17 +47,39 @@ export function uniqueKeysTrackerFactory(
       
       if (uniqueTrackerSize >= cacheSize) {
         log.warn(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The UniqueKeysTracker size reached the maximum limit`);
-        senderAdapter && senderAdapter.recordUniqueKeys(uniqueKeysTracker);
+        // @TODO trigger event to submitter to send mtk
         uniqueTrackerSize = 0;
       }
     },
     
-    start(): void {
-      // @TODO
+    /**
+     * Pop the collected data, used as payload for posting.
+     */
+    pop(toMerge?: { [featureName: string]: ISet<string> }) {
+      const data = uniqueKeysTracker;
+      uniqueKeysTracker = {};
+      if (toMerge) {
+        Object.keys(data).forEach((key) => {
+          if (toMerge[key]) toMerge[key] = {...toMerge[key],...data[key]};
+          else toMerge[key] = data[key];
+        });
+        return toMerge;
+      }
+      return data;
     },
-    
-    stop(): void {
-      // @TODO
+
+    /**
+     * Clear the data stored on the cache.
+     */
+    clear() {
+      uniqueKeysTracker = {};
+    },
+
+    /**
+     * Check if the cache is empty.
+     */
+    isEmpty() {
+      return Object.keys(uniqueKeysTracker).length === 0;
     }
     
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface ISettings {
     featuresRefreshRate: number,
     impressionsRefreshRate: number,
     impressionsQueueSize: number,
+    uniqueKeysRefreshRate: number,
     /**
      * @deprecated
      */

--- a/src/utils/settingsValidation/__tests__/settings.mocks.ts
+++ b/src/utils/settingsValidation/__tests__/settings.mocks.ts
@@ -52,6 +52,7 @@ export const fullSettings: ISettings = {
     impressionsRefreshRate: 1,
     telemetryRefreshRate: 1,
     segmentsRefreshRate: 1,
+    uniqueKeysRefreshRate: 1,
     offlineRefreshRate: 1,
     eventsPushRate: 1,
     eventsQueueSize: 1,

--- a/src/utils/settingsValidation/index.ts
+++ b/src/utils/settingsValidation/index.ts
@@ -1,7 +1,7 @@
 import { merge, get } from '../lang';
 import { mode } from './mode';
 import { validateSplitFilters } from './splitFilters';
-import { STANDALONE_MODE, OPTIMIZED, LOCALHOST_MODE, DEBUG } from '../constants';
+import { STANDALONE_MODE, OPTIMIZED, LOCALHOST_MODE, DEBUG, NONE } from '../constants';
 import { validImpressionsMode } from './impressionsMode';
 import { ISettingsValidationParams } from './types';
 import { ISettings } from '../../types';
@@ -137,6 +137,10 @@ export function settingsValidation(config: unknown, validationParams: ISettingsV
   // Default impressionsRefreshRate for DEBUG mode is 60 secs
   if (get(config, 'scheduler.impressionsRefreshRate') === undefined && withDefaults.sync.impressionsMode === DEBUG) scheduler.impressionsRefreshRate = 60;
   scheduler.impressionsRefreshRate = fromSecondsToMillis(scheduler.impressionsRefreshRate);
+  
+  // Default uniqueKeysRefreshRate for NONE mode is 15 mins
+  if (get(config, 'scheduler.uniqueKeysRefreshRate') === undefined && withDefaults.sync.impressionsMode === NONE) scheduler.uniqueKeysRefreshRate = 900;
+  scheduler.uniqueKeysRefreshRate = fromSecondsToMillis(scheduler.uniqueKeysRefreshRate);
 
   // Log deprecation for old telemetry param
   if (scheduler.metricsRefreshRate) log.warn('`metricsRefreshRate` will be deprecated soon. For configuring telemetry rates, update `telemetryRefreshRate` value in configs');

--- a/src/utils/settingsValidation/index.ts
+++ b/src/utils/settingsValidation/index.ts
@@ -36,6 +36,8 @@ export const base = {
     telemetryRefreshRate: 3600,
     // publish evaluations each 300 sec (default value for OPTIMIZED impressions mode)
     impressionsRefreshRate: 300,
+    // publish unique Keys each 900 sec (15 min) 
+    uniqueKeysRefreshRate: 900,
     // fetch offline changes each 15 sec
     offlineRefreshRate: 15,
     // publish events every 60 seconds after the first flush

--- a/src/utils/settingsValidation/index.ts
+++ b/src/utils/settingsValidation/index.ts
@@ -1,7 +1,7 @@
 import { merge, get } from '../lang';
 import { mode } from './mode';
 import { validateSplitFilters } from './splitFilters';
-import { STANDALONE_MODE, OPTIMIZED, LOCALHOST_MODE, DEBUG, NONE } from '../constants';
+import { STANDALONE_MODE, OPTIMIZED, LOCALHOST_MODE, DEBUG } from '../constants';
 import { validImpressionsMode } from './impressionsMode';
 import { ISettingsValidationParams } from './types';
 import { ISettings } from '../../types';
@@ -132,15 +132,13 @@ export function settingsValidation(config: unknown, validationParams: ISettingsV
   scheduler.segmentsRefreshRate = fromSecondsToMillis(scheduler.segmentsRefreshRate);
   scheduler.offlineRefreshRate = fromSecondsToMillis(scheduler.offlineRefreshRate);
   scheduler.eventsPushRate = fromSecondsToMillis(scheduler.eventsPushRate);
+  scheduler.uniqueKeysRefreshRate = fromSecondsToMillis(scheduler.uniqueKeysRefreshRate);
   scheduler.telemetryRefreshRate = fromSecondsToMillis(validateMinValue('telemetryRefreshRate', scheduler.telemetryRefreshRate, 60));
 
   // Default impressionsRefreshRate for DEBUG mode is 60 secs
   if (get(config, 'scheduler.impressionsRefreshRate') === undefined && withDefaults.sync.impressionsMode === DEBUG) scheduler.impressionsRefreshRate = 60;
   scheduler.impressionsRefreshRate = fromSecondsToMillis(scheduler.impressionsRefreshRate);
   
-  // Default uniqueKeysRefreshRate for NONE mode is 15 mins
-  if (get(config, 'scheduler.uniqueKeysRefreshRate') === undefined && withDefaults.sync.impressionsMode === NONE) scheduler.uniqueKeysRefreshRate = 900;
-  scheduler.uniqueKeysRefreshRate = fromSecondsToMillis(scheduler.uniqueKeysRefreshRate);
 
   // Log deprecation for old telemetry param
   if (scheduler.metricsRefreshRate) log.warn('`metricsRefreshRate` will be deprecated soon. For configuring telemetry rates, update `telemetryRefreshRate` value in configs');


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
Create uniqueKeysSubmitter
Add uniqueKeysSubmitter to SyncManager
Add pop, clear and is empty methods to uniqueKeysTracker to be used as submitter cache
Remove senderAdapter from uniqueKeysTracker since that functionality will be on uniqueKeysSubmitter
Fix uniqueKeysTracker tests
Fix types

## How do we test the changes introduced in this PR?
Unit tests included

## Extra Notes