### PR TITLE
[SDKS-5970] add task to clean uniquekeystracker filteradapter every n ms

### DIFF
--- a/src/sdkClient/sdkClient.ts
+++ b/src/sdkClient/sdkClient.ts
@@ -40,7 +40,7 @@ export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: bo
           // Release the API Key if it is the main client
           if (!isSharedClient) releaseApiKey(settings.core.authorizationKey);
           
-          if (uniqueKeysTracker && uniqueKeysTracker.stopFilterCleaner) uniqueKeysTracker.stopFilterCleaner();
+          if (uniqueKeysTracker) uniqueKeysTracker.stop();
 
           // Cleanup storage
           return storage.destroy();

--- a/src/sdkClient/sdkClient.ts
+++ b/src/sdkClient/sdkClient.ts
@@ -9,7 +9,7 @@ import { ISdkFactoryContext } from '../sdkFactory/types';
  * Creates an Sdk client, i.e., a base client with status and destroy interface
  */
 export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: boolean): SplitIO.IClient | SplitIO.IAsyncClient {
-  const { sdkReadinessManager, syncManager, storage, signalListener, settings, telemetryTracker } = params;
+  const { sdkReadinessManager, syncManager, storage, signalListener, settings, telemetryTracker, uniqueKeysTracker } = params;
 
   return objectAssign(
     // Proto-linkage of the readiness Event Emitter
@@ -39,6 +39,8 @@ export function sdkClientFactory(params: ISdkFactoryContext, isSharedClient?: bo
 
           // Release the API Key if it is the main client
           if (!isSharedClient) releaseApiKey(settings.core.authorizationKey);
+          
+          if (uniqueKeysTracker && uniqueKeysTracker.stopFilterCleaner) uniqueKeysTracker.stopFilterCleaner();
 
           // Cleanup storage
           return storage.destroy();

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -80,6 +80,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
       break;
     case NONE: 
       strategy = strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker!);
+      if (uniqueKeysTracker!.startFilterCleaner) uniqueKeysTracker!.startFilterCleaner();
       break;
     default: 
       strategy = strategyDebugFactory(observer);

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -80,7 +80,6 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
       break;
     case NONE: 
       strategy = strategyNoneFactory(storage.impressionCounts!, uniqueKeysTracker!);
-      if (uniqueKeysTracker!.startFilterCleaner) uniqueKeysTracker!.startFilterCleaner();
       break;
     default: 
       strategy = strategyDebugFactory(observer);

--- a/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
+++ b/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
@@ -9,7 +9,7 @@ export class ImpressionCountsCacheInRedis extends ImpressionCountsCacheInMemory 
   private readonly key: string;
   private readonly redis: Redis;
   private readonly refreshRate: number;
-  private handle: any;
+  private intervalId: any;
   
   constructor(log: ILogger, key: string, redis: Redis, impressionCountsCacheSize?: number, refreshRate: number = REFRESH_RATE) {
     super(impressionCountsCacheSize);
@@ -41,10 +41,10 @@ export class ImpressionCountsCacheInRedis extends ImpressionCountsCacheInMemory 
   }
   
   start() {
-    this.handle = setInterval(this.postImpressionCountsInRedis.bind(this), this.refreshRate);
+    this.intervalId = setInterval(this.postImpressionCountsInRedis.bind(this), this.refreshRate);
   }
   
   stop() {
-    clearInterval(this.handle);
+    clearInterval(this.intervalId);
   }
 }

--- a/src/storages/inRedis/__tests__/ImpressionCountsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/ImpressionCountsCacheInRedis.spec.ts
@@ -109,7 +109,7 @@ describe('IMPRESSION COUNTS CACHE IN REDIS', () => {
   test('IMPRESSION COUNTS CACHE IN REDIS / start and stop task', (done) => {
     
     const connection = new Redis();
-    const refreshRate = 100;
+    const refreshRate = 200;
     const counter = new ImpressionCountsCacheInRedis(loggerMock, key, connection, undefined, refreshRate);
     // Clean up in case there are still keys there.
     connection.del(key);
@@ -135,7 +135,7 @@ describe('IMPRESSION COUNTS CACHE IN REDIS', () => {
         counter.stop();
         counter.track('feature3', nextHourTimestamp + 4, 2);      
       });
-    }, refreshRate + 50);
+    }, refreshRate + 30);
     
     setTimeout(() => {
       
@@ -146,7 +146,7 @@ describe('IMPRESSION COUNTS CACHE IN REDIS', () => {
         await connection.quit();
         done();
       });
-    }, 2 * refreshRate + 50);
+    }, 2 * refreshRate + 30);
     
   });
   

--- a/src/storages/inRedis/__tests__/uniqueKeysCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/uniqueKeysCacheInRedis.spec.ts
@@ -111,7 +111,7 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
     const key = 'unique_key_post';
     // Clean up in case there are still keys there.
     connection.del(key);
-    const refreshRate = 100;
+    const refreshRate = 200;
     
     const cache = new UniqueKeysCacheInRedis(loggerMock, key, connection, undefined, refreshRate);  
     cache.track('key1', 'feature1');
@@ -139,7 +139,7 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
         cache.track('key3', 'feature4');
         
       });
-    }, refreshRate + 50);
+    }, refreshRate + 30);
     
     setTimeout(() => {
       
@@ -150,7 +150,7 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
         await connection.quit();
         done();
       });
-    }, 2 * refreshRate + 50);
+    }, 2 * refreshRate + 30);
   });
   
   test('UNIQUE KEYS CACHE IN REDIS / Should call "onFullQueueCb" when the queue is full.', async () => {

--- a/src/storages/inRedis/uniqueKeysCacheInRedis.ts
+++ b/src/storages/inRedis/uniqueKeysCacheInRedis.ts
@@ -12,7 +12,7 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
   private readonly key: string;
   private readonly redis: Redis;
   private readonly refreshRate: number;
-  private handle: any;
+  private intervalId: any;
   
   constructor(log: ILogger, key: string, redis: Redis, uniqueKeysQueueSize: number = DEFAULT_CACHE_SIZE, refreshRate: number = REFRESH_RATE) {
     super(uniqueKeysQueueSize);
@@ -53,11 +53,11 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
   
     
   start() {
-    this.handle = setInterval(this.postUniqueKeysInRedis.bind(this), this.refreshRate);
+    this.intervalId = setInterval(this.postUniqueKeysInRedis.bind(this), this.refreshRate);
   }
   
   stop() {
-    clearInterval(this.handle);
+    clearInterval(this.intervalId);
   }
   
 }

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -41,7 +41,7 @@ describe('Unique keys tracker', () => {
   
   test('Unique keys filter cleaner', () => { 
     
-    const refreshRate = 100;
+    const refreshRate = 200;
     const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
     
     expect(uniqueKeysTracker.startFilterCleaner).toBe(undefined);
@@ -54,17 +54,17 @@ describe('Unique keys tracker', () => {
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(1);
-    }, refreshRate + 20);
+    }, refreshRate + 50);
     
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(2);
       uniqueKeysTrackerWithRefresh.stopFilterCleaner!();
-    }, 2 * refreshRate + 20);
+    }, 2 * refreshRate + 50);
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(2);
-    }, 3 * refreshRate + 20);
+    }, 3 * refreshRate + 50);
     
     
   });

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -42,15 +42,10 @@ describe('Unique keys tracker', () => {
   test('Unique keys filter cleaner', () => { 
     
     const refreshRate = 200;
-    const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
-    
-    expect(uniqueKeysTracker.startFilterCleaner).toBe(undefined);
     
     fakeFilter.refreshRate = refreshRate;
     
     const uniqueKeysTrackerWithRefresh = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
-    
-    uniqueKeysTrackerWithRefresh.startFilterCleaner!();
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(1);
@@ -59,7 +54,7 @@ describe('Unique keys tracker', () => {
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(2);
-      uniqueKeysTrackerWithRefresh.stopFilterCleaner!();
+      uniqueKeysTrackerWithRefresh.stop();
     }, 2 * refreshRate + 50);
     
     setTimeout(() => {

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -49,17 +49,17 @@ describe('Unique keys tracker', () => {
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(1);
-    }, refreshRate + 50);
+    }, refreshRate + 100);
     
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(2);
       uniqueKeysTrackerWithRefresh.stop();
-    }, 2 * refreshRate + 50);
+    }, 2 * refreshRate + 100);
     
     setTimeout(() => {
       expect(fakeFilter.clear).toBeCalledTimes(2);
-    }, 3 * refreshRate + 50);
+    }, 3 * refreshRate + 100);
     
     
   });

--- a/src/trackers/__tests__/uniqueKeysTracker.spec.ts
+++ b/src/trackers/__tests__/uniqueKeysTracker.spec.ts
@@ -10,13 +10,13 @@ describe('Unique keys tracker', () => {
     clear: jest.fn(),
     setOnFullQueueCb: jest.fn()
   };
-  const fakeFilter = {
+  let fakeFilter: any = {
     add: jest.fn(() => { return true; }),
     contains: jest.fn(() => { return true; }),
     clear: jest.fn(),
   };
 
-  test('Should be able to track impressions', () => { 
+  test('Should be able to track unique keys', () => { 
     
     const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
     
@@ -36,6 +36,36 @@ describe('Unique keys tracker', () => {
     uniqueKeysTracker.track('key2', 'value4');
     expect(fakeFilter.add).toBeCalledWith('key2','value4');
     expect(fakeUniqueKeysCache.track).toBeCalledWith('key2','value4');
+    
+  });
+  
+  test('Unique keys filter cleaner', () => { 
+    
+    const refreshRate = 100;
+    const uniqueKeysTracker = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
+    
+    expect(uniqueKeysTracker.startFilterCleaner).toBe(undefined);
+    
+    fakeFilter.refreshRate = refreshRate;
+    
+    const uniqueKeysTrackerWithRefresh = uniqueKeysTrackerFactory(loggerMock, fakeUniqueKeysCache, fakeFilter);
+    
+    uniqueKeysTrackerWithRefresh.startFilterCleaner!();
+    
+    setTimeout(() => {
+      expect(fakeFilter.clear).toBeCalledTimes(1);
+    }, refreshRate + 20);
+    
+    
+    setTimeout(() => {
+      expect(fakeFilter.clear).toBeCalledTimes(2);
+      uniqueKeysTrackerWithRefresh.stopFilterCleaner!();
+    }, 2 * refreshRate + 20);
+    
+    setTimeout(() => {
+      expect(fakeFilter.clear).toBeCalledTimes(2);
+    }, 3 * refreshRate + 20);
+    
     
   });
 });

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -57,8 +57,7 @@ export interface IImpressionSenderAdapter {
 
 /** Unique keys tracker */
 export interface IUniqueKeysTracker {
-  startFilterCleaner?(): void;
-  stopFilterCleaner?(): void;
+  stop(): void;
   track(key: string, featureName: string): void;
 }
 

--- a/src/trackers/types.ts
+++ b/src/trackers/types.ts
@@ -47,6 +47,7 @@ export interface IFilterAdapter {
   add(key: string, featureName: string): boolean;
   contains(key: string, featureName: string): boolean;
   clear(): void;
+  refreshRate?: number;
 }
 
 export interface IImpressionSenderAdapter {
@@ -56,6 +57,8 @@ export interface IImpressionSenderAdapter {
 
 /** Unique keys tracker */
 export interface IUniqueKeysTracker {
+  startFilterCleaner?(): void;
+  stopFilterCleaner?(): void;
   track(key: string, featureName: string): void;
 }
 

--- a/src/trackers/uniqueKeysTracker.ts
+++ b/src/trackers/uniqueKeysTracker.ts
@@ -23,28 +23,26 @@ export function uniqueKeysTrackerFactory(
   uniqueKeysCache: IUniqueKeysCacheBase,
   filterAdapter: IFilterAdapter = noopFilterAdapter,
 ): IUniqueKeysTracker {
-  let handle: any;
-  
-  const tracker:any = {
+  let intervalId: any;
+
+  if (filterAdapter.refreshRate) {
+    intervalId = setInterval(filterAdapter.clear, filterAdapter.refreshRate);
+  }
+
+  return {
+
     track(key: string, featureName: string): void {
       if (!filterAdapter.add(key, featureName)) {
         log.debug(`${LOG_PREFIX_UNIQUE_KEYS_TRACKER}The feature ${featureName} and key ${key} exist in the filter`);
         return;
       }
       uniqueKeysCache.track(key, featureName);
+    },
+
+    stop(): void {
+      clearInterval(intervalId);
     }
-  };
-  
-  if (filterAdapter.refreshRate) {
-    tracker.startFilterCleaner = function() {
-      handle = setInterval(filterAdapter.clear, filterAdapter.refreshRate);
-    };
     
-    tracker.stopFilterCleaner = function() {
-      clearInterval(handle);
-    };
-  }
-  
-  return tracker;
+  };
 
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
Added `startFilterCleaner` method on `uniqueKeysTracker` to execute `filterAdapter::clear` every N ms. That refresh rate should be set in `filterAdapter::refreshRate` property.
`uniqueKeysTracker::startFilterCleaner` and  `uniqueKeysTracker::stopFilterCleaner` are present only when `filterAdapter::refreshRate` is not undefined

## How do we test the changes introduced in this PR?
Unit tests included

## Extra Notes