### PR TITLE
[REFACTOR] Add uniqueKeysCacheInMemory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.1",
+  "version": "1.6.2-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.1",
+  "version": "1.6.2-rc.2",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -43,6 +43,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   const storageFactoryParams: IStorageFactoryParams = {
     impressionsQueueSize: settings.scheduler.impressionsQueueSize,
     eventsQueueSize: settings.scheduler.eventsQueueSize,
+    uniqueKeysCacheSize: settings.scheduler.uniqueKeysCacheSize,
     optimize: shouldBeOptimized(settings),
 
     // ATM, only used by InLocalStorage

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -29,7 +29,6 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
     integrationsManagerFactory, sdkManagerFactory, sdkClientMethodFactory,
     filterAdapterFactory } = params;
   const log = settings.log;
-  const impressionsMode = settings.sync.impressionsMode;
 
   // @TODO handle non-recoverable errors, such as, global `fetch` not available, invalid API Key, etc.
   // On non-recoverable errors, we should mark the SDK as destroyed and not start synchronization.
@@ -52,6 +51,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
 
     // ATM, only used by PluggableStorage
     mode: settings.mode,
+    impressionsMode: settings.sync.impressionsMode,
 
     // Callback used to emit SDK_READY in consumer mode, where `syncManagerFactory` is undefined,
     // or partial consumer mode, where it only has submitters, and therefore it doesn't emit readiness events.
@@ -70,9 +70,9 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
   const integrationsManager = integrationsManagerFactory && integrationsManagerFactory({ settings, storage });
 
   const observer = impressionsObserverFactory();
-  const uniqueKeysTracker = impressionsMode === NONE ? uniqueKeysTrackerFactory(log, filterAdapterFactory && filterAdapterFactory()) : undefined;
+  const uniqueKeysTracker = storageFactoryParams.impressionsMode === NONE ? uniqueKeysTrackerFactory(log, storage.uniqueKeys!, filterAdapterFactory && filterAdapterFactory()) : undefined;
   const strategy = (storageFactoryParams.optimize) ? strategyOptimizedFactory(observer, storage.impressionCounts!) :
-    (impressionsMode === NONE) ? strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker!) : strategyDebugFactory(observer);
+    (storageFactoryParams.impressionsMode === NONE) ? strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker!) : strategyDebugFactory(observer);
 
   const impressionsTracker = impressionsTrackerFactory(settings, storage.impressions, strategy, integrationsManager, storage.telemetry);
   const eventTracker = eventTrackerFactory(settings, storage.events, integrationsManager, storage.telemetry);

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -114,7 +114,7 @@ export function splitApiFactory(
      * @param headers  Optionals headers to overwrite default ones. For example, it is used in producer mode to overwrite metadata headers.
      */
     postUniqueKeysBulkCs(body: string, headers?: Record<string, string>) {
-      const url = `${urls.telemetry}/api/v1/keys/cs`;
+      const url = `${urls.telemetry}/v1/keys/cs`;
       return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY));
     },
     
@@ -125,7 +125,7 @@ export function splitApiFactory(
      * @param headers  Optionals headers to overwrite default ones. For example, it is used in producer mode to overwrite metadata headers.
      */
     postUniqueKeysBulkSs(body: string, headers?: Record<string, string>) {
-      const url = `${urls.telemetry}/api/v1/keys/ss`;
+      const url = `${urls.telemetry}/v1/keys/ss`;
       return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY));
     },
 

--- a/src/storages/inLocalStorage/index.ts
+++ b/src/storages/inLocalStorage/index.ts
@@ -12,8 +12,9 @@ import { SplitsCacheInMemory } from '../inMemory/SplitsCacheInMemory';
 import { DEFAULT_CACHE_EXPIRATION_IN_MILLIS } from '../../utils/constants/browser';
 import { InMemoryStorageCSFactory } from '../inMemory/InMemoryStorageCS';
 import { LOG_PREFIX } from './constants';
-import { LOCALHOST_MODE, STORAGE_LOCALSTORAGE } from '../../utils/constants';
+import { LOCALHOST_MODE, NONE, STORAGE_LOCALSTORAGE } from '../../utils/constants';
 import { shouldRecordTelemetry, TelemetryCacheInMemory } from '../inMemory/TelemetryCacheInMemory';
+import { UniqueKeysCacheInMemoryCS } from '../inMemory/uniqueKeysCacheInMemoryCS';
 
 export interface InLocalStorageOptions {
   prefix?: string
@@ -45,6 +46,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
       impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
       events: new EventsCacheInMemory(params.eventsQueueSize),
       telemetry: params.mode !== LOCALHOST_MODE && shouldRecordTelemetry() ? new TelemetryCacheInMemory() : undefined,
+      uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemoryCS() : undefined,
 
       destroy() {
         this.splits = new SplitsCacheInMemory();
@@ -52,6 +54,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
         this.impressions.clear();
         this.impressionCounts && this.impressionCounts.clear();
         this.events.clear();
+        this.uniqueKeys?.clear();
       },
 
       // When using shared instanciation with MEMORY we reuse everything but segments (they are customer per key).

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -22,7 +22,7 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
     impressionCounts: params.optimize || params.impressionsMode === NONE ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE ? new TelemetryCacheInMemory() : undefined, // Always track telemetry in standalone mode on server-side
-    uniqueKeys: new UniqueKeysCacheInMemory(),
+    uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemory() : undefined,
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -4,7 +4,7 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageFactoryParams, IStorageSync } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
+import { DEBUG, LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
 import { TelemetryCacheInMemory } from './TelemetryCacheInMemory';
 import { UniqueKeysCacheInMemory } from './uniqueKeysCacheInMemory';
 
@@ -19,7 +19,7 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
     splits: new SplitsCacheInMemory(),
     segments: new SegmentsCacheInMemory(),
     impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
-    impressionCounts: params.optimize || params.impressionsMode === NONE ? new ImpressionCountsCacheInMemory() : undefined,
+    impressionCounts: params.impressionsMode !== DEBUG ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE ? new TelemetryCacheInMemory() : undefined, // Always track telemetry in standalone mode on server-side
     uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemory(params.uniqueKeysCacheSize) : undefined,

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -22,7 +22,7 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
     impressionCounts: params.optimize || params.impressionsMode === NONE ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE ? new TelemetryCacheInMemory() : undefined, // Always track telemetry in standalone mode on server-side
-    uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemory() : undefined,
+    uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemory(params.uniqueKeysCacheSize) : undefined,
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -4,8 +4,9 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageFactoryParams, IStorageSync } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, STORAGE_MEMORY } from '../../utils/constants';
+import { LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
 import { TelemetryCacheInMemory } from './TelemetryCacheInMemory';
+import { UniqueKeysCacheInMemory } from './uniqueKeysCacheInMemory';
 
 /**
  * InMemory storage factory for standalone server-side SplitFactory
@@ -18,9 +19,10 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
     splits: new SplitsCacheInMemory(),
     segments: new SegmentsCacheInMemory(),
     impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
-    impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
+    impressionCounts: params.optimize || params.impressionsMode === NONE ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE ? new TelemetryCacheInMemory() : undefined, // Always track telemetry in standalone mode on server-side
+    uniqueKeys: new UniqueKeysCacheInMemory(),
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {
@@ -29,6 +31,7 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
       this.impressions.clear();
       this.impressionCounts && this.impressionCounts.clear();
       this.events.clear();
+      this.uniqueKeys?.clear();
     }
   };
 }

--- a/src/storages/inMemory/InMemoryStorageCS.ts
+++ b/src/storages/inMemory/InMemoryStorageCS.ts
@@ -4,7 +4,7 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageSync, IStorageFactoryParams } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
+import { DEBUG, LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
 import { shouldRecordTelemetry, TelemetryCacheInMemory } from './TelemetryCacheInMemory';
 import { UniqueKeysCacheInMemoryCS } from './uniqueKeysCacheInMemoryCS';
 
@@ -19,7 +19,7 @@ export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorag
     splits: new SplitsCacheInMemory(),
     segments: new MySegmentsCacheInMemory(),
     impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
-    impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
+    impressionCounts: params.impressionsMode !== DEBUG ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE && shouldRecordTelemetry() ? new TelemetryCacheInMemory() : undefined,
     uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemoryCS(params.uniqueKeysCacheSize) : undefined,

--- a/src/storages/inMemory/InMemoryStorageCS.ts
+++ b/src/storages/inMemory/InMemoryStorageCS.ts
@@ -4,8 +4,9 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageSync, IStorageFactoryParams } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, STORAGE_MEMORY } from '../../utils/constants';
+import { LOCALHOST_MODE, NONE, STORAGE_MEMORY } from '../../utils/constants';
 import { shouldRecordTelemetry, TelemetryCacheInMemory } from './TelemetryCacheInMemory';
+import { UniqueKeysCacheInMemoryCS } from './uniqueKeysCacheInMemoryCS';
 
 /**
  * InMemory storage factory for standalone client-side SplitFactory
@@ -21,6 +22,8 @@ export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorag
     impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
     telemetry: params.mode !== LOCALHOST_MODE && shouldRecordTelemetry() ? new TelemetryCacheInMemory() : undefined,
+    uniqueKeys: params.impressionsMode === NONE ? new UniqueKeysCacheInMemoryCS(params.uniqueKeysCacheSize) : undefined,
+    
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {
@@ -29,6 +32,7 @@ export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorag
       this.impressions.clear();
       this.impressionCounts && this.impressionCounts.clear();
       this.events.clear();
+      this.uniqueKeys?.clear();
     },
 
     // When using shared instanciation with MEMORY we reuse everything but segments (they are unique per key)

--- a/src/storages/inMemory/__tests__/uniqueKeysCacheInMemory.spec.ts
+++ b/src/storages/inMemory/__tests__/uniqueKeysCacheInMemory.spec.ts
@@ -1,0 +1,64 @@
+// @ts-nocheck
+import { _Set } from '../../../utils/lang/sets';
+import { UniqueKeysCacheInMemory } from '../uniqueKeysCacheInMemory';
+
+test('UNIQUE KEYS CACHE IN MEMORY / should incrementally store values, clear the queue, and tell if it is empty', () => {
+  const expected = {};
+  expected['key1'] = new _Set();
+  expected['key1'].add('value1');
+  expected['key2'] = new _Set();
+  expected['key2'].add('value2');
+  expected['key1'].add('value3');
+  const c = new UniqueKeysCacheInMemory();
+  
+  // queue is initially empty
+  expect(c.pop()).toEqual({});
+  expect(c.isEmpty()).toBe(true);
+
+  c.track('key1', 'value1');
+  c.track('key2', 'value2');
+  c.track('key1', 'value3');
+
+  expect(c.isEmpty()).toBe(false);
+  expect(c.pop()).toEqual(expected); // all the items should be stored in sequential order
+  expect(c.isEmpty()).toBe(true);
+
+  // should empty the queue
+  c.track('key4', 'value4');
+  c.clear();
+  expect(c.pop()).toEqual({});
+  expect(c.isEmpty()).toBe(true);
+});
+
+test('UNIQUE KEYS CACHE IN MEMORY / Should call "onFullQueueCb" when the queue is full.', () => {
+  let cbCalled = 0;
+  const cache = new UniqueKeysCacheInMemory(3); // small uniqueKeysCache size to be reached
+  cache.setOnFullQueueCb(() => { cbCalled++; cache.clear(); });
+
+  cache.track('key1', 'value1');
+  cache.track('key1', 'value1');
+  expect(cbCalled).toBe(0); // if the storage is not full, it will not run the callback.
+  cache.track('key1', 'value1');
+  expect(cbCalled).toBe(0); // the storage should just have the pair key1 - value1
+  cache.track('key1', 'value2');
+  expect(cbCalled).toBe(0); // storage: {key1: [value1, value2]} size: 2
+  cache.track('key2', 'value3');
+  expect(cbCalled).toBe(1); // storage: {key1: [value1, value2], key2: [value3]} size: 3 FLUSH!
+  cache.track('key2', 'value4');
+  expect(cbCalled).toBe(1); // it should not flush again
+  cache.track('key2', 'value4');
+  expect(cbCalled).toBe(1); // And it should not flush again,
+  cache.track('key3', 'value5');
+  expect(cbCalled).toBe(1); // And it should not flush again,
+  cache.track('key2', 'value6');
+  expect(cbCalled).toBe(2); // Until the queue is filled with events again.
+});
+
+test('UNIQUE KEYS CACHE IN MEMORY / Should not throw if the "onFullQueueCb" callback was not provided.', () => {
+  const cache = new UniqueKeysCacheInMemory(3); // small eventsQueueSize to be reached
+
+  cache.track('key1', 'value1');
+  cache.track('key1', 'value2'); // Cache still not full,
+  expect(cache.track.bind(cache, 'key2', 'value3')).not.toThrow(); // but when it is full, as 'onFullQueueCb' was not provided, nothing happens but no exceptions are thrown.
+  expect(cache.track.bind(cache, 'key3', 'value4')).not.toThrow(); // but when it is full, as 'onFullQueueCb' was not provided, nothing happens but no exceptions are thrown.
+});

--- a/src/storages/inMemory/__tests__/uniqueKeysCacheInMemoryCS.spec.ts
+++ b/src/storages/inMemory/__tests__/uniqueKeysCacheInMemoryCS.spec.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
-import { UniqueKeysCacheInMemory } from '../uniqueKeysCacheInMemory';
+import { UniqueKeysCacheInMemoryCS } from '../uniqueKeysCacheInMemoryCS';
 
-test('UNIQUE KEYS CACHE IN MEMORY / should incrementally store values, clear the queue, and tell if it is empty', () => {
-  const c = new UniqueKeysCacheInMemory();
+test('UNIQUE KEYS CACHE IN MEMORY CS / should incrementally store values, clear the queue, and tell if it is empty', () => {
+  const c = new UniqueKeysCacheInMemoryCS();
   
   // queue is initially empty
   expect(c.pop()).toEqual({keys:[]});
@@ -16,19 +16,15 @@ test('UNIQUE KEYS CACHE IN MEMORY / should incrementally store values, clear the
   expect(c.pop()).toEqual({
     keys: [
       {
-        f: 'value1',
-        ks: ['key1']
+        'fs': ['value1','value3'],
+        'k': 'key1',
       },
       {
-        f: 'value2',
-        ks: ['key2']
-      },
-      {
-        f: 'value3',
-        ks: ['key1']
+        'fs': ['value2'],
+        'k': 'key2',
       }
     ]
-  }); // all the items should be stored in sequential order
+  });
   expect(c.isEmpty()).toBe(true);
 
   // should empty the queue
@@ -40,7 +36,7 @@ test('UNIQUE KEYS CACHE IN MEMORY / should incrementally store values, clear the
 
 test('UNIQUE KEYS CACHE IN MEMORY / Should call "onFullQueueCb" when the queue is full.', () => {
   let cbCalled = 0;
-  const cache = new UniqueKeysCacheInMemory(3); // small uniqueKeysCache size to be reached
+  const cache = new UniqueKeysCacheInMemoryCS(3); // small uniqueKeysCache size to be reached
   cache.setOnFullQueueCb(() => { cbCalled++; cache.clear(); });
 
   cache.track('key1', 'value1');
@@ -63,7 +59,7 @@ test('UNIQUE KEYS CACHE IN MEMORY / Should call "onFullQueueCb" when the queue i
 });
 
 test('UNIQUE KEYS CACHE IN MEMORY / Should not throw if the "onFullQueueCb" callback was not provided.', () => {
-  const cache = new UniqueKeysCacheInMemory(3); // small eventsQueueSize to be reached
+  const cache = new UniqueKeysCacheInMemoryCS(3); // small eventsQueueSize to be reached
 
   cache.track('key1', 'value1');
   cache.track('key1', 'value2'); // Cache still not full,

--- a/src/storages/inMemory/uniqueKeysCacheInMemory.ts
+++ b/src/storages/inMemory/uniqueKeysCacheInMemory.ts
@@ -1,0 +1,68 @@
+import { IUniqueKeysCacheBase } from '../types';
+import { ISet, _Set } from '../../utils/lang/sets';
+
+const DEFAULT_CACHE_SIZE = 30000;
+
+export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
+
+  private onFullQueue?: () => void;
+  private readonly maxStorage: number;
+  private uniqueTrackerSize = 0;
+  private uniqueKeysTracker: { [key: string]: ISet<string> };
+
+  /**
+   *
+   * @param impressionsQueueSize number of queued impressions to call onFullQueueCb.
+   * Default value is 0, that means no maximum value, in case we want to avoid this being triggered.
+   */
+  constructor(uniqueKeysQueueSize: number = DEFAULT_CACHE_SIZE) {
+    this.maxStorage = uniqueKeysQueueSize;
+    this.uniqueKeysTracker = {};
+  }
+
+  setOnFullQueueCb(cb: () => void) {
+    this.onFullQueue = cb;
+  }
+
+  /**
+   * Store unique keys in sequential order
+   */
+  track(key: string, value: string) {
+    
+    if (!this.uniqueKeysTracker[key]) this.uniqueKeysTracker[key] = new _Set();
+    const tracker = this.uniqueKeysTracker[key];
+    if (!tracker.has(value)) {
+      tracker.add(value);
+      this.uniqueTrackerSize++;
+    }
+    
+    if (this.uniqueTrackerSize >= this.maxStorage && this.onFullQueue) {
+      this.uniqueTrackerSize = 0;
+      this.onFullQueue();
+    }
+  }
+
+  /**
+   * Clear the data stored on the cache.
+   */
+  clear() {
+    this.uniqueKeysTracker = {};
+  }
+
+  /**
+   * Pop the collected data, used as payload for posting.
+   */
+  pop() {
+    const data = this.uniqueKeysTracker;
+    this.uniqueKeysTracker = {};
+    return data;
+  }
+
+  /**
+   * Check if the cache is empty.
+   */
+  isEmpty() {
+    return Object.keys(this.uniqueKeysTracker).length === 0;
+  }
+  
+}

--- a/src/storages/inMemory/uniqueKeysCacheInMemory.ts
+++ b/src/storages/inMemory/uniqueKeysCacheInMemory.ts
@@ -9,7 +9,7 @@ export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
   private onFullQueue?: () => void;
   private readonly maxStorage: number;
   private uniqueTrackerSize = 0;
-  private uniqueKeysTracker: { [featureName: string]: ISet<string> };
+  private uniqueKeysTracker: { [keys: string]: ISet<string> };
 
   constructor(uniqueKeysQueueSize: number = DEFAULT_CACHE_SIZE) {
     this.maxStorage = uniqueKeysQueueSize;

--- a/src/storages/inMemory/uniqueKeysCacheInMemory.ts
+++ b/src/storages/inMemory/uniqueKeysCacheInMemory.ts
@@ -9,7 +9,7 @@ export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
   private onFullQueue?: () => void;
   private readonly maxStorage: number;
   private uniqueTrackerSize = 0;
-  private uniqueKeysTracker: { [key: string]: ISet<string> };
+  private uniqueKeysTracker: { [featureName: string]: ISet<string> };
 
   constructor(uniqueKeysQueueSize: number = DEFAULT_CACHE_SIZE) {
     this.maxStorage = uniqueKeysQueueSize;

--- a/src/storages/inMemory/uniqueKeysCacheInMemoryCS.ts
+++ b/src/storages/inMemory/uniqueKeysCacheInMemoryCS.ts
@@ -9,7 +9,7 @@ export class UniqueKeysCacheInMemoryCS implements IUniqueKeysCacheBase {
   private onFullQueue?: () => void;
   private readonly maxStorage: number;
   private uniqueTrackerSize = 0;
-  private uniqueKeysTracker: { [key: string]: ISet<string> };
+  private uniqueKeysTracker: { [keys: string]: ISet<string> };
 
   /**
    *

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -1,8 +1,7 @@
 import { MaybeThenable, IMetadata, ISplitFiltersValidation } from '../dtos/types';
 import { ILogger } from '../logger/types';
-import { EventDataType, HttpErrors, HttpLatencies, ImpressionDataType, LastSync, Method, MethodExceptions, MethodLatencies, OperationType, StoredEventWithMetadata, StoredImpressionWithMetadata, StreamingEvent } from '../sync/submitters/types';
+import { EventDataType, HttpErrors, HttpLatencies, ImpressionDataType, LastSync, Method, MethodExceptions, MethodLatencies, OperationType, StoredEventWithMetadata, StoredImpressionWithMetadata, StreamingEvent, UniqueKeysPayloadCs, UniqueKeysPayloadSs } from '../sync/submitters/types';
 import { SplitIO, ImpressionDTO, SDKMode } from '../types';
-import { ISet } from '../utils/lang/sets';
 
 /**
  * Interface of a pluggable storage wrapper.
@@ -356,13 +355,16 @@ export interface IImpressionCountsCacheSync extends IRecorderCacheProducerSync<R
   pop(toMerge?: Record<string, number> ): Record<string, number> // pop cache data
 }
 
-export interface IUniqueKeysCacheBase extends IRecorderCacheProducerSync<{ [key: string]: ISet<string> }>{
+export interface IUniqueKeysCacheBase {
   // Used by unique Keys tracker
   track(key: string, value: string): void
 
   // Used by unique keys submitter in standalone and producer mode
   isEmpty(): boolean // check if cache is empty. Return true if the cache was just created or cleared.
-  pop(): { [key: string]: ISet<string> } // pop cache data
+  pop(): UniqueKeysPayloadSs | UniqueKeysPayloadCs // pop cache data
+  /* Registers callback for full queue */
+  setOnFullQueueCb(cb: () => void): void,
+  clear(): void
 }
 
 /**
@@ -493,6 +495,7 @@ export type DataLoader = (storage: IStorageSync, matchingKey: string) => void
 export interface IStorageFactoryParams {
   log: ILogger,
   impressionsQueueSize?: number,
+  uniqueKeysCacheSize?: number;
   eventsQueueSize?: number,
   optimize?: boolean /* whether create the `impressionCounts` cache (OPTIMIZED impression mode) or not (DEBUG impression mode) */,
   mode: SDKMode,

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -356,13 +356,13 @@ export interface IImpressionCountsCacheSync extends IRecorderCacheProducerSync<R
   pop(toMerge?: Record<string, number> ): Record<string, number> // pop cache data
 }
 
-export interface IUniqueKeysCacheBase extends IRecorderCacheProducerSync<{ [featureName: string]: ISet<string> }>{
+export interface IUniqueKeysCacheBase extends IRecorderCacheProducerSync<{ [key: string]: ISet<string> }>{
   // Used by unique Keys tracker
-  track(featureName: string, timeFrame: number, amount: number): void
+  track(key: string, value: string): void
 
   // Used by unique keys submitter in standalone and producer mode
   isEmpty(): boolean // check if cache is empty. Return true if the cache was just created or cleared.
-  pop(toMerge?: { [featureName: string]: ISet<string> } ): { [featureName: string]: ISet<string> } // pop cache data
+  pop(): { [key: string]: ISet<string> } // pop cache data
 }
 
 /**
@@ -496,7 +496,7 @@ export interface IStorageFactoryParams {
   eventsQueueSize?: number,
   optimize?: boolean /* whether create the `impressionCounts` cache (OPTIMIZED impression mode) or not (DEBUG impression mode) */,
   mode: SDKMode,
-
+  impressionsMode?: string,
   // ATM, only used by InLocalStorage
   matchingKey?: string, /* undefined on server-side SDKs */
   splitFiltersValidation?: ISplitFiltersValidation,

--- a/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/uniqueKeysSubmitter.spec.ts
@@ -1,6 +1,6 @@
 import { uniqueKeysSubmitterFactory } from '../uniqueKeysSubmitter';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-import { uniqueKeysTrackerFactory } from '../../../trackers/uniqueKeysTracker';
+import { UniqueKeysCacheInMemory } from '../../../storages/inMemory/uniqueKeysCacheInMemory';
 
 const imp1 = {
   feature: 'someFeature',
@@ -15,11 +15,10 @@ const imp3 = { ...imp1, keyName: 'k3' };
 const imp4 = { ...imp1, keyName: 'k3', feature: 'anotherFeature' };
 
 describe('uniqueKeys submitter', () => {
-
-  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock);
+  const uniqueKeysCache = new UniqueKeysCacheInMemory(4);
   const params: any = {
     settings: { log: loggerMock, scheduler: { uniqueKeysRefreshRate: 200 }, core: { key: undefined} },
-    storage: { uniqueKeys: uniqueKeysTracker },
+    storage: { uniqueKeys: uniqueKeysCache },
     splitApi: { 
       postUniqueKeysBulkCs: jest.fn(() => Promise.resolve()),
       postUniqueKeysBulkSs: jest.fn(() => Promise.resolve()) }
@@ -32,14 +31,14 @@ describe('uniqueKeys submitter', () => {
 
   test('doesn\'t drop items from cache when POST is resolved SS', (done) => {
     const uniqueKeysSubmitter = uniqueKeysSubmitterFactory(params);
-    uniqueKeysTracker.track(imp1.feature, imp1.keyName);
+    uniqueKeysCache.track(imp1.feature, imp1.keyName);
     uniqueKeysSubmitter.start();
 
     // Tracking unique keys when POST is pending
-    uniqueKeysTracker.track(imp2.feature, imp2.keyName);
-    uniqueKeysTracker.track(imp3.feature, imp3.keyName);
+    uniqueKeysCache.track(imp2.feature, imp2.keyName);
+    uniqueKeysCache.track(imp3.feature, imp3.keyName);
     // Tracking unique keys after POST is resolved
-    setTimeout(() => { uniqueKeysTracker.track(imp4.feature, imp4.keyName); });
+    setTimeout(() => { uniqueKeysCache.track(imp4.feature, imp4.keyName); });
 
     setTimeout(() => {
       expect(params.splitApi.postUniqueKeysBulkCs.mock.calls).toEqual([]);
@@ -57,14 +56,14 @@ describe('uniqueKeys submitter', () => {
   test('doesn\'t drop items from cache when POST is resolved CS', (done) => {
     params.settings.core.key = 'emma';
     const uniqueKeysSubmitter = uniqueKeysSubmitterFactory(params);
-    uniqueKeysTracker.track(imp1.feature, imp1.keyName);
+    uniqueKeysCache.track(imp1.keyName, imp1.feature);
     uniqueKeysSubmitter.start();
 
     // Tracking unique keys when POST is pending
-    uniqueKeysTracker.track(imp2.feature, imp2.keyName);
-    uniqueKeysTracker.track(imp3.feature, imp3.keyName);
+    uniqueKeysCache.track(imp2.keyName, imp2.feature);
+    uniqueKeysCache.track(imp3.keyName, imp3.feature);
     // Tracking unique keys after POST is resolved
-    setTimeout(() => { uniqueKeysTracker.track(imp4.feature, imp4.keyName); });
+    setTimeout(() => { uniqueKeysCache.track(imp4.keyName, imp4.feature); });
 
     setTimeout(() => {
       expect(params.splitApi.postUniqueKeysBulkSs.mock.calls).toEqual([]);

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -1,7 +1,7 @@
 import { ISegmentsCacheSync, ISplitsCacheSync, ITelemetryCacheSync } from '../../storages/types';
 import { submitterFactory, firstPushWindowDecorator } from './submitter';
 import { TelemetryUsageStatsPayload, TelemetryConfigStatsPayload, TelemetryConfigStats } from './types';
-import { QUEUED, DEDUPED, DROPPED, CONSUMER_MODE, CONSUMER_ENUM, STANDALONE_MODE, CONSUMER_PARTIAL_MODE, STANDALONE_ENUM, CONSUMER_PARTIAL_ENUM, OPTIMIZED, DEBUG, DEBUG_ENUM, OPTIMIZED_ENUM, CONSENT_GRANTED, CONSENT_DECLINED, CONSENT_UNKNOWN } from '../../utils/constants';
+import { QUEUED, DEDUPED, DROPPED, CONSUMER_MODE, CONSUMER_ENUM, STANDALONE_MODE, CONSUMER_PARTIAL_MODE, STANDALONE_ENUM, CONSUMER_PARTIAL_ENUM, OPTIMIZED, DEBUG, NONE, DEBUG_ENUM, OPTIMIZED_ENUM, NONE_ENUM, CONSENT_GRANTED, CONSENT_DECLINED, CONSENT_UNKNOWN } from '../../utils/constants';
 import { SDK_READY, SDK_READY_FROM_CACHE } from '../../readiness/constants';
 import { ConsentStatus, ISettings, SDKMode } from '../../types';
 import { base } from '../../utils/settingsValidation';
@@ -52,8 +52,9 @@ const OPERATION_MODE_MAP = {
 
 const IMPRESSIONS_MODE_MAP = {
   [OPTIMIZED]: OPTIMIZED_ENUM,
-  [DEBUG]: DEBUG_ENUM
-} as Record<ISettings['sync']['impressionsMode'], (0 | 1)>;
+  [DEBUG]: DEBUG_ENUM,
+  [NONE]: NONE_ENUM
+} as Record<ISettings['sync']['impressionsMode'], (0 | 1 | 2)>;
 
 const USER_CONSENT_MAP = {
   [CONSENT_UNKNOWN]: 1,

--- a/src/sync/submitters/uniqueKeysSubmitter.ts
+++ b/src/sync/submitters/uniqueKeysSubmitter.ts
@@ -1,45 +1,8 @@
+import { SUBMITTERS_PUSH_FULL_QUEUE } from '../../logger/constants';
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
-import { ISet, setToArray } from '../../utils/lang/sets';
 import { submitterFactory } from './submitter';
-import { UniqueKeysPayloadCs, UniqueKeysPayloadSs } from './types';
 
-/**
- * Converts `uniqueKeys` data from cache into request payload for CS.
- */
-export function fromUniqueKeysCollectorCs(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadCs {
-  const payload = [];
-  const featureKeys = Object.keys(uniqueKeys);
-  for (let k = 0; k < featureKeys.length; k++) {
-    const featureKey = featureKeys[k];
-    const featureNames = setToArray(uniqueKeys[featureKey]);
-    const uniqueKeysPayload = {
-      k: featureKey,
-      fs: featureNames
-    };
-
-    payload.push(uniqueKeysPayload);
-  }
-  return { keys: payload };
-}
-
-/**
- * Converts `uniqueKeys` data from cache into request payload for SS.
- */
-export function fromUniqueKeysCollectorSs(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadSs {
-  const payload = [];
-  const featureNames = Object.keys(uniqueKeys);
-  for (let i = 0; i < featureNames.length; i++) {
-    const featureName = featureNames[i];
-    const featureKeys = setToArray(uniqueKeys[featureName]);
-    const uniqueKeysPayload = {
-      f: featureName,
-      ks: featureKeys
-    };
-
-    payload.push(uniqueKeysPayload);
-  }
-  return { keys: payload };
-}
+const DATA_NAME = 'uniqueKeys';
 
 /**
  * Submitter that periodically posts impression counts
@@ -54,8 +17,19 @@ export function uniqueKeysSubmitterFactory(params: ISdkFactoryContextSync) {
   
   const isClientSide = key !== undefined;
   const postUniqueKeysBulk = isClientSide ? postUniqueKeysBulkCs : postUniqueKeysBulkSs;
-  const fromUniqueKeysCollector = isClientSide ? fromUniqueKeysCollectorCs : fromUniqueKeysCollectorSs;
 
-  return submitterFactory(log, postUniqueKeysBulk, uniqueKeys!, uniqueKeysRefreshRate, 'unique keys', fromUniqueKeysCollector);
+  const syncTask = submitterFactory(log, postUniqueKeysBulk, uniqueKeys!, uniqueKeysRefreshRate, 'unique keys');
+
+  // register unique keys submitter to be executed when uniqueKeys cache is full
+  uniqueKeys!.setOnFullQueueCb(() => {
+    if (syncTask.isRunning()) {
+      log.info(SUBMITTERS_PUSH_FULL_QUEUE, [DATA_NAME]);
+      syncTask.execute();
+    }
+    // If submitter is stopped (e.g., user consent declined or unknown, or app state offline), we don't send the data.
+    // Data will be sent when submitter is resumed.
+  });
+  
+  return syncTask;
 }
 

--- a/src/sync/submitters/uniqueKeysSubmitter.ts
+++ b/src/sync/submitters/uniqueKeysSubmitter.ts
@@ -3,36 +3,18 @@ import { ISet, setToArray } from '../../utils/lang/sets';
 import { submitterFactory } from './submitter';
 import { UniqueKeysPayloadCs, UniqueKeysPayloadSs } from './types';
 
-/** 
- * Invert keys for feature to features for key
- */
-function invertUniqueKeys(uniqueKeys: { [featureName: string]: ISet<string> }): { [key: string]: string[] } {
-  const featureNames = Object.keys(uniqueKeys);
-  const inverted: { [key: string]: string[] } = {};
-  for (let i = 0; i < featureNames.length; i++) {
-    const featureName = featureNames[i];
-    const featureKeys = setToArray(uniqueKeys[featureName]);
-    for (let j = 0; j< featureKeys.length; j++) {
-      const featureKey = featureKeys[j];
-      if (!inverted[featureKey]) inverted[featureKey] = []; 
-      inverted[featureKey].push(featureName);
-    }
-  }
-  return inverted;
-}
-
 /**
  * Converts `uniqueKeys` data from cache into request payload for CS.
  */
 export function fromUniqueKeysCollectorCs(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadCs {
   const payload = [];
-  const featuresPerKey = invertUniqueKeys(uniqueKeys);
-  const keys = Object.keys(featuresPerKey);
-  for (let k = 0; k < keys.length; k++) {
-    const key = keys[k];
+  const featureKeys = Object.keys(uniqueKeys);
+  for (let k = 0; k < featureKeys.length; k++) {
+    const featureKey = featureKeys[k];
+    const featureNames = setToArray(uniqueKeys[featureKey]);
     const uniqueKeysPayload = {
-      k: key,
-      fs: featuresPerKey[key]
+      k: featureKey,
+      fs: featureNames
     };
 
     payload.push(uniqueKeysPayload);

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -8,6 +8,7 @@ describe('Unique keys tracker', () => {
     pop: jest.fn(),
     isEmpty: jest.fn(),
     clear: jest.fn(),
+    setOnFullQueueCb: jest.fn()
   };
   const fakeFilter = {
     add: jest.fn(() => { return true; }),

--- a/src/trackers/impressionsTracker.ts
+++ b/src/trackers/impressionsTracker.ts
@@ -30,8 +30,8 @@ export function impressionsTrackerFactory(
       if (settings.userConsent === CONSENT_DECLINED) return;
 
       const impressionsCount = impressions.length;
-
-      const { impressionsToStore, impressionsToListener, deduped } = strategy.process(impressions);
+      const isClientSide = settings.core.key !== undefined;
+      const { impressionsToStore, impressionsToListener, deduped } = strategy.process(impressions, isClientSide);
       
       const impressionsToListenerCount = impressionsToListener.length;
       

--- a/src/trackers/impressionsTracker.ts
+++ b/src/trackers/impressionsTracker.ts
@@ -30,8 +30,7 @@ export function impressionsTrackerFactory(
       if (settings.userConsent === CONSENT_DECLINED) return;
 
       const impressionsCount = impressions.length;
-      const isClientSide = settings.core.key !== undefined;
-      const { impressionsToStore, impressionsToListener, deduped } = strategy.process(impressions, isClientSide);
+      const { impressionsToStore, impressionsToListener, deduped } = strategy.process(impressions);
       
       const impressionsToListenerCount = impressionsToListener.length;
       

--- a/src/trackers/strategy/__tests__/strategyDebug.spec.ts
+++ b/src/trackers/strategy/__tests__/strategyDebug.spec.ts
@@ -1,7 +1,7 @@
 import { impressionObserverSSFactory } from '../../impressionObserver/impressionObserverSS';
 import { impressionObserverCSFactory } from '../../impressionObserver/impressionObserverCS';
 import { strategyDebugFactory } from '../strategyDebug';
-import { impression1, impression2, processStrategy } from './testUtils';
+import { impression1, impression2 } from './testUtils';
 
 test('strategyDebug', () => {
   
@@ -14,7 +14,7 @@ test('strategyDebug', () => {
   
   const strategyDebugSS = strategyDebugFactory(impressionObserverSSFactory());
   
-  let { impressionsToStore, impressionsToListener, deduped } = processStrategy(strategyDebugSS, impressions);
+  let { impressionsToStore, impressionsToListener, deduped } = strategyDebugSS.process(impressions);
   
   expect(impressionsToStore).toStrictEqual(augmentedImpressions);
   expect(impressionsToListener).toStrictEqual(augmentedImpressions);
@@ -22,7 +22,7 @@ test('strategyDebug', () => {
   
   const strategyDebugCS = strategyDebugFactory(impressionObserverCSFactory());
   
-  ({ impressionsToStore, impressionsToListener, deduped } = processStrategy(strategyDebugCS, impressions));
+  ({ impressionsToStore, impressionsToListener, deduped } = strategyDebugCS.process(impressions));
   
   expect(impressionsToStore).toStrictEqual(augmentedImpressions);
   expect(impressionsToListener).toStrictEqual(augmentedImpressions);

--- a/src/trackers/strategy/__tests__/strategyNone.spec.ts
+++ b/src/trackers/strategy/__tests__/strategyNone.spec.ts
@@ -2,8 +2,9 @@ import { ImpressionCountsCacheInMemory } from '../../../storages/inMemory/Impres
 import { UniqueKeysCacheInMemory } from '../../../storages/inMemory/uniqueKeysCacheInMemory';
 import { strategyNoneFactory } from '../strategyNone';
 import { uniqueKeysTrackerFactory } from '../../uniqueKeysTracker';
-import { getExpected, impression1, impression2, processStrategy } from './testUtils';
+import { impression1, impression2, processStrategy } from './testUtils';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
+import { UniqueKeysCacheInMemoryCS } from '../../../storages/inMemory/uniqueKeysCacheInMemoryCS';
 
 const fakeFilter = {
   add: jest.fn(() => { return true; }),
@@ -11,45 +12,84 @@ const fakeFilter = {
   clear: jest.fn(),
 };
 
-test('strategyNone', () => {
+let impressions = [
+  impression1,
+  impression2,
+  {...impression1, keyName: 'emma@split.io'},
+  {...impression1, keyName: 'nico@split.io'},
+  {...impression1, keyName: 'emi@split.io'},
+  {...impression1, keyName: 'emi@split.io'}
+];
+
+test('strategyNone - Client side', () => {
   const impressionCountsCache = new ImpressionCountsCacheInMemory();
-  const uniqueKeysCache = new UniqueKeysCacheInMemory(6);
-  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, uniqueKeysCache, fakeFilter);
-  
-  let impressions = [
-    impression1, 
-    impression2, 
-    {...impression1, keyName: 'emma@split.io'}, 
-    {...impression1, keyName: 'nico@split.io'}, 
-    {...impression1, keyName: 'emi@split.io'}, 
-    {...impression1, keyName: 'emi@split.io'}
-  ];
+  const uniqueKeysCacheCS = new UniqueKeysCacheInMemoryCS(6);
+  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, uniqueKeysCacheCS, fakeFilter);
   
   const strategyNone = strategyNoneFactory(impressionCountsCache, uniqueKeysTracker);
-  let clientSide = true;
+  
   const { 
     impressionsToStore: impressionsToStoreCs, 
     impressionsToListener: impressionsToListenerCs, 
     deduped: dedupedCs 
-  } = processStrategy(strategyNone, impressions, clientSide);
+  } = processStrategy(strategyNone, impressions);
   
-  expect(uniqueKeysCache.pop()).toStrictEqual(getExpected(impressions, clientSide));
-  expect(uniqueKeysCache.pop()).toStrictEqual({});
+  expect(uniqueKeysCacheCS.pop()).toStrictEqual({
+    keys: [
+      {
+        k: 'emma@split.io',
+        fs: ['qc_team', 'qc_team_2'],
+      },
+      {
+        k: 'nico@split.io',
+        fs:  ['qc_team'],
+      },
+      {
+        k: 'emi@split.io',
+        fs:  ['qc_team'],
+      }
+    ]
+  });
+
+  expect(uniqueKeysCacheCS.pop()).toStrictEqual({ keys: [] });
   
   expect(impressionsToStoreCs).toStrictEqual([]);
   expect(impressionsToListenerCs).toStrictEqual(impressions);
   expect(dedupedCs).toStrictEqual(0);
+
+});
+
+test('strategyNone - Server side', () => {
+
+  const impressionCountsCache = new ImpressionCountsCacheInMemory();
+  const uniqueKeysCache = new UniqueKeysCacheInMemory(6);
+  const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, uniqueKeysCache, fakeFilter);
   
-  clientSide = false;
+  const strategyNone = strategyNoneFactory(impressionCountsCache, uniqueKeysTracker);
   
   const { 
     impressionsToStore: impressionsToStoreSs, 
     impressionsToListener: impressionsToListenerSs, 
     deduped: dedupedSs 
-  } = processStrategy(strategyNone, impressions, clientSide);
+  } = processStrategy(strategyNone, impressions);
   
-  expect(uniqueKeysCache.pop()).toStrictEqual(getExpected(impressions, clientSide));
-  expect(uniqueKeysCache.pop()).toStrictEqual({});
+  expect(uniqueKeysCache.pop()).toStrictEqual({
+    keys: [
+      {
+        f: 'qc_team',
+        ks: [
+          'emma@split.io',
+          'nico@split.io',
+          'emi@split.io',
+        ],
+      },
+      {
+        f: 'qc_team_2',
+        ks: ['emma@split.io']
+      }
+    ]
+  });
+  expect(uniqueKeysCache.pop()).toStrictEqual({ keys: [] });
   
   expect(impressionsToStoreSs).toStrictEqual([]);
   expect(impressionsToListenerSs).toStrictEqual(impressions);

--- a/src/trackers/strategy/__tests__/strategyNone.spec.ts
+++ b/src/trackers/strategy/__tests__/strategyNone.spec.ts
@@ -2,7 +2,7 @@ import { ImpressionCountsCacheInMemory } from '../../../storages/inMemory/Impres
 import { UniqueKeysCacheInMemory } from '../../../storages/inMemory/uniqueKeysCacheInMemory';
 import { strategyNoneFactory } from '../strategyNone';
 import { uniqueKeysTrackerFactory } from '../../uniqueKeysTracker';
-import { impression1, impression2, processStrategy } from './testUtils';
+import { impression1, impression2 } from './testUtils';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { UniqueKeysCacheInMemoryCS } from '../../../storages/inMemory/uniqueKeysCacheInMemoryCS';
 
@@ -32,7 +32,7 @@ test('strategyNone - Client side', () => {
     impressionsToStore: impressionsToStoreCs, 
     impressionsToListener: impressionsToListenerCs, 
     deduped: dedupedCs 
-  } = processStrategy(strategyNone, impressions);
+  } = strategyNone.process(impressions);
   
   expect(uniqueKeysCacheCS.pop()).toStrictEqual({
     keys: [
@@ -71,7 +71,7 @@ test('strategyNone - Server side', () => {
     impressionsToStore: impressionsToStoreSs, 
     impressionsToListener: impressionsToListenerSs, 
     deduped: dedupedSs 
-  } = processStrategy(strategyNone, impressions);
+  } = strategyNone.process(impressions);
   
   expect(uniqueKeysCache.pop()).toStrictEqual({
     keys: [

--- a/src/trackers/strategy/__tests__/strategyOptimized.spec.ts
+++ b/src/trackers/strategy/__tests__/strategyOptimized.spec.ts
@@ -2,7 +2,7 @@ import { impressionObserverSSFactory } from '../../impressionObserver/impression
 import { impressionObserverCSFactory } from '../../impressionObserver/impressionObserverCS';
 import { strategyOptimizedFactory } from '../strategyOptimized';
 import { ImpressionCountsCacheInMemory } from '../../../storages/inMemory/ImpressionCountsCacheInMemory';
-import { impression1, impression2, processStrategy } from './testUtils';
+import { impression1, impression2 } from './testUtils';
 
 test('strategyOptimized', () => {
   
@@ -17,7 +17,7 @@ test('strategyOptimized', () => {
   
   const strategyOptimizedSS = strategyOptimizedFactory(impressionObserverSSFactory(), impressionCountsCache);
   
-  let { impressionsToStore, impressionsToListener, deduped } = processStrategy(strategyOptimizedSS, impressions);
+  let { impressionsToStore, impressionsToListener, deduped } = strategyOptimizedSS.process(impressions);
 
   expect(impressionsToStore).toStrictEqual([augmentedImp1, augmentedImp2]);
   expect(impressionsToListener).toStrictEqual(augmentedImpressions);
@@ -25,7 +25,7 @@ test('strategyOptimized', () => {
   
   const strategyOptimizedCS = strategyOptimizedFactory(impressionObserverCSFactory(), impressionCountsCache);
   
-  ({ impressionsToStore, impressionsToListener, deduped } = processStrategy(strategyOptimizedCS, impressions));
+  ({ impressionsToStore, impressionsToListener, deduped } = strategyOptimizedCS.process(impressions));
   
   expect(impressionsToStore).toStrictEqual([augmentedImp1, augmentedImp2]);
   expect(impressionsToListener).toStrictEqual(augmentedImpressions);

--- a/src/trackers/strategy/__tests__/testUtils.ts
+++ b/src/trackers/strategy/__tests__/testUtils.ts
@@ -1,5 +1,4 @@
 import { ImpressionDTO } from '../../../types';
-import { IStrategy } from '../../types';
 
 export const impression1 = {
   feature: 'qc_team',
@@ -17,7 +16,3 @@ export const impression2 = {
   bucketingKey: 'impr_bucketing_2',
   label: 'default rule'
 } as ImpressionDTO;
-
-export function processStrategy(strategy: IStrategy, impressions: ImpressionDTO[]) {  
-  return strategy.process(impressions);
-}

--- a/src/trackers/strategy/__tests__/testUtils.ts
+++ b/src/trackers/strategy/__tests__/testUtils.ts
@@ -1,5 +1,4 @@
 import { ImpressionDTO } from '../../../types';
-import { ISet, _Set } from '../../../utils/lang/sets';
 import { IStrategy } from '../../types';
 
 export const impression1 = {
@@ -19,19 +18,6 @@ export const impression2 = {
   label: 'default rule'
 } as ImpressionDTO;
 
-export function processStrategy(strategy: IStrategy, impressions: ImpressionDTO[], isClientSide?: boolean) {  
-  return strategy.process(impressions, isClientSide);
-}
-
-export function getExpected(impressions: ImpressionDTO[], clientSide: boolean) {
-  const expectedPop: { [key: string]: ISet<string> } = {};
-
-  impressions.forEach(impression => {
-    const key = clientSide ? impression.keyName : impression.feature;
-    const value = clientSide ? impression.feature : impression.keyName;
-    
-    if (!expectedPop[key]) expectedPop[key] = new _Set();
-    expectedPop[key].add(value);
-  });
-  return expectedPop;
+export function processStrategy(strategy: IStrategy, impressions: ImpressionDTO[]) {  
+  return strategy.process(impressions);
 }

--- a/src/trackers/strategy/__tests__/testUtils.ts
+++ b/src/trackers/strategy/__tests__/testUtils.ts
@@ -1,4 +1,5 @@
 import { ImpressionDTO } from '../../../types';
+import { ISet, _Set } from '../../../utils/lang/sets';
 import { IStrategy } from '../../types';
 
 export const impression1 = {
@@ -18,6 +19,19 @@ export const impression2 = {
   label: 'default rule'
 } as ImpressionDTO;
 
-export function processStrategy(strategy: IStrategy, impressions: ImpressionDTO[]) {  
-  return strategy.process(impressions);
+export function processStrategy(strategy: IStrategy, impressions: ImpressionDTO[], isClientSide?: boolean) {  
+  return strategy.process(impressions, isClientSide);
+}
+
+export function getExpected(impressions: ImpressionDTO[], clientSide: boolean) {
+  const expectedPop: { [key: string]: ISet<string> } = {};
+
+  impressions.forEach(impression => {
+    const key = clientSide ? impression.keyName : impression.feature;
+    const value = clientSide ? impression.feature : impression.keyName;
+    
+    if (!expectedPop[key]) expectedPop[key] = new _Set();
+    expectedPop[key].add(value);
+  });
+  return expectedPop;
 }

--- a/src/trackers/strategy/strategyNone.ts
+++ b/src/trackers/strategy/strategyNone.ts
@@ -15,13 +15,15 @@ export function strategyNoneFactory(
 ): IStrategy {
   
   return {
-    process(impressions: ImpressionDTO[]) {
+    process(impressions: ImpressionDTO[], isClientSide: boolean) {
       impressions.forEach((impression) => {        
         const now = Date.now();
         // Increments impression counter per featureName
         impressionsCounter.track(impression.feature, now, 1);
         // Keep track by unique key
-        uniqueKeysTracker.track(impression.feature, impression.keyName);
+        const key = isClientSide ? impression.keyName : impression.feature;
+        const value = isClientSide ? impression.feature : impression.keyName;
+        uniqueKeysTracker.track(key, value);
       });
       
       return {

--- a/src/trackers/strategy/strategyNone.ts
+++ b/src/trackers/strategy/strategyNone.ts
@@ -15,15 +15,13 @@ export function strategyNoneFactory(
 ): IStrategy {
   
   return {
-    process(impressions: ImpressionDTO[], isClientSide: boolean) {
+    process(impressions: ImpressionDTO[]) {
       impressions.forEach((impression) => {        
         const now = Date.now();
         // Increments impression counter per featureName
         impressionsCounter.track(impression.feature, now, 1);
         // Keep track by unique key
-        const key = isClientSide ? impression.keyName : impression.feature;
-        const value = isClientSide ? impression.feature : impression.keyName;
-        uniqueKeysTracker.track(key, value);
+        uniqueKeysTracker.track(impression.keyName, impression.feature);
       });
       
       return {

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -66,5 +66,5 @@ export interface IStrategyResult {
 }
 
 export interface IStrategy {
-  process(impressions:  ImpressionDTO[], isClientSide?: boolean): IStrategyResult
+  process(impressions:  ImpressionDTO[]): IStrategyResult
 }

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -2,7 +2,6 @@ import { SplitIO, ImpressionDTO } from '../types';
 import { StreamingEventType, Method, OperationType } from '../sync/submitters/types';
 import { IEventsCacheBase } from '../storages/types';
 import { NetworkError } from '../services/types';
-import { ISet } from '../utils/lang/sets';
 
 /** Events tracker */
 
@@ -45,8 +44,8 @@ export interface ITelemetryTracker {
 }
 
 export interface IFilterAdapter {
-  add(featureName: string, key: string): boolean;
-  contains(featureName: string, key: string): boolean;
+  add(key: string, featureName: string): boolean;
+  contains(key: string, featureName: string): boolean;
   clear(): void;
 }
 
@@ -57,10 +56,7 @@ export interface IImpressionSenderAdapter {
 
 /** Unique keys tracker */
 export interface IUniqueKeysTracker {
-  track(featureName: string, key: string): void;
-  pop(toMerge?: { [featureName: string]: ISet<string> }): { [featureName: string]: ISet<string>; };
-  clear(): void;
-  isEmpty(): boolean;
+  track(key: string, featureName: string): void;
 }
 
 export interface IStrategyResult {
@@ -70,5 +66,5 @@ export interface IStrategyResult {
 }
 
 export interface IStrategy {
-  process(impressions:  ImpressionDTO[]): IStrategyResult
+  process(impressions:  ImpressionDTO[], isClientSide?: boolean): IStrategyResult
 }

--- a/src/trackers/uniqueKeysTracker.ts
+++ b/src/trackers/uniqueKeysTracker.ts
@@ -25,12 +25,12 @@ export function uniqueKeysTrackerFactory(
 ): IUniqueKeysTracker {
   
   return {
-    track(key: string, value: string): void {
-      if (!filterAdapter.add(key, value)) {
-        log.debug(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The value ${value} and key ${key} exist in the filter`);
+    track(key: string, featureName: string): void {
+      if (!filterAdapter.add(key, featureName)) {
+        log.debug(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The feature ${featureName} and key ${key} exist in the filter`);
         return;
       }
-      uniqueKeysCache.track(key, value);
+      uniqueKeysCache.track(key, featureName);
     }
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface ISettings {
     impressionsRefreshRate: number,
     impressionsQueueSize: number,
     uniqueKeysRefreshRate: number,
+    uniqueKeysCacheSize: number,
     /**
      * @deprecated
      */

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -50,6 +50,7 @@ export const CONSUMER_PARTIAL_ENUM = 2;
 
 export const OPTIMIZED_ENUM = 0;
 export const DEBUG_ENUM = 1;
+export const NONE_ENUM = 2;
 
 export const SPLITS = 'sp';
 export const IMPRESSIONS = 'im';

--- a/src/utils/settingsValidation/__tests__/settings.mocks.ts
+++ b/src/utils/settingsValidation/__tests__/settings.mocks.ts
@@ -53,6 +53,7 @@ export const fullSettings: ISettings = {
     telemetryRefreshRate: 1,
     segmentsRefreshRate: 1,
     uniqueKeysRefreshRate: 1,
+    uniqueKeysCacheSize: 1,
     offlineRefreshRate: 1,
     eventsPushRate: 1,
     eventsQueueSize: 1,


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

**uniqueKeysTracker Refactor**

- Added uniqueKeysCacheInMemory to be used by uniqueKeysTracker and UniqueKeysSubmitter
- Added onFullQeue functionality for uniqueKeysCacheInMemory
- Modified uniqueKeys storage logic: 
    uniqueKeysCache has key: string and value: string as params, strategyNone is in charge to send features as key when 
    relates to server side and impression key as storage key when it relates to client side, so the storage structure match 
    with the spec 

## How do we test the changes introduced in this PR?
Unit tests included

## Extra Notes