### PR TITLE
Add TelemetryCache in PluggableStorage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
-1.6.2 (September XXX, 2022)
+1.7.0 (September XXX, 2022)
+- Updated SDK telemetry to support pluggable storage, partial consumer mode, and synchronizer.
 - Updated storage implementations to improve the performance of split evaluations (i.e., `getTreatment(s)` method calls) when using the default storage in memory.
 
 1.6.1 (July 22, 2022)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.6",
+  "version": "1.6.2-rc.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.6",
+  "version": "1.6.2-rc.9",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",
@@ -70,7 +70,6 @@
     "ioredis": "^4.28.0",
     "jest": "^27.2.3",
     "jest-localstorage-mock": "^2.4.3",
-    "js-yaml": "^3.13.1",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "redis-server": "1.2.2",

--- a/src/evaluator/index.ts
+++ b/src/evaluator/index.ts
@@ -29,19 +29,19 @@ export function evaluateFeature(
   attributes: SplitIO.Attributes | undefined,
   storage: IStorageSync | IStorageAsync,
 ): MaybeThenable<IEvaluationResult> {
-  let stringifiedSplit;
+  let parsedSplit;
 
   try {
-    stringifiedSplit = storage.splits.getSplit(splitName);
+    parsedSplit = storage.splits.getSplit(splitName);
   } catch (e) {
     // Exception on sync `getSplit` storage. Not possible ATM with InMemory and InLocal storages.
     return treatmentException;
   }
 
-  if (thenable(stringifiedSplit)) {
-    return stringifiedSplit.then((result) => getEvaluation(
+  if (thenable(parsedSplit)) {
+    return parsedSplit.then((split) => getEvaluation(
       log,
-      result,
+      split,
       key,
       attributes,
       storage,
@@ -54,7 +54,7 @@ export function evaluateFeature(
 
   return getEvaluation(
     log,
-    stringifiedSplit,
+    parsedSplit,
     key,
     attributes,
     storage,

--- a/src/sdkClient/client.ts
+++ b/src/sdkClient/client.ts
@@ -9,6 +9,17 @@ import { IEvaluationResult } from '../evaluator/types';
 import { SplitIO, ImpressionDTO } from '../types';
 import { IMPRESSION, IMPRESSION_QUEUEING } from '../logger/constants';
 import { ISdkFactoryContext } from '../sdkFactory/types';
+import { isStorageSync } from '../trackers/impressionObserver/utils';
+
+const treatmentNotReady = { treatment: CONTROL, label: SDK_NOT_READY };
+
+function treatmentsNotReady(splitNames: string[]) {
+  const evaluations: Record<string, IEvaluationResult> = {};
+  splitNames.forEach(splitName => {
+    evaluations[splitName] = treatmentNotReady;
+  });
+  return evaluations;
+}
 
 /**
  * Creator of base client with getTreatments and track methods.
@@ -29,7 +40,11 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
       return treatment;
     };
 
-    const evaluation = evaluateFeature(log, key, splitName, attributes, storage);
+    const evaluation = readinessManager.isReady() || readinessManager.isReadyFromCache() ?
+      evaluateFeature(log, key, splitName, attributes, storage) :
+      isStorageSync(settings) ? // If the SDK is not ready, treatment may be incorrect due to having splits but not segments data, or storage is not connected
+        treatmentNotReady :
+        Promise.resolve(treatmentNotReady); // Promisify if async
 
     return thenable(evaluation) ? evaluation.then((res) => wrapUp(res)) : wrapUp(evaluation);
   }
@@ -53,7 +68,11 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
       return treatments;
     };
 
-    const evaluations = evaluateFeatures(log, key, splitNames, attributes, storage);
+    const evaluations = readinessManager.isReady() || readinessManager.isReadyFromCache() ?
+      evaluateFeatures(log, key, splitNames, attributes, storage) :
+      isStorageSync(settings) ? // If the SDK is not ready, treatment may be incorrect due to having splits but not segments data, or storage is not connected
+        treatmentsNotReady(splitNames) :
+        Promise.resolve(treatmentsNotReady(splitNames)); // Promisify if async
 
     return thenable(evaluations) ? evaluations.then((res) => wrapUp(res)) : wrapUp(evaluations);
   }
@@ -72,14 +91,8 @@ export function clientFactory(params: ISdkFactoryContext): SplitIO.IClient | Spl
     invokingMethodName: string,
     queue: ImpressionDTO[]
   ): SplitIO.Treatment | SplitIO.TreatmentWithConfig {
-    const isSdkReady = readinessManager.isReady() || readinessManager.isReadyFromCache();
     const matchingKey = getMatching(key);
     const bucketingKey = getBucketing(key);
-
-    // If the SDK was not ready, treatment may be incorrect due to having Splits but not segments data.
-    if (!isSdkReady) {
-      evaluation = { treatment: CONTROL, label: SDK_NOT_READY };
-    }
 
     const { treatment, label, changeNumber, config = null } = evaluation;
     log.info(IMPRESSION, [splitName, matchingKey, treatment, label]);

--- a/src/sdkManager/__tests__/index.asyncCache.spec.ts
+++ b/src/sdkManager/__tests__/index.asyncCache.spec.ts
@@ -8,6 +8,7 @@ import { wrapperAdapter } from '../../storages/pluggable/wrapperAdapter';
 import { KeyBuilderSS } from '../../storages/KeyBuilderSS';
 import { ISdkReadinessManager } from '../../readiness/types';
 import { loggerMock } from '../../logger/__tests__/sdkLogger.mock';
+import { metadata } from '../../storages/__tests__/KeyBuilder.spec';
 
 // @ts-expect-error
 const sdkReadinessManagerMock = {
@@ -18,8 +19,7 @@ const sdkReadinessManagerMock = {
   sdkStatus: jest.fn()
 } as ISdkReadinessManager;
 
-// @ts-expect-error
-const keys = new KeyBuilderSS();
+const keys = new KeyBuilderSS('prefix', metadata);
 
 describe('MANAGER API', () => {
 

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -107,14 +107,14 @@ export function splitApiFactory(
       return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(IMPRESSIONS_COUNT));
     },
 
-    postMetricsConfig(body: string) {
+    postMetricsConfig(body: string, headers?: Record<string, string>) {
       const url = `${urls.telemetry}/v1/metrics/config`;
-      return splitHttpClient(url, { method: 'POST', body }, telemetryTracker.trackHttp(TELEMETRY), true);
+      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY), true);
     },
 
-    postMetricsUsage(body: string) {
+    postMetricsUsage(body: string, headers?: Record<string, string>) {
       const url = `${urls.telemetry}/v1/metrics/usage`;
-      return splitHttpClient(url, { method: 'POST', body }, telemetryTracker.trackHttp(TELEMETRY), true);
+      return splitHttpClient(url, { method: 'POST', body, headers }, telemetryTracker.trackHttp(TELEMETRY), true);
     }
   };
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -47,9 +47,9 @@ export type IPostTestImpressionsBulk = (body: string, headers?: Record<string, s
 
 export type IPostTestImpressionsCount = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
-export type IPostMetricsConfig = (body: string) => Promise<IResponse>
+export type IPostMetricsConfig = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
-export type IPostMetricsUsage = (body: string) => Promise<IResponse>
+export type IPostMetricsUsage = (body: string, headers?: Record<string, string>) => Promise<IResponse>
 
 export interface ISplitApi {
 	getSdkAPIHealthCheck: IHealthCheckAPI

--- a/src/storages/AbstractSplitsCacheAsync.ts
+++ b/src/storages/AbstractSplitsCacheAsync.ts
@@ -41,7 +41,7 @@ export abstract class AbstractSplitsCacheAsync implements ISplitsCacheAsync {
    * @param {string} name
    * @param {string} defaultTreatment
    * @param {number} changeNumber
-   * @returns {Promise} a promise that is resolved once the split kill operation is performed. The fulfillment value is a boolean: `true` if the kill success updating the split or `false` if no split is updated,
+   * @returns {Promise} a promise that is resolved once the split kill operation is performed. The fulfillment value is a boolean: `true` if the operation successed updating the split or `false` if no split is updated,
    * for instance, if the `changeNumber` is old, or if the split is not found (e.g., `/splitchanges` hasn't been fetched yet), or if the storage fails to apply the update.
    * The promise will never be rejected.
    */

--- a/src/storages/AbstractSplitsCacheSync.ts
+++ b/src/storages/AbstractSplitsCacheSync.ts
@@ -61,7 +61,7 @@ export abstract class AbstractSplitsCacheSync implements ISplitsCacheSync {
    * @param {string} name
    * @param {string} defaultTreatment
    * @param {number} changeNumber
-   * @returns {Promise} a promise that is resolved once the split kill is performed. The fulfillment value is a boolean: `true` if the kill success updating the split or `false` if no split is updated,
+   * @returns {boolean} `true` if the operation successed updating the split, or `false` if no split is updated,
    * for instance, if the `changeNumber` is old, or if the split is not found (e.g., `/splitchanges` hasn't been fetched yet), or if the storage fails to apply the update.
    */
   killLocally(name: string, defaultTreatment: string, changeNumber: number): boolean {

--- a/src/storages/KeyBuilderSS.ts
+++ b/src/storages/KeyBuilderSS.ts
@@ -1,8 +1,9 @@
 import { KeyBuilder } from './KeyBuilder';
 import { IMetadata } from '../dtos/types';
 import { Method } from '../sync/submitters/types';
+import { MAX_LATENCY_BUCKET_COUNT } from './inMemory/TelemetryCacheInMemory';
 
-const methodNames: Record<Method, string> = {
+const METHOD_NAMES: Record<Method, string> = {
   t: 'treatment',
   ts: 'treatments',
   tc: 'treatmentWithConfig',
@@ -12,11 +13,17 @@ const methodNames: Record<Method, string> = {
 
 export class KeyBuilderSS extends KeyBuilder {
 
-  protected readonly metadata: IMetadata;
+  latencyPrefix: string;
+  exceptionPrefix: string;
+  initPrefix: string;
+  private versionablePrefix: string;
 
   constructor(prefix: string, metadata: IMetadata) {
     super(prefix);
-    this.metadata = metadata;
+    this.latencyPrefix = `${this.prefix}.telemetry.latencies`;
+    this.exceptionPrefix = `${this.prefix}.telemetry.exceptions`;
+    this.initPrefix = `${this.prefix}.telemetry.init`;
+    this.versionablePrefix = `${metadata.s}/${metadata.n}/${metadata.i}`;
   }
 
   buildRegisteredSegmentsKey() {
@@ -38,19 +45,56 @@ export class KeyBuilderSS extends KeyBuilder {
   /* Telemetry keys */
 
   buildLatencyKey(method: Method, bucket: number) {
-    return `${this.prefix}.telemetry.latencies::${this.buildVersionablePrefix()}/${methodNames[method]}/${bucket}`;
+    return `${this.latencyPrefix}::${this.versionablePrefix}/${METHOD_NAMES[method]}/${bucket}`;
   }
 
   buildExceptionKey(method: Method) {
-    return `${this.prefix}.telemetry.exceptions::${this.buildVersionablePrefix()}/${methodNames[method]}`;
+    return `${this.exceptionPrefix}::${this.versionablePrefix}/${METHOD_NAMES[method]}`;
   }
 
   buildInitKey() {
-    return `${this.prefix}.telemetry.init::${this.buildVersionablePrefix()}`;
+    return `${this.initPrefix}::${this.versionablePrefix}`;
   }
 
-  private buildVersionablePrefix() {
-    return `${this.metadata.s}/${this.metadata.n}/${this.metadata.i}`;
-  }
+}
 
+// Used by consumer methods of TelemetryCacheInRedis and TelemetryCachePluggable
+
+const REVERSE_METHOD_NAMES = Object.keys(METHOD_NAMES).reduce((acc, key) => {
+  acc[METHOD_NAMES[key as Method]] = key as Method;
+  return acc;
+}, {} as Record<string, Method>);
+
+
+export function parseMetadata(field: string): [metadata: string] | string {
+  const parts = field.split('/');
+  if (parts.length !== 3) return `invalid subsection count. Expected 3, got: ${parts.length}`;
+
+  const [s /* metadata.s */, n /* metadata.n */, i /* metadata.i */] = parts;
+  return [JSON.stringify({ s, n, i })];
+}
+
+export function parseExceptionField(field: string): [metadata: string, method: Method] | string {
+  const parts = field.split('/');
+  if (parts.length !== 4) return `invalid subsection count. Expected 4, got: ${parts.length}`;
+
+  const [s /* metadata.s */, n /* metadata.n */, i /* metadata.i */, m] = parts;
+  const method = REVERSE_METHOD_NAMES[m];
+  if (!method) return `unknown method '${m}'`;
+
+  return [JSON.stringify({ s, n, i }), method];
+}
+
+export function parseLatencyField(field: string): [metadata: string, method: Method, bucket: number] | string {
+  const parts = field.split('/');
+  if (parts.length !== 5) return `invalid subsection count. Expected 5, got: ${parts.length}`;
+
+  const [s /* metadata.s */, n /* metadata.n */, i /* metadata.i */, m, b] = parts;
+  const method = REVERSE_METHOD_NAMES[m];
+  if (!method) return `unknown method '${m}'`;
+
+  const bucket = parseInt(b);
+  if (isNaN(bucket) || bucket >= MAX_LATENCY_BUCKET_COUNT) return `invalid bucket. Expected a number between 0 and ${MAX_LATENCY_BUCKET_COUNT - 1}, got: ${b}`;
+
+  return [JSON.stringify({ s, n, i }), method, bucket];
 }

--- a/src/storages/__tests__/KeyBuilder.spec.ts
+++ b/src/storages/__tests__/KeyBuilder.spec.ts
@@ -35,9 +35,11 @@ test('KEYS / splits keys with custom prefix', () => {
   // expect(builder.buildSplitsReady() === expectedReady).toBe(true);
 });
 
+const prefix = 'SPLITIO';
+export const metadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
+
 test('KEYS / segments keys', () => {
-  // @ts-expect-error
-  const builder = new KeyBuilderSS();
+  const builder = new KeyBuilderSS(prefix, metadata);
 
   const segmentName = 'segment_name__for_testing';
   const expectedKey = `SPLITIO.segment.${segmentName}`;
@@ -66,8 +68,6 @@ test('KEYS / traffic type keys', () => {
 });
 
 test('KEYS / impressions', () => {
-  const prefix = 'SPLITIO';
-  const metadata = { s: 'js-1234', i: '10-10-10-10', n: 'UNKNOWN' };
   const builder = new KeyBuilderSS(prefix, metadata);
 
   const expectedImpressionKey = `${prefix}.impressions`;
@@ -76,14 +76,12 @@ test('KEYS / impressions', () => {
 });
 
 test('KEYS / events', () => {
-  // @ts-expect-error
-  let builder = new KeyBuilderSS('test-prefix-1');
+  let builder = new KeyBuilderSS('test-prefix-1', metadata);
 
   expect(builder.buildEventsKey()).toBe('test-prefix-1.events'); // Events key should only vary because of the storage prefix and return the same value on multiple invocations.
   expect(builder.buildEventsKey()).toBe('test-prefix-1.events'); // Events key should only vary because of the storage prefix and return the same value on multiple invocations.
 
-  // @ts-expect-error
-  builder = new KeyBuilderSS('testPrefix2');
+  builder = new KeyBuilderSS('testPrefix2', metadata);
 
   expect(builder.buildEventsKey()).toBe('testPrefix2.events'); // Events key should only vary because of the storage prefix and return the same value on multiple invocations.
   expect(builder.buildEventsKey()).toBe('testPrefix2.events'); // Events key should only vary because of the storage prefix and return the same value on multiple invocations.
@@ -91,8 +89,6 @@ test('KEYS / events', () => {
 });
 
 test('KEYS / latency and exception keys (telemetry)', () => {
-  const prefix = 'SPLITIO';
-  const metadata = { s: 'js-1234', i: '10-10-10-10', n: 'UNKNOWN' };
   const builder = new KeyBuilderSS(prefix, metadata);
 
   const methodName = 't'; // treatment

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -229,7 +229,6 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
   /**
    * Clean Splits cache if its `lastUpdated` timestamp is older than the given `expirationTimestamp`,
-   * Clean operation (clear) also updates `lastUpdated` timestamp with current time.
    *
    * @param {number | undefined} expirationTimestamp if the value is not a number, data will not be cleaned
    */

--- a/src/storages/inLocalStorage/index.ts
+++ b/src/storages/inLocalStorage/index.ts
@@ -12,7 +12,7 @@ import { SplitsCacheInMemory } from '../inMemory/SplitsCacheInMemory';
 import { DEFAULT_CACHE_EXPIRATION_IN_MILLIS } from '../../utils/constants/browser';
 import { InMemoryStorageCSFactory } from '../inMemory/InMemoryStorageCS';
 import { LOG_PREFIX } from './constants';
-import { LOCALHOST_MODE, STORAGE_LOCALSTORAGE } from '../../utils/constants';
+import { STORAGE_LOCALSTORAGE } from '../../utils/constants';
 import { shouldRecordTelemetry, TelemetryCacheInMemory } from '../inMemory/TelemetryCacheInMemory';
 
 export interface InLocalStorageOptions {
@@ -44,7 +44,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
       impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
       impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
       events: new EventsCacheInMemory(params.eventsQueueSize),
-      telemetry: params.mode !== LOCALHOST_MODE && shouldRecordTelemetry() ? new TelemetryCacheInMemory() : undefined,
+      telemetry: shouldRecordTelemetry(params) ? new TelemetryCacheInMemory() : undefined,
 
       destroy() {
         this.splits = new SplitsCacheInMemory();

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -4,8 +4,8 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageFactoryParams, IStorageSync } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, STORAGE_MEMORY } from '../../utils/constants';
-import { TelemetryCacheInMemory } from './TelemetryCacheInMemory';
+import { STORAGE_MEMORY } from '../../utils/constants';
+import { shouldRecordTelemetry, TelemetryCacheInMemory } from './TelemetryCacheInMemory';
 
 /**
  * InMemory storage factory for standalone server-side SplitFactory
@@ -20,7 +20,7 @@ export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageS
     impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
     impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
-    telemetry: params.mode !== LOCALHOST_MODE ? new TelemetryCacheInMemory() : undefined, // Always track telemetry in standalone mode on server-side
+    telemetry: shouldRecordTelemetry(params) ? new TelemetryCacheInMemory() : undefined,
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {

--- a/src/storages/inMemory/InMemoryStorageCS.ts
+++ b/src/storages/inMemory/InMemoryStorageCS.ts
@@ -4,7 +4,7 @@ import { ImpressionsCacheInMemory } from './ImpressionsCacheInMemory';
 import { EventsCacheInMemory } from './EventsCacheInMemory';
 import { IStorageSync, IStorageFactoryParams } from '../types';
 import { ImpressionCountsCacheInMemory } from './ImpressionCountsCacheInMemory';
-import { LOCALHOST_MODE, STORAGE_MEMORY } from '../../utils/constants';
+import { STORAGE_MEMORY } from '../../utils/constants';
 import { shouldRecordTelemetry, TelemetryCacheInMemory } from './TelemetryCacheInMemory';
 
 /**
@@ -20,7 +20,7 @@ export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorag
     impressions: new ImpressionsCacheInMemory(params.impressionsQueueSize),
     impressionCounts: params.optimize ? new ImpressionCountsCacheInMemory() : undefined,
     events: new EventsCacheInMemory(params.eventsQueueSize),
-    telemetry: params.mode !== LOCALHOST_MODE && shouldRecordTelemetry() ? new TelemetryCacheInMemory() : undefined,
+    telemetry: shouldRecordTelemetry(params) ? new TelemetryCacheInMemory() : undefined,
 
     // When using MEMORY we should clean all the caches to leave them empty
     destroy() {

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -5,10 +5,10 @@ import { IStorageFactoryParams, ITelemetryCacheSync } from '../types';
 
 const MAX_STREAMING_EVENTS = 20;
 const MAX_TAGS = 10;
+export const MAX_LATENCY_BUCKET_COUNT = 23;
 
-function newBuckets() {
-  // MAX_LATENCY_BUCKET_COUNT (length) is 23;
-  return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+export function newBuckets() {
+  return new Array(MAX_LATENCY_BUCKET_COUNT).fill(0);
 }
 
 const ACCEPTANCE_RANGE = 0.001;

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -8,7 +8,9 @@ const MAX_TAGS = 10;
 export const MAX_LATENCY_BUCKET_COUNT = 23;
 
 export function newBuckets() {
-  return new Array(MAX_LATENCY_BUCKET_COUNT).fill(0);
+  // MAX_LATENCY_BUCKET_COUNT (length) is 23
+  // Not using Array.fill for old browsers compatibility
+  return [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 }
 
 const ACCEPTANCE_RANGE = 0.001;

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -1,6 +1,7 @@
 import { ImpressionDataType, EventDataType, LastSync, HttpErrors, HttpLatencies, StreamingEvent, Method, OperationType, MethodExceptions, MethodLatencies } from '../../sync/submitters/types';
+import { LOCALHOST_MODE } from '../../utils/constants';
 import { findLatencyIndex } from '../findLatencyIndex';
-import { ITelemetryCacheSync } from '../types';
+import { IStorageFactoryParams, ITelemetryCacheSync } from '../types';
 
 const MAX_STREAMING_EVENTS = 20;
 const MAX_TAGS = 10;
@@ -13,10 +14,11 @@ function newBuckets() {
 const ACCEPTANCE_RANGE = 0.001;
 
 /**
- * Used on client-side. 0.1% of instances will track telemetry
+ * Record telemetry if mode is not localhost.
+ * All factory instances track telemetry on server-side, and 0.1% on client-side.
  */
-export function shouldRecordTelemetry() {
-  return Math.random() <= ACCEPTANCE_RANGE;
+export function shouldRecordTelemetry(params: IStorageFactoryParams) {
+  return params.mode !== LOCALHOST_MODE && (params.matchingKey === undefined || Math.random() <= ACCEPTANCE_RANGE);
 }
 
 export class TelemetryCacheInMemory implements ITelemetryCacheSync {

--- a/src/storages/inRedis/EventsCacheInRedis.ts
+++ b/src/storages/inRedis/EventsCacheInRedis.ts
@@ -59,7 +59,7 @@ export class EventsCacheInRedis implements IEventsCacheAsync {
 
   /**
    * Pop the given number of events from the storage.
-   * The returned promise rejects if the wrapper operation fails.
+   * The returned promise rejects if the redis operation fails.
    *
    * NOTE: this method doesn't take into account MAX_EVENT_SIZE or MAX_QUEUE_BYTE_SIZE limits.
    * It is the submitter responsability to handle that.

--- a/src/storages/inRedis/TelemetryCacheInRedis.ts
+++ b/src/storages/inRedis/TelemetryCacheInRedis.ts
@@ -1,11 +1,14 @@
 import { ILogger } from '../../logger/types';
-import { Method } from '../../sync/submitters/types';
-import { KeyBuilderSS } from '../KeyBuilderSS';
+import { Method, MultiConfigs, MultiMethodExceptions, MultiMethodLatencies } from '../../sync/submitters/types';
+import { KeyBuilderSS, parseExceptionField, parseLatencyField, parseMetadata } from '../KeyBuilderSS';
 import { ITelemetryCacheAsync } from '../types';
 import { findLatencyIndex } from '../findLatencyIndex';
 import { Redis } from 'ioredis';
 import { getTelemetryConfigStats } from '../../sync/submitters/telemetrySubmitter';
 import { CONSUMER_MODE, STORAGE_REDIS } from '../../utils/constants';
+import { isNaNNumber, isString } from '../../utils/lang';
+import { _Map } from '../../utils/lang/maps';
+import { MAX_LATENCY_BUCKET_COUNT, newBuckets } from '../inMemory/TelemetryCacheInMemory';
 
 export class TelemetryCacheInRedis implements ITelemetryCacheAsync {
 
@@ -22,6 +25,7 @@ export class TelemetryCacheInRedis implements ITelemetryCacheAsync {
     return this.redis.hincrby(key, field, 1)
       .catch(() => { /* Handle rejections for telemetry */ });
   }
+
   recordException(method: Method) {
     const [key, field] = this.keys.buildExceptionKey(method).split('::');
     return this.redis.hincrby(key, field, 1)
@@ -32,5 +36,121 @@ export class TelemetryCacheInRedis implements ITelemetryCacheAsync {
     const [key, field] = this.keys.buildInitKey().split('::');
     const value = JSON.stringify(getTelemetryConfigStats(CONSUMER_MODE, STORAGE_REDIS));
     return this.redis.hset(key, field, value).catch(() => { /* Handle rejections for telemetry */ });
+  }
+
+  /**
+   * Pop telemetry latencies.
+   * The returned promise rejects if redis operations fail.
+   */
+  popLatencies(): Promise<MultiMethodLatencies> {
+    return this.redis.hgetall(this.keys.latencyPrefix).then(latencies => {
+
+      const result: MultiMethodLatencies = new _Map();
+
+      Object.keys(latencies).forEach(field => {
+
+        const parsedField = parseLatencyField(field);
+        if (isString(parsedField)) {
+          this.log.error(`Ignoring invalid latency field: ${field}: ${parsedField}`);
+          return;
+        }
+
+        const count = parseInt(latencies[field]);
+        if (isNaNNumber(count)) {
+          this.log.error(`Ignoring latency with invalid count: ${latencies[field]}`);
+          return;
+        }
+
+        const [metadata, method, bucket] = parsedField;
+
+        if (bucket >= MAX_LATENCY_BUCKET_COUNT) {
+          this.log.error(`Ignoring latency with invalid bucket: ${bucket}`);
+          return;
+        }
+
+        if (!result.has(metadata)) result.set(metadata, {
+          t: newBuckets(),
+          ts: newBuckets(),
+          tc: newBuckets(),
+          tcs: newBuckets(),
+          tr: newBuckets(),
+        });
+
+        result.get(metadata)![method][bucket] = count;
+      });
+
+      return this.redis.del(this.keys.latencyPrefix).then(() => result);
+    });
+  }
+
+  /**
+   * Pop telemetry exceptions.
+   * The returned promise rejects if redis operations fail.
+   */
+  popExceptions(): Promise<MultiMethodExceptions> {
+    return this.redis.hgetall(this.keys.exceptionPrefix).then(exceptions => {
+
+      const result: MultiMethodExceptions = new _Map();
+
+      Object.keys(exceptions).forEach(field => {
+
+        const parsedField = parseExceptionField(field);
+        if (isString(parsedField)) {
+          this.log.error(`Ignoring invalid exception field: ${field}: ${parsedField}`);
+          return;
+        }
+
+        const count = parseInt(exceptions[field]);
+        if (isNaNNumber(count)) {
+          this.log.error(`Ignoring exception with invalid count: ${exceptions[field]}`);
+          return;
+        }
+
+        const [metadata, method] = parsedField;
+
+        if (!result.has(metadata)) result.set(metadata, {
+          t: 0,
+          ts: 0,
+          tc: 0,
+          tcs: 0,
+          tr: 0,
+        });
+
+        result.get(metadata)![method] = count;
+      });
+
+      return this.redis.del(this.keys.exceptionPrefix).then(() => result);
+    });
+  }
+
+  /**
+   * Pop telemetry configs.
+   * The returned promise rejects if redis operations fail.
+   */
+  popConfigs(): Promise<MultiConfigs> {
+    return this.redis.hgetall(this.keys.initPrefix).then(configs => {
+
+      const result: MultiConfigs = new _Map();
+
+      Object.keys(configs).forEach(field => {
+
+        const parsedField = parseMetadata(field);
+        if (isString(parsedField)) {
+          this.log.error(`Ignoring invalid config field: ${field}: ${parsedField}`);
+          return;
+        }
+
+        const [metadata] = parsedField;
+
+        try {
+          const config = JSON.parse(configs[field]);
+          result.set(metadata, config);
+        } catch (e) {
+          this.log.error(`Ignoring invalid config: ${configs[field]}`);
+        }
+      });
+
+      return this.redis.del(this.keys.initPrefix).then(() => result);
+    });
   }
 }

--- a/src/storages/inRedis/__tests__/EventsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/EventsCacheInRedis.spec.ts
@@ -1,7 +1,7 @@
 import Redis from 'ioredis';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { EventsCacheInRedis } from '../EventsCacheInRedis';
-import { fakeMetadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored } from '../../pluggable/__tests__/EventsCachePluggable.spec';
+import { metadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored } from '../../pluggable/__tests__/EventsCachePluggable.spec';
 
 const prefix = 'events_cache_ut';
 const eventsKey = `${prefix}.events`;
@@ -17,11 +17,11 @@ test('EVENTS CACHE IN REDIS / `track`, `count`, `popNWithMetadata` and `drop` me
 
   expect(redisValues.length).toBe(0); // control assertion, there are no events previously queued.
 
-  const cache = new EventsCacheInRedis(loggerMock, eventsKey, connection, fakeMetadata);
+  const cache = new EventsCacheInRedis(loggerMock, eventsKey, connection, metadata);
   // I'll use a "bad" instance so I can force an issue with the rpush command. I'll store an integer and will make the cache try to use rpush there.
   await connection.set(nonListKey, 10);
 
-  const faultyCache = new EventsCacheInRedis(loggerMock, nonListKey, connection, fakeMetadata);
+  const faultyCache = new EventsCacheInRedis(loggerMock, nonListKey, connection, metadata);
 
   expect(await cache.track(fakeEvent1)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
   expect(await cache.track(fakeEvent2)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"

--- a/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/ImpressionsCacheInRedis.spec.ts
@@ -2,7 +2,7 @@ import { RedisAdapter } from '../RedisAdapter';
 import { ImpressionsCacheInRedis } from '../ImpressionsCacheInRedis';
 import IORedis, { BooleanResponse } from 'ioredis';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-import { fakeMetadata, o1, o2, o3, o1stored, o2stored, o3stored } from '../../pluggable/__tests__/ImpressionsCachePluggable.spec';
+import { o1, o2, o3, o1stored, o2stored, o3stored, metadata } from '../../pluggable/__tests__/ImpressionsCachePluggable.spec';
 
 describe('IMPRESSIONS CACHE IN REDIS', () => {
 
@@ -10,7 +10,7 @@ describe('IMPRESSIONS CACHE IN REDIS', () => {
     const connection = new RedisAdapter(loggerMock, {});
     const impressionsKey = 'impr_cache_ut.impressions';
 
-    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
+    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, metadata);
 
     // cleanup
     await connection.del(impressionsKey);
@@ -51,7 +51,7 @@ describe('IMPRESSIONS CACHE IN REDIS', () => {
     const impressionsKey = 'impr_cache_ut_2.impressions';
     const connection = new RedisAdapter(loggerMock, {});
 
-    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, fakeMetadata);
+    const c = new ImpressionsCacheInRedis(loggerMock, impressionsKey, connection, metadata);
 
     const i1 = { feature: 'test4', keyName: 'nicolas@split.io', treatment: 'off', time: Date.now(), changeNumber: 1 };
     const i2 = { feature: 'test5', keyName: 'matias@split.io', treatment: 'on', time: Date.now(), changeNumber: 2 };

--- a/src/storages/inRedis/__tests__/SegmentsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/SegmentsCacheInRedis.spec.ts
@@ -2,9 +2,9 @@ import Redis from 'ioredis';
 import { SegmentsCacheInRedis } from '../SegmentsCacheInRedis';
 import { KeyBuilderSS } from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
-// @ts-expect-error. Doesn't require metadata
-const keys = new KeyBuilderSS();
+const keys = new KeyBuilderSS('prefix', metadata);
 
 describe('SEGMENTS CACHE IN REDIS', () => {
 

--- a/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
@@ -4,6 +4,7 @@ import { KeyBuilderSS } from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { splitWithUserTT, splitWithAccountTT } from '../../__tests__/testUtils';
 import { ISplit } from '../../../dtos/types';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
 const prefix = 'splits_cache_ut';
 
@@ -11,8 +12,7 @@ describe('SPLITS CACHE REDIS', () => {
 
   test('add/remove/get splits & set/get change number', async () => {
     const connection = new Redis();
-    // @ts-expect-error
-    const keysBuilder = new KeyBuilderSS(prefix);
+    const keysBuilder = new KeyBuilderSS(prefix, metadata);
     const cache = new SplitsCacheInRedis(loggerMock, keysBuilder, connection);
 
     await cache.clear();
@@ -61,8 +61,7 @@ describe('SPLITS CACHE REDIS', () => {
   test('trafficTypeExists', async () => {
     const prefix = 'splits_cache_ut';
     const connection = new Redis();
-    // @ts-expect-error
-    const keysBuilder = new KeyBuilderSS(prefix);
+    const keysBuilder = new KeyBuilderSS(prefix, metadata);
     const cache = new SplitsCacheInRedis(loggerMock, keysBuilder, connection);
 
     await cache.addSplits([
@@ -113,8 +112,7 @@ describe('SPLITS CACHE REDIS', () => {
 
   test('killLocally', async () => {
     const connection = new Redis();
-    // @ts-expect-error
-    const keys = new KeyBuilderSS(prefix);
+    const keys = new KeyBuilderSS(prefix, metadata);
     const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
 
     await cache.addSplit('lol1', splitWithUserTT);

--- a/src/storages/inRedis/__tests__/TelemetryCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/TelemetryCacheInRedis.spec.ts
@@ -2,17 +2,18 @@ import Redis from 'ioredis';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { KeyBuilderSS } from '../../KeyBuilderSS';
 import { TelemetryCacheInRedis } from '../TelemetryCacheInRedis';
-import { fakeMetadata } from '../../pluggable/__tests__/ImpressionsCachePluggable.spec';
+import { newBuckets } from '../../inMemory/TelemetryCacheInMemory';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
 const prefix = 'telemetry_cache_ut';
 const exceptionKey = `${prefix}.telemetry.exceptions`;
 const latencyKey = `${prefix}.telemetry.latencies`;
 const initKey = `${prefix}.telemetry.init`;
-const fieldVersionablePrefix = `${fakeMetadata.s}/${fakeMetadata.n}/${fakeMetadata.i}`;
+const fieldVersionablePrefix = `${metadata.s}/${metadata.n}/${metadata.i}`;
 
 test('TELEMETRY CACHE IN REDIS', async () => {
 
-  const keysBuilder = new KeyBuilderSS(prefix, fakeMetadata);
+  const keysBuilder = new KeyBuilderSS(prefix, metadata);
   const connection = new Redis();
   const cache = new TelemetryCacheInRedis(loggerMock, keysBuilder, connection);
 
@@ -39,9 +40,51 @@ test('TELEMETRY CACHE IN REDIS', async () => {
     rF: 0
   });
 
-  // Clean up then end.
-  await connection.hdel(exceptionKey, fieldVersionablePrefix + '/track');
-  await connection.hdel(latencyKey, fieldVersionablePrefix + '/track/2');
-  await connection.hdel(initKey, fieldVersionablePrefix);
+  // popLatencies
+  const latencies = await cache.popLatencies();
+  latencies.forEach((latency, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(latency).toEqual({
+      t: newBuckets(),
+      ts: newBuckets(),
+      tc: newBuckets(),
+      tcs: newBuckets(),
+      tr: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    });
+  });
+  expect(await connection.hget(latencyKey, fieldVersionablePrefix + '/track/2')).toBe(null);
+
+  // popExceptions
+  const exceptions = await cache.popExceptions();
+  exceptions.forEach((exception, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(exception).toEqual({
+      t: 0,
+      ts: 0,
+      tc: 0,
+      tcs: 0,
+      tr: 2,
+    });
+  });
+  expect(await connection.hget(exceptionKey, fieldVersionablePrefix + '/track')).toBe(null);
+
+  // popConfig
+  const configs = await cache.popConfigs();
+  configs.forEach((config, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(config).toEqual({
+      oM: 1,
+      st: 'redis',
+      aF: 0,
+      rF: 0
+    });
+  });
+  expect(await connection.hget(initKey, fieldVersionablePrefix)).toBe(null);
+
+  // pops when there is no data
+  expect((await cache.popLatencies()).size).toBe(0);
+  expect((await cache.popExceptions()).size).toBe(0);
+  expect((await cache.popConfigs()).size).toBe(0);
+
   await connection.quit();
 });

--- a/src/storages/pluggable/TelemetryCachePluggable.ts
+++ b/src/storages/pluggable/TelemetryCachePluggable.ts
@@ -1,10 +1,13 @@
 import { ILogger } from '../../logger/types';
-import { Method } from '../../sync/submitters/types';
-import { KeyBuilderSS } from '../KeyBuilderSS';
+import { Method, MultiConfigs, MultiMethodExceptions, MultiMethodLatencies } from '../../sync/submitters/types';
+import { KeyBuilderSS, parseExceptionField, parseLatencyField, parseMetadata } from '../KeyBuilderSS';
 import { IPluggableStorageWrapper, ITelemetryCacheAsync } from '../types';
 import { findLatencyIndex } from '../findLatencyIndex';
 import { getTelemetryConfigStats } from '../../sync/submitters/telemetrySubmitter';
 import { CONSUMER_MODE, STORAGE_PLUGGABLE } from '../../utils/constants';
+import { isString, isNaNNumber } from '../../utils/lang';
+import { _Map } from '../../utils/lang/maps';
+import { MAX_LATENCY_BUCKET_COUNT, newBuckets } from '../inMemory/TelemetryCacheInMemory';
 
 export class TelemetryCachePluggable implements ITelemetryCacheAsync {
 
@@ -28,5 +31,141 @@ export class TelemetryCachePluggable implements ITelemetryCacheAsync {
   recordConfig() {
     const value = JSON.stringify(getTelemetryConfigStats(CONSUMER_MODE, STORAGE_PLUGGABLE));
     return this.wrapper.set(this.keys.buildInitKey(), value).catch(() => { /* Handle rejections for telemetry */ });
+  }
+
+  /**
+   * Pop telemetry latencies.
+   * The returned promise rejects if wrapper operations fail.
+   */
+  popLatencies(): Promise<MultiMethodLatencies> {
+    return this.wrapper.getKeysByPrefix(this.keys.latencyPrefix).then(latencyKeys => {
+      return latencyKeys.length ?
+        this.wrapper.getMany(latencyKeys).then(latencies => {
+
+          const result: MultiMethodLatencies = new _Map();
+
+          for (let i = 0; i < latencyKeys.length; i++) {
+            const field = latencyKeys[i].split('::')[1];
+
+            const parsedField = parseLatencyField(field);
+            if (isString(parsedField)) {
+              this.log.error(`Ignoring invalid latency field: ${field}: ${parsedField}`);
+              continue;
+            }
+
+            // @ts-ignore
+            const count = parseInt(latencies[i]);
+            if (isNaNNumber(count)) {
+              this.log.error(`Ignoring latency with invalid count: ${latencies[i]}`);
+              continue;
+            }
+
+            const [metadata, method, bucket] = parsedField;
+
+            if (bucket >= MAX_LATENCY_BUCKET_COUNT) {
+              this.log.error(`Ignoring latency with invalid bucket: ${bucket}`);
+              continue;
+            }
+
+            if (!result.has(metadata)) result.set(metadata, {
+              t: newBuckets(),
+              ts: newBuckets(),
+              tc: newBuckets(),
+              tcs: newBuckets(),
+              tr: newBuckets(),
+            });
+
+            result.get(metadata)![method][bucket] = count;
+          }
+
+          return Promise.all(latencyKeys.map((latencyKey) => this.wrapper.del(latencyKey))).then(() => result);
+        }) :
+        // If latencyKeys is empty, return an empty map.
+        new _Map();
+    });
+  }
+
+  /**
+   * Pop telemetry exceptions.
+   * The returned promise rejects if wrapper operations fail.
+   */
+  popExceptions(): Promise<MultiMethodExceptions> {
+    return this.wrapper.getKeysByPrefix(this.keys.exceptionPrefix).then(exceptionKeys => {
+      return exceptionKeys.length ?
+        this.wrapper.getMany(exceptionKeys).then(exceptions => {
+
+          const result: MultiMethodExceptions = new _Map();
+
+          for (let i = 0; i < exceptionKeys.length; i++) {
+            const field = exceptionKeys[i].split('::')[1];
+
+            const parsedField = parseExceptionField(field);
+            if (isString(parsedField)) {
+              this.log.error(`Ignoring invalid exception field: ${field}: ${parsedField}`);
+              continue;
+            }
+
+            // @ts-ignore
+            const count = parseInt(exceptions[i]);
+            if (isNaNNumber(count)) {
+              this.log.error(`Ignoring exception with invalid count: ${exceptions[i]}`);
+              continue;
+            }
+
+            const [metadata, method] = parsedField;
+
+            if (!result.has(metadata)) result.set(metadata, {
+              t: 0,
+              ts: 0,
+              tc: 0,
+              tcs: 0,
+              tr: 0,
+            });
+
+            result.get(metadata)![method] = count;
+          }
+
+          return Promise.all(exceptionKeys.map((exceptionKey) => this.wrapper.del(exceptionKey))).then(() => result);
+        }) :
+        // If exceptionKeys is empty, return an empty map.
+        new _Map();
+    });
+  }
+
+  /**
+   * Pop telemetry configs.
+   * The returned promise rejects if wrapper operations fail.
+   */
+  popConfigs(): Promise<MultiConfigs> {
+    return this.wrapper.getKeysByPrefix(this.keys.initPrefix).then(configKeys => {
+      return configKeys.length ?
+        this.wrapper.getMany(configKeys).then(configs => {
+
+          const result: MultiConfigs = new _Map();
+
+          for (let i = 0; i < configKeys.length; i++) {
+            const field = configKeys[i].split('::')[1];
+
+            const parsedField = parseMetadata(field);
+            if (isString(parsedField)) {
+              this.log.error(`Ignoring invalid config field: ${field}: ${parsedField}`);
+              continue;
+            }
+
+            const [metadata] = parsedField;
+
+            try { // @ts-ignore
+              const config = JSON.parse(configs[i]);
+              result.set(metadata, config);
+            } catch (e) {
+              this.log.error(`Ignoring invalid config: ${configs[i]}`);
+            }
+          }
+
+          return Promise.all(configKeys.map((configKey) => this.wrapper.del(configKey))).then(() => result);
+        }) :
+        // If configKeys is empty, return an empty map.
+        new _Map();
+    });
   }
 }

--- a/src/storages/pluggable/TelemetryCachePluggable.ts
+++ b/src/storages/pluggable/TelemetryCachePluggable.ts
@@ -3,6 +3,8 @@ import { Method } from '../../sync/submitters/types';
 import { KeyBuilderSS } from '../KeyBuilderSS';
 import { IPluggableStorageWrapper, ITelemetryCacheAsync } from '../types';
 import { findLatencyIndex } from '../findLatencyIndex';
+import { getTelemetryConfigStats } from '../../sync/submitters/telemetrySubmitter';
+import { CONSUMER_MODE, STORAGE_PLUGGABLE } from '../../utils/constants';
 
 export class TelemetryCachePluggable implements ITelemetryCacheAsync {
 
@@ -23,4 +25,8 @@ export class TelemetryCachePluggable implements ITelemetryCacheAsync {
       .catch(() => { /* Handle rejections for telemetry */ });
   }
 
+  recordConfig() {
+    const value = JSON.stringify(getTelemetryConfigStats(CONSUMER_MODE, STORAGE_PLUGGABLE));
+    return this.wrapper.set(this.keys.buildInitKey(), value).catch(() => { /* Handle rejections for telemetry */ });
+  }
 }

--- a/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/EventsCachePluggable.spec.ts
@@ -2,27 +2,27 @@ import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { EventsCachePluggable } from '../EventsCachePluggable';
 import { wrapperMockFactory } from './wrapper.mock';
 import { wrapperAdapter } from '../wrapperAdapter';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
 const prefix = 'events_cache_ut';
 const eventsKey = `${prefix}.events`;
-const fakeMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
 
 const fakeEvent1 = { eventTypeId: '1', timestamp: 111 };
-const fakeEvent1stored = { m: fakeMetadata, e: fakeEvent1 };
+const fakeEvent1stored = { m: metadata, e: fakeEvent1 };
 
 const fakeEvent2 = { eventTypeId: '2', timestamp: 222 };
-const fakeEvent2stored = { m: fakeMetadata, e: fakeEvent2 };
+const fakeEvent2stored = { m: metadata, e: fakeEvent2 };
 
 const fakeEvent3 = { eventTypeId: '3', timestamp: 333 };
-const fakeEvent3stored = { m: fakeMetadata, e: fakeEvent3 };
+const fakeEvent3stored = { m: metadata, e: fakeEvent3 };
 
-export { fakeMetadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored };
+export { metadata, fakeEvent1, fakeEvent1stored, fakeEvent2, fakeEvent2stored, fakeEvent3, fakeEvent3stored };
 
 describe('PLUGGABLE EVENTS CACHE', () => {
 
   test('`track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
     const wrapperMock = wrapperMockFactory();
-    const cache = new EventsCachePluggable(loggerMock, eventsKey, wrapperMock, fakeMetadata);
+    const cache = new EventsCachePluggable(loggerMock, eventsKey, wrapperMock, metadata);
 
     // Testing track and count methods.
     expect(await cache.track(fakeEvent1)).toBe(true); // If the queueing operation was successful, it should resolve the returned promise with "true"
@@ -57,7 +57,7 @@ describe('PLUGGABLE EVENTS CACHE', () => {
     // @ts-ignore. I'll use a "bad" queue to force an exception with the pushItems wrapper operation.
     wrapperMock._cache['non-list-key'] = 10;
     // wrapperMock is adapted this time to properly handle unexpected exceptions
-    const faultyCache = new EventsCachePluggable(loggerMock, 'non-list-key', wrapperAdapter(loggerMock, wrapperMock), fakeMetadata);
+    const faultyCache = new EventsCachePluggable(loggerMock, 'non-list-key', wrapperAdapter(loggerMock, wrapperMock), metadata);
 
     expect(await faultyCache.track(fakeEvent1)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.
     expect(await faultyCache.track(fakeEvent2)).toBe(false); // If the queueing operation was NOT successful, it should resolve the returned promise with "false" instead of rejecting it.

--- a/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionsCachePluggable.spec.ts
@@ -1,12 +1,10 @@
 import { ImpressionsCachePluggable } from '../ImpressionsCachePluggable';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMock } from './wrapper.mock';
-import { IMetadata } from '../../../dtos/types';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
 const prefix = 'impr_cache_ut';
 const impressionsKey = `${prefix}.impressions`;
-
-const fakeMetadata: IMetadata = { s: 'js_someversion', i: 'some_ip', n: 'some_hostname' };
 
 const o1 = {
   feature: 'test1',
@@ -18,7 +16,7 @@ const o1 = {
 };
 
 const o1stored = {
-  m: fakeMetadata,
+  m: metadata,
   i: { k: o1.keyName, f: o1.feature, t: o1.treatment, r: o1.label, c: o1.changeNumber, m: o1.time }
 };
 
@@ -33,7 +31,7 @@ const o2 = {
 };
 
 const o2stored = {
-  m: fakeMetadata,
+  m: metadata,
   i: { k: o2.keyName, b: o2.bucketingKey, f: o2.feature, t: o2.treatment, r: o2.label, c: o2.changeNumber, m: o2.time }
 };
 
@@ -47,11 +45,11 @@ const o3 = {
 };
 
 const o3stored = {
-  m: fakeMetadata,
+  m: metadata,
   i: { k: o3.keyName, f: o3.feature, t: o3.treatment, r: o3.label, c: o3.changeNumber, m: o3.time }
 };
 
-export { fakeMetadata, o1, o2, o3, o1stored, o2stored, o3stored };
+export { metadata, o1, o2, o3, o1stored, o2stored, o3stored };
 
 describe('PLUGGABLE IMPRESSIONS CACHE', () => {
 
@@ -61,7 +59,7 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
   });
 
   test('`track`, `count`, `popNWithMetadata` and `drop` methods', async () => {
-    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, fakeMetadata);
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, metadata);
 
     // Testing track and count methods.
     await cache.track([o1]);
@@ -93,7 +91,7 @@ describe('PLUGGABLE IMPRESSIONS CACHE', () => {
   test('`track` method rejects if wrapper operation fails', (done) => {
     // make wrapper operation fail
     wrapperMock.pushItems.mockImplementation(() => Promise.reject());
-    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, fakeMetadata);
+    const cache = new ImpressionsCachePluggable(loggerMock, impressionsKey, wrapperMock, metadata);
 
     cache.track([o1]).catch(done); // result should rejects
   });

--- a/src/storages/pluggable/__tests__/SegmentsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/SegmentsCachePluggable.spec.ts
@@ -2,9 +2,9 @@ import { SegmentsCachePluggable } from '../SegmentsCachePluggable';
 import { KeyBuilderSS } from '../../KeyBuilderSS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { wrapperMock } from './wrapper.mock';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
-// @ts-ignore. Doesn't require metadata
-const keyBuilder = new KeyBuilderSS();
+const keyBuilder = new KeyBuilderSS('prefix', metadata);
 
 describe('SEGMENTS CACHE PLUGGABLE', () => {
 

--- a/src/storages/pluggable/__tests__/TelemetryCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/TelemetryCachePluggable.spec.ts
@@ -7,24 +7,35 @@ import { fakeMetadata } from './ImpressionsCachePluggable.spec';
 const prefix = 'telemetry_cache_ut';
 const exceptionKey = `${prefix}.telemetry.exceptions`;
 const latencyKey = `${prefix}.telemetry.latencies`;
+const initKey = `${prefix}.telemetry.init`;
 const fieldVersionablePrefix = `${fakeMetadata.s}/${fakeMetadata.n}/${fakeMetadata.i}`;
 
-test('TELEMETRY CACHE PLUGGABLE / `recordLatency` and `recordException`', async () => {
+test('TELEMETRY CACHE PLUGGABLE', async () => {
 
   const keysBuilder = new KeyBuilderSS(prefix, fakeMetadata);
   const wrapper = wrapperMockFactory();
   const cache = new TelemetryCachePluggable(loggerMock, keysBuilder, wrapper);
 
+  // recordException
   expect(await cache.recordException('tr')).toBe(1);
   expect(await cache.recordException('tr')).toBe(2);
 
   expect(await wrapper.get(exceptionKey + '::' + fieldVersionablePrefix + '/track')).toBe('2');
   expect(await wrapper.get(exceptionKey + '::' + fieldVersionablePrefix + '/treatment')).toBe(null);
 
+  // recordLatency
   expect(await cache.recordLatency('tr', 1.6)).toBe(1);
   expect(await cache.recordLatency('tr', 1.6)).toBe(2);
 
   expect(await wrapper.get(latencyKey + '::' + fieldVersionablePrefix + '/track/2')).toBe('2');
-  expect(await wrapper.get(latencyKey+ '::' + fieldVersionablePrefix + '/treatment/2')).toBe(null);
+  expect(await wrapper.get(latencyKey + '::' + fieldVersionablePrefix + '/treatment/2')).toBe(null);
 
+  // recordConfig
+  await cache.recordConfig();
+  expect(JSON.parse(await wrapper.get(initKey + '::' + fieldVersionablePrefix) as string)).toEqual({
+    oM: 1,
+    st: 'pluggable',
+    aF: 0,
+    rF: 0
+  });
 });

--- a/src/storages/pluggable/__tests__/TelemetryCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/TelemetryCachePluggable.spec.ts
@@ -2,17 +2,17 @@ import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { KeyBuilderSS } from '../../KeyBuilderSS';
 import { wrapperMockFactory } from './wrapper.mock';
 import { TelemetryCachePluggable } from '../TelemetryCachePluggable';
-import { fakeMetadata } from './ImpressionsCachePluggable.spec';
+import { metadata } from '../../__tests__/KeyBuilder.spec';
 
 const prefix = 'telemetry_cache_ut';
 const exceptionKey = `${prefix}.telemetry.exceptions`;
 const latencyKey = `${prefix}.telemetry.latencies`;
 const initKey = `${prefix}.telemetry.init`;
-const fieldVersionablePrefix = `${fakeMetadata.s}/${fakeMetadata.n}/${fakeMetadata.i}`;
+const fieldVersionablePrefix = `${metadata.s}/${metadata.n}/${metadata.i}`;
 
 test('TELEMETRY CACHE PLUGGABLE', async () => {
 
-  const keysBuilder = new KeyBuilderSS(prefix, fakeMetadata);
+  const keysBuilder = new KeyBuilderSS(prefix, metadata);
   const wrapper = wrapperMockFactory();
   const cache = new TelemetryCachePluggable(loggerMock, keysBuilder, wrapper);
 
@@ -38,4 +38,35 @@ test('TELEMETRY CACHE PLUGGABLE', async () => {
     aF: 0,
     rF: 0
   });
+
+  // popLatencies
+  const latencies = await cache.popLatencies();
+  latencies.forEach((latency, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(latency.tr[2]).toBe(2);
+  });
+
+  // popExceptions
+  const exceptions = await cache.popExceptions();
+  exceptions.forEach((exception, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(exception.tr).toBe(2);
+  });
+
+  // popConfigs
+  const configs = await cache.popConfigs();
+  configs.forEach((config, m) => {
+    expect(JSON.parse(m)).toEqual(metadata);
+    expect(config).toEqual({
+      oM: 1,
+      st: 'pluggable',
+      aF: 0,
+      rF: 0
+    });
+  });
+
+  // pops when there is no data
+  expect(await cache.popLatencies()).toEqual(new Map());
+  expect(await cache.popExceptions()).toEqual(new Map());
+  expect(await cache.popConfigs()).toEqual(new Map());
 });

--- a/src/storages/pluggable/__tests__/index.spec.ts
+++ b/src/storages/pluggable/__tests__/index.spec.ts
@@ -37,7 +37,7 @@ describe('PLUGGABLE STORAGE', () => {
     const sharedStorage = storage.shared('some_key', sharedOnReadyCb);
     assertStorageInterface(sharedStorage);
     expect(sharedStorage.splits).toBe(storage.splits);
-    expect(wrapperMock.connect).toBeCalledTimes(2);
+    expect(wrapperMock.connect).toBeCalledTimes(1); // wrapper connect method should be called once
 
     expect(await storage.splits.getSplit('some_split')).toBe(null);
     expect(await sharedStorage.splits.getSplit('some_split')).toBe(null);

--- a/src/storages/pluggable/index.ts
+++ b/src/storages/pluggable/index.ts
@@ -1,4 +1,4 @@
-import { IPluggableStorageWrapper, IStorageAsync, IStorageAsyncFactory, IStorageFactoryParams } from '../types';
+import { IPluggableStorageWrapper, IStorageAsync, IStorageAsyncFactory, IStorageFactoryParams, ITelemetryCacheAsync } from '../types';
 
 import { KeyBuilderSS } from '../KeyBuilderSS';
 import { SplitsCachePluggable } from './SplitsCachePluggable';
@@ -68,8 +68,8 @@ export function PluggableStorage(options: PluggableStorageOptions): IStorageAsyn
     // Connects to wrapper and emits SDK_READY event on main client
     const connectPromise = wrapper.connect().then(() => {
       onReadyCb();
-      // @ts-ignore
-      if (telemetry && telemetry.recordConfig) telemetry.recordConfig();
+      // If mode is not defined, it means that the synchronizer is running and so we don't have to record telemetry
+      if (telemetry && (telemetry as ITelemetryCacheAsync).recordConfig && mode) (telemetry as ITelemetryCacheAsync).recordConfig();
     }).catch((e) => {
       e = e || new Error('Error connecting wrapper');
       onReadyCb(e);

--- a/src/storages/pluggable/index.ts
+++ b/src/storages/pluggable/index.ts
@@ -56,11 +56,12 @@ export function PluggableStorage(options: PluggableStorageOptions): IStorageAsyn
 
   const prefix = validatePrefix(options.prefix);
 
-  function PluggableStorageFactory({ log, metadata, onReadyCb, mode, eventsQueueSize, impressionsQueueSize, optimize, matchingKey }: IStorageFactoryParams): IStorageAsync {
+  function PluggableStorageFactory(params: IStorageFactoryParams): IStorageAsync {
+    const { log, metadata, onReadyCb, mode, eventsQueueSize, impressionsQueueSize, optimize } = params;
     const keys = new KeyBuilderSS(prefix, metadata);
     const wrapper = wrapperAdapter(log, options.wrapper);
     const isPartialConsumer = mode === CONSUMER_PARTIAL_MODE;
-    const telemetry = !matchingKey || shouldRecordTelemetry() ?
+    const telemetry = shouldRecordTelemetry(params) ?
       isPartialConsumer ? new TelemetryCacheInMemory() : new TelemetryCachePluggable(log, keys, wrapper) :
       undefined;
 

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -470,7 +470,7 @@ export interface IStorageAsync extends IStorageBase<
   ISegmentsCacheAsync,
   IImpressionsCacheAsync | IImpressionsCacheSync,
   IEventsCacheAsync | IEventsCacheSync,
-  ITelemetryCacheAsync
+  ITelemetryCacheAsync | ITelemetryCacheSync
   > { }
 
 /** StorageFactory */

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -1,6 +1,6 @@
 import { MaybeThenable, IMetadata, ISplitFiltersValidation, ISplit } from '../dtos/types';
 import { ILogger } from '../logger/types';
-import { EventDataType, HttpErrors, HttpLatencies, ImpressionDataType, LastSync, Method, MethodExceptions, MethodLatencies, OperationType, StoredEventWithMetadata, StoredImpressionWithMetadata, StreamingEvent } from '../sync/submitters/types';
+import { EventDataType, HttpErrors, HttpLatencies, ImpressionDataType, LastSync, Method, MethodExceptions, MethodLatencies, MultiMethodExceptions, MultiMethodLatencies, MultiConfigs, OperationType, StoredEventWithMetadata, StoredImpressionWithMetadata, StreamingEvent } from '../sync/submitters/types';
 import { SplitIO, ImpressionDTO, SDKMode } from '../types';
 
 /**
@@ -423,18 +423,19 @@ export interface ITelemetryCacheSync extends ITelemetryStorageConsumerSync, ITel
  */
 
 export interface ITelemetryEvaluationConsumerAsync {
-  popExceptions(): Promise<MethodExceptions>;
-  popLatencies(): Promise<MethodLatencies>;
+  popLatencies(): Promise<MultiMethodLatencies>;
+  popExceptions(): Promise<MultiMethodExceptions>;
+  popConfigs(): Promise<MultiConfigs>;
 }
 
 export interface ITelemetryEvaluationProducerAsync {
   recordLatency(method: Method, latencyMs: number): Promise<any>;
   recordException(method: Method): Promise<any>;
+  recordConfig(): Promise<any>;
 }
 
 // ATM it only implements the producer API, used by the SDK in consumer mode.
-// @TODO implement consumer API for JS Synchronizer.
-export interface ITelemetryCacheAsync extends ITelemetryEvaluationProducerAsync { }
+export interface ITelemetryCacheAsync extends ITelemetryEvaluationProducerAsync, ITelemetryEvaluationConsumerAsync { }
 
 /**
  * Storages

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -9,11 +9,12 @@ import { usedKeysMap } from '../../utils/inputValidation/apiKey';
 import { timer } from '../../utils/timeTracker/timer';
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 import { objectAssign } from '../../utils/lang/objectAssign';
+import { isStorageSync } from '../../trackers/impressionObserver/utils';
 
 /**
  * Converts data from telemetry cache into /metrics/usage request payload.
  */
-export function telemetryCacheStatsAdapter(telemetry: ITelemetryCacheSync, splits: ISplitsCacheSync, segments: ISegmentsCacheSync) {
+export function telemetryCacheStatsAdapter(telemetry: ITelemetryCacheSync, splits?: ISplitsCacheSync, segments?: ISegmentsCacheSync) {
   return {
     isEmpty() { return false; }, // There is always data in telemetry cache
     clear() { }, //  No-op
@@ -31,9 +32,9 @@ export function telemetryCacheStatsAdapter(telemetry: ITelemetryCacheSync, split
         iQ: telemetry.getImpressionStats(QUEUED),
         iDe: telemetry.getImpressionStats(DEDUPED),
         iDr: telemetry.getImpressionStats(DROPPED),
-        spC: splits.getSplitNames().length,
-        seC: segments.getRegisteredSegments().length,
-        skC: segments.getKeysCount(),
+        spC: splits && splits.getSplitNames().length,
+        seC: segments && segments.getRegisteredSegments().length,
+        skC: segments && segments.getKeysCount(),
         sL: telemetry.getSessionLength(),
         eQ: telemetry.getEventStats(QUEUED),
         eD: telemetry.getEventStats(DROPPED),
@@ -136,7 +137,12 @@ export function telemetrySubmitterFactory(params: ISdkFactoryContextSync) {
   const startTime = timer(now);
 
   const submitter = firstPushWindowDecorator(
-    submitterFactory(log, splitApi.postMetricsUsage, telemetryCacheStatsAdapter(telemetry, splits, segments), telemetryRefreshRate, 'telemetry stats', undefined, 0, true),
+    submitterFactory(
+      log, splitApi.postMetricsUsage,
+      // @TODO cannot provide splits and segments cache if they are async, because `submitterFactory` expects a sync storage source
+      isStorageSync(params.settings) ? telemetryCacheStatsAdapter(telemetry, splits, segments) : telemetryCacheStatsAdapter(telemetry),
+      telemetryRefreshRate, 'telemetry stats', undefined, 0, true
+    ),
     telemetryRefreshRate
   );
 

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -127,9 +127,9 @@ export type TelemetryUsageStatsPayload = {
   iQ: number, // impressionsQueued
   iDe: number, // impressionsDeduped
   iDr: number, // impressionsDropped
-  spC: number, // splitCount
-  seC: number, // segmentCount
-  skC: number, // segmentKeyCount
+  spC?: number, // splitCount
+  seC?: number, // segmentCount
+  skC?: number, // segmentKeyCount
   sL?: number, // sessionLengthMs
   eQ: number, // eventsQueued
   eD: number, // eventsDropped

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -1,5 +1,7 @@
+/* eslint-disable no-use-before-define */
 import { IMetadata } from '../../dtos/types';
 import { SplitIO } from '../../types';
+import { IMap } from '../../utils/lang/maps';
 import { ISyncTask } from '../types';
 
 export type ImpressionsPayload = {
@@ -64,6 +66,12 @@ export type StoredEventWithMetadata = {
   e: SplitIO.EventData
 }
 
+export type MultiMethodLatencies = IMap<string, MethodLatencies>
+
+export type MultiMethodExceptions = IMap<string, MethodExceptions>
+
+export type MultiConfigs = IMap<string, TelemetryConfigStats>
+
 /**
  * Telemetry usage stats
  */
@@ -115,11 +123,15 @@ export type StreamingEvent = {
   t: number, // timestamp
 }
 
+// 'telemetry.latencias' and 'telemetry.exceptions' Redis/Pluggable keys
+export type TelemetryUsageStats = {
+  mL?: MethodLatencies, // clientMethodLatencies
+  mE?: MethodExceptions, // methodExceptions
+}
+
 // 'metrics/usage' JSON request body
-export type TelemetryUsageStatsPayload = {
+export type TelemetryUsageStatsPayload = TelemetryUsageStats & {
   lS: LastSync, // lastSynchronization
-  mL: MethodLatencies, // clientMethodLatencies
-  mE: MethodExceptions, // methodExceptions
   hE: HttpErrors, // httpErrors
   hL: HttpLatencies, // httpLatencies
   tR: number, // tokenRefreshes

--- a/src/trackers/__tests__/telemetryTracker.spec.ts
+++ b/src/trackers/__tests__/telemetryTracker.spec.ts
@@ -15,7 +15,7 @@ describe('Telemetry Tracker', () => {
     recordSessionLength: jest.fn(),
     recordStreamingEvents: jest.fn(),
   };
-
+  // @ts-ignore
   const tracker = telemetryTrackerFactory(fakeTelemetryCache, fakeNow);
   const startTimestamp = Date.now();
 

--- a/src/utils/lang/maps.ts
+++ b/src/utils/lang/maps.ts
@@ -24,10 +24,12 @@ THE SOFTWARE.
 **/
 
 export interface IMap<K, V> {
-  set(key: K, value: V): this;
   clear(): void;
   delete(key: K): boolean;
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
   get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): this;
   readonly size: number;
 }
 
@@ -46,13 +48,6 @@ export class MapPoly<K, V> implements IMap<K, V>{
     this.__mapValuesData__.length = 0;
   }
 
-  set(key: K, value: V) {
-    let index = this.__mapKeysData__.indexOf(key);
-    if (index === -1) index = this.__mapKeysData__.push(key) - 1;
-    this.__mapValuesData__[index] = value;
-    return this;
-  }
-
   delete(key: K) {
     const index = this.__mapKeysData__.indexOf(key);
     if (index === -1) return false;
@@ -61,10 +56,27 @@ export class MapPoly<K, V> implements IMap<K, V>{
     return true;
   }
 
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any) {
+    for (let i = 0; i < this.__mapKeysData__.length; i++) {
+      callbackfn.call(thisArg, this.__mapValuesData__[i], this.__mapKeysData__[i], this as any);
+    }
+  }
+
   get(key: K) {
     const index = this.__mapKeysData__.indexOf(key);
     if (index === -1) return;
     return this.__mapValuesData__[index];
+  }
+
+  has(key: K): boolean {
+    return this.__mapKeysData__.indexOf(key) !== -1;
+  }
+
+  set(key: K, value: V) {
+    let index = this.__mapKeysData__.indexOf(key);
+    if (index === -1) index = this.__mapKeysData__.push(key) - 1;
+    this.__mapValuesData__[index] = value;
+    return this;
   }
 
   get size() {


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Add `recordConfig` method in TelemetryCachePluggable, to track telemetry init stats.
- Add TelemetryCache in PluggableStorage. It can be `TelemetryCacheInMemory` for partial consumer mode, or `TelemetryCachePluggable` for consumer mode.
- Updated internal logic of PluggableStorage to call the `connect` method of the pluggable storage wrapper only once if shared clients are used.
- Refactor on storages to reuse `shouldRecordTelemetry` logic.
- Update `telemetrySubmitter` to support partial consumer mode, where splits and segments cache are async.

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes