### PR TITLE
Add consumer methods of ImpressionCounts and UniqueKeys caches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.10",
+  "version": "1.6.2-rc.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.11",
+  "version": "1.6.2-rc.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.11",
+  "version": "1.6.2-rc.12",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.6.2-rc.10",
+  "version": "1.6.2-rc.11",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/storages/inMemory/UniqueKeysCacheInMemory.ts
+++ b/src/storages/inMemory/UniqueKeysCacheInMemory.ts
@@ -3,12 +3,31 @@ import { ISet, setToArray, _Set } from '../../utils/lang/sets';
 import { UniqueKeysPayloadSs } from '../../sync/submitters/types';
 import { DEFAULT_CACHE_SIZE } from '../inRedis/constants';
 
+/**
+ * Converts `uniqueKeys` data from cache into request payload for SS.
+ */
+export function fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadSs {
+  const payload = [];
+  const featureNames = Object.keys(uniqueKeys);
+  for (let i = 0; i < featureNames.length; i++) {
+    const featureName = featureNames[i];
+    const userKeys = setToArray(uniqueKeys[featureName]);
+    const uniqueKeysPayload = {
+      f: featureName,
+      ks: userKeys
+    };
+
+    payload.push(uniqueKeysPayload);
+  }
+  return { keys: payload };
+}
+
 export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
 
   protected onFullQueue?: () => void;
   private readonly maxStorage: number;
   private uniqueTrackerSize = 0;
-  protected uniqueKeysTracker: { [keys: string]: ISet<string> };
+  protected uniqueKeysTracker: { [featureName: string]: ISet<string> };
 
   constructor(uniqueKeysQueueSize = DEFAULT_CACHE_SIZE) {
     this.maxStorage = uniqueKeysQueueSize;
@@ -20,15 +39,13 @@ export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
   }
 
   /**
-   * Store unique keys in sequential order
-   * key: string = feature name.
-   * value: Set<string> = set of unique keys.
+   * Store unique keys per feature.
    */
-  track(key: string, featureName: string) {
+  track(userKey: string, featureName: string) {
     if (!this.uniqueKeysTracker[featureName]) this.uniqueKeysTracker[featureName] = new _Set();
     const tracker = this.uniqueKeysTracker[featureName];
-    if (!tracker.has(key)) {
-      tracker.add(key);
+    if (!tracker.has(userKey)) {
+      tracker.add(userKey);
       this.uniqueTrackerSize++;
     }
     if (this.uniqueTrackerSize >= this.maxStorage && this.onFullQueue) {
@@ -50,7 +67,7 @@ export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
   pop() {
     const data = this.uniqueKeysTracker;
     this.uniqueKeysTracker = {};
-    return this.fromUniqueKeysCollector(data);
+    return fromUniqueKeysCollector(data);
   }
 
   /**
@@ -58,25 +75,6 @@ export class UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
    */
   isEmpty() {
     return Object.keys(this.uniqueKeysTracker).length === 0;
-  }
-
-  /**
-   * Converts `uniqueKeys` data from cache into request payload for SS.
-   */
-  private fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadSs {
-    const payload = [];
-    const featureNames = Object.keys(uniqueKeys);
-    for (let i = 0; i < featureNames.length; i++) {
-      const featureName = featureNames[i];
-      const featureKeys = setToArray(uniqueKeys[featureName]);
-      const uniqueKeysPayload = {
-        f: featureName,
-        ks: featureKeys
-      };
-
-      payload.push(uniqueKeysPayload);
-    }
-    return { keys: payload };
   }
 
 }

--- a/src/storages/inMemory/UniqueKeysCacheInMemoryCS.ts
+++ b/src/storages/inMemory/UniqueKeysCacheInMemoryCS.ts
@@ -8,7 +8,7 @@ export class UniqueKeysCacheInMemoryCS implements IUniqueKeysCacheBase {
   private onFullQueue?: () => void;
   private readonly maxStorage: number;
   private uniqueTrackerSize = 0;
-  private uniqueKeysTracker: { [keys: string]: ISet<string> };
+  private uniqueKeysTracker: { [userKey: string]: ISet<string> };
 
   /**
    *
@@ -25,14 +25,12 @@ export class UniqueKeysCacheInMemoryCS implements IUniqueKeysCacheBase {
   }
 
   /**
-   * Store unique keys in sequential order
-   * key: string = key.
-   * value: HashSet<string> = set of split names.
+   * Store unique keys per feature.
    */
-  track(key: string, featureName: string) {
+  track(userKey: string, featureName: string) {
 
-    if (!this.uniqueKeysTracker[key]) this.uniqueKeysTracker[key] = new _Set();
-    const tracker = this.uniqueKeysTracker[key];
+    if (!this.uniqueKeysTracker[userKey]) this.uniqueKeysTracker[userKey] = new _Set();
+    const tracker = this.uniqueKeysTracker[userKey];
     if (!tracker.has(featureName)) {
       tracker.add(featureName);
       this.uniqueTrackerSize++;
@@ -69,14 +67,14 @@ export class UniqueKeysCacheInMemoryCS implements IUniqueKeysCacheBase {
   /**
    * Converts `uniqueKeys` data from cache into request payload.
    */
-  private fromUniqueKeysCollector(uniqueKeys: { [featureName: string]: ISet<string> }): UniqueKeysPayloadCs {
+  private fromUniqueKeysCollector(uniqueKeys: { [userKey: string]: ISet<string> }): UniqueKeysPayloadCs {
     const payload = [];
-    const featureKeys = Object.keys(uniqueKeys);
-    for (let k = 0; k < featureKeys.length; k++) {
-      const featureKey = featureKeys[k];
-      const featureNames = setToArray(uniqueKeys[featureKey]);
+    const userKeys = Object.keys(uniqueKeys);
+    for (let k = 0; k < userKeys.length; k++) {
+      const userKey = userKeys[k];
+      const featureNames = setToArray(uniqueKeys[userKey]);
       const uniqueKeysPayload = {
-        k: featureKey,
+        k: userKey,
         fs: featureNames
       };
 

--- a/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
+++ b/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
@@ -1,5 +1,7 @@
 import { Redis } from 'ioredis';
 import { ILogger } from '../../logger/types';
+import { ImpressionCountsPayload } from '../../sync/submitters/types';
+import { forOwn } from '../../utils/lang';
 import { ImpressionCountsCacheInMemory } from '../inMemory/ImpressionCountsCacheInMemory';
 import { LOG_PREFIX, REFRESH_RATE, TTL_REFRESH } from './constants';
 
@@ -20,7 +22,7 @@ export class ImpressionCountsCacheInRedis extends ImpressionCountsCacheInMemory 
     this.onFullQueue = () => { this.postImpressionCountsInRedis(); };
   }
 
-  private postImpressionCountsInRedis(){
+  private postImpressionCountsInRedis() {
     const counts = this.pop();
     const keys = Object.keys(counts);
     if (!keys.length) return Promise.resolve(false);
@@ -49,5 +51,45 @@ export class ImpressionCountsCacheInRedis extends ImpressionCountsCacheInMemory 
   stop() {
     clearInterval(this.intervalId);
     return this.postImpressionCountsInRedis();
+  }
+
+  // Async consumer API, used by synchronizer
+  getImpressionsCount(): Promise<ImpressionCountsPayload | undefined> {
+    return this.redis.hgetall(this.key)
+      .then(counts => {
+        if (!Object.keys(counts).length) return undefined;
+
+        this.redis.del(this.key);
+
+        const impressionsCount: ImpressionCountsPayload = { pf: [] };
+
+        forOwn(counts, (count, key) => {
+          const nameAndTime = key.split('::');
+          if (nameAndTime.length !== 2) {
+            this.log.error(`${LOG_PREFIX}Error spliting key ${key}`);
+            return;
+          }
+
+          const timeFrame = parseInt(nameAndTime[1]);
+          if (isNaN(timeFrame)) {
+            this.log.error(`${LOG_PREFIX}Error parsing time frame ${nameAndTime[1]}`);
+            return;
+          }
+
+          const rawCount = parseInt(count);
+          if (isNaN(rawCount)) {
+            this.log.error(`${LOG_PREFIX}Error parsing raw count ${count}`);
+            return;
+          }
+
+          impressionsCount.pf.push({
+            f: nameAndTime[0],
+            m: timeFrame,
+            rc: rawCount,
+          });
+        });
+
+        return impressionsCount;
+      });
   }
 }

--- a/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
+++ b/src/storages/inRedis/ImpressionCountsCacheInRedis.ts
@@ -59,7 +59,7 @@ export class ImpressionCountsCacheInRedis extends ImpressionCountsCacheInMemory 
       .then(counts => {
         if (!Object.keys(counts).length) return undefined;
 
-        this.redis.del(this.key);
+        this.redis.del(this.key).catch(() => { /* no-op */ });
 
         const impressionsCount: ImpressionCountsPayload = { pf: [] };
 

--- a/src/storages/inRedis/UniqueKeysCacheInRedis.ts
+++ b/src/storages/inRedis/UniqueKeysCacheInRedis.ts
@@ -62,9 +62,11 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
     return this.postUniqueKeysInRedis();
   }
 
-
-  // Async consumer API, used by synchronizer
-  popNRaw(count: number): Promise<string[]> {
+  /**
+   * Async consumer API, used by synchronizer.
+   * @param count number of items to pop from the queue. If not provided or equal 0, all items will be popped.
+   */
+  popNRaw(count = 0): Promise<string[]> {
     return this.redis.lrange(this.key, 0, count - 1).then(items => {
       return this.redis.ltrim(this.key, items.length, -1).then(() => items);
     });

--- a/src/storages/inRedis/UniqueKeysCacheInRedis.ts
+++ b/src/storages/inRedis/UniqueKeysCacheInRedis.ts
@@ -5,6 +5,7 @@ import { setToArray } from '../../utils/lang/sets';
 import { DEFAULT_CACHE_SIZE, REFRESH_RATE, TTL_REFRESH } from './constants';
 import { LOG_PREFIX } from './constants';
 import { ILogger } from '../../logger/types';
+import { UniqueKeysItemSs } from '../../sync/submitters/types';
 
 export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
 
@@ -66,9 +67,10 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
    * Async consumer API, used by synchronizer.
    * @param count number of items to pop from the queue. If not provided or equal 0, all items will be popped.
    */
-  popNRaw(count = 0): Promise<string[]> {
-    return this.redis.lrange(this.key, 0, count - 1).then(items => {
-      return this.redis.ltrim(this.key, items.length, -1).then(() => items);
+  popNRaw(count = 0): Promise<UniqueKeysItemSs[]> {
+    return this.redis.lrange(this.key, 0, count - 1).then(uniqueKeyItems => {
+      return this.redis.ltrim(this.key, uniqueKeyItems.length, -1)
+        .then(() => uniqueKeyItems.map(uniqueKeyItem => JSON.parse(uniqueKeyItem)));
     });
   }
 

--- a/src/storages/inRedis/UniqueKeysCacheInRedis.ts
+++ b/src/storages/inRedis/UniqueKeysCacheInRedis.ts
@@ -20,7 +20,7 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
     this.key = key;
     this.redis = redis;
     this.refreshRate = refreshRate;
-    this.onFullQueue = () => {this.postUniqueKeysInRedis();};
+    this.onFullQueue = () => { this.postUniqueKeysInRedis(); };
   }
 
   private postUniqueKeysInRedis() {
@@ -60,6 +60,14 @@ export class UniqueKeysCacheInRedis extends UniqueKeysCacheInMemory implements I
   stop() {
     clearInterval(this.intervalId);
     return this.postUniqueKeysInRedis();
+  }
+
+
+  // Async consumer API, used by synchronizer
+  popNRaw(count: number): Promise<string[]> {
+    return this.redis.lrange(this.key, 0, count - 1).then(items => {
+      return this.redis.ltrim(this.key, items.length, -1).then(() => items);
+    });
   }
 
 }

--- a/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/SplitsCacheInRedis.spec.ts
@@ -24,7 +24,7 @@ describe('SPLITS CACHE REDIS', () => {
 
     let values = await cache.getAll();
 
-    expect(values).toEqual([splitWithAccountTT, splitWithUserTT]);
+    expect(values).toEqual([splitWithUserTT, splitWithAccountTT]);
 
     let splitNames = await cache.getSplitNames();
 

--- a/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
@@ -169,7 +169,7 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
     // Validate `popNRaw` method
     let poped = await cache.popNRaw(2); // pop two items
     expect(poped).toEqual([JSON.stringify({ 'f': 'feature1', 'ks': ['key1'] }), JSON.stringify({ 'f': 'feature2', 'ks': ['key1'] })]);
-    poped = await cache.popNRaw(100); // pop remaining items
+    poped = await cache.popNRaw(); // pop remaining items
     expect(poped).toEqual([JSON.stringify({ 'f': 'feature3', 'ks': ['key2'] }), JSON.stringify({ 'f': 'feature4', 'ks': ['key2'] }), JSON.stringify({ 'f': 'feature5', 'ks': ['key3'] }), JSON.stringify({ 'f': 'feature6', 'ks': ['key2'] })]);
     poped = await cache.popNRaw(100); // try to pop more items when the queue is empty
     expect(poped).toEqual([]);

--- a/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
@@ -168,9 +168,9 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
 
     // Validate `popNRaw` method
     let poped = await cache.popNRaw(2); // pop two items
-    expect(poped).toEqual([JSON.stringify({ 'f': 'feature1', 'ks': ['key1'] }), JSON.stringify({ 'f': 'feature2', 'ks': ['key1'] })]);
+    expect(poped).toEqual([{ f: 'feature1', ks: ['key1'] }, { f: 'feature2', ks: ['key1'] }]);
     poped = await cache.popNRaw(); // pop remaining items
-    expect(poped).toEqual([JSON.stringify({ 'f': 'feature3', 'ks': ['key2'] }), JSON.stringify({ 'f': 'feature4', 'ks': ['key2'] }), JSON.stringify({ 'f': 'feature5', 'ks': ['key3'] }), JSON.stringify({ 'f': 'feature6', 'ks': ['key2'] })]);
+    expect(poped).toEqual([{ f: 'feature3', ks: ['key2'] }, { f: 'feature4', ks: ['key2'] }, { f: 'feature5', ks: ['key3'] }, { f: 'feature6', ks: ['key2'] }]);
     poped = await cache.popNRaw(100); // try to pop more items when the queue is empty
     expect(poped).toEqual([]);
 

--- a/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
+++ b/src/storages/inRedis/__tests__/UniqueKeysCacheInRedis.spec.ts
@@ -6,10 +6,10 @@ import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 import { RedisMock } from '../../../utils/redis/RedisMock';
 
 describe('UNIQUE KEYS CACHE IN REDIS', () => {
+  const key = 'unique_key_post';
 
   test('should incrementally store values, clear the queue, and tell if it is empty', async () => {
     const connection = new Redis();
-    const key = 'unique_key_post';
 
     const cache = new UniqueKeysCacheInRedis(loggerMock, key, connection);
 
@@ -52,7 +52,6 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
   test('Should call "onFullQueueCb" when the queue is full.', async () => {
     let cbCalled = 0;
     const connection = new Redis();
-    const key = 'unique_key_post';
 
     const cache = new UniqueKeysCacheInRedis(loggerMock, key, connection, 3); // small uniqueKeysCache size to be reached
     cache.setOnFullQueueCb(() => { cbCalled++; cache.clear(); });
@@ -81,9 +80,6 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
 
   test('post unique keys in redis method', async () => {
     const connection = new Redis();
-    const key = 'unique_key_post';
-    // Clean up in case there are still keys there.
-    await connection.del(key);
 
     const cache = new UniqueKeysCacheInRedis(loggerMock, key, connection, 20);
     cache.track('key1', 'feature1');
@@ -105,8 +101,6 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
       await connection.del(key);
       await connection.quit();
     });
-
-
   });
 
   test('start and stop task', (done) => {
@@ -146,10 +140,6 @@ describe('UNIQUE KEYS CACHE IN REDIS', () => {
 
   test('Should call "onFullQueueCb" when the queue is full. "popNRaw" should pop items.', async () => {
     const connection = new Redis();
-    const key = 'unique_key_post';
-
-    // Clean up in case there are still keys there.
-    await connection.del(key);
 
     const cache = new UniqueKeysCacheInRedis(loggerMock, key, connection, 3);
 

--- a/src/storages/inRedis/index.ts
+++ b/src/storages/inRedis/index.ts
@@ -52,7 +52,7 @@ export function InRedisStorage(options: InRedisStorageOptions = {}): IStorageAsy
 
       // When using REDIS we should:
       // 1- Disconnect from the storage
-      destroy(): Promise<void>{
+      destroy(): Promise<void> {
         let promises = [];
         if (impressionCountsCache) promises.push(impressionCountsCache.stop());
         if (uniqueKeysCache) promises.push(uniqueKeysCache.stop());

--- a/src/storages/pluggable/ImpressionCountsCachePluggable.ts
+++ b/src/storages/pluggable/ImpressionCountsCachePluggable.ts
@@ -52,7 +52,7 @@ export class ImpressionCountsCachePluggable extends ImpressionCountsCacheInMemor
       .then(keys => {
         return keys.length ? Promise.all(keys.map(key => this.wrapper.get(key)))
           .then(counts => {
-            keys.forEach(key => this.wrapper.del(key));
+            keys.forEach(key => this.wrapper.del(key).catch(() => { /* noop */ }));
 
             const impressionsCount: ImpressionCountsPayload = { pf: [] };
 
@@ -60,15 +60,15 @@ export class ImpressionCountsCachePluggable extends ImpressionCountsCacheInMemor
               const key = keys[i];
               const count = counts[i];
 
-              const nameAndTime = key.split('::');
-              if (nameAndTime.length !== 2) {
+              const keyFeatureNameAndTime = key.split('::');
+              if (keyFeatureNameAndTime.length !== 3) {
                 this.log.error(`${LOG_PREFIX}Error spliting key ${key}`);
                 continue;
               }
 
-              const timeFrame = parseInt(nameAndTime[1]);
+              const timeFrame = parseInt(keyFeatureNameAndTime[2]);
               if (isNaN(timeFrame)) {
-                this.log.error(`${LOG_PREFIX}Error parsing time frame ${nameAndTime[1]}`);
+                this.log.error(`${LOG_PREFIX}Error parsing time frame ${keyFeatureNameAndTime[2]}`);
                 continue;
               }
               // @ts-ignore
@@ -79,7 +79,7 @@ export class ImpressionCountsCachePluggable extends ImpressionCountsCacheInMemor
               }
 
               impressionsCount.pf.push({
-                f: nameAndTime[0],
+                f: keyFeatureNameAndTime[1],
                 m: timeFrame,
                 rc: rawCount,
               });

--- a/src/storages/pluggable/ImpressionCountsCachePluggable.ts
+++ b/src/storages/pluggable/ImpressionCountsCachePluggable.ts
@@ -1,4 +1,5 @@
 import { ILogger } from '../../logger/types';
+import { ImpressionCountsPayload } from '../../sync/submitters/types';
 import { ImpressionCountsCacheInMemory } from '../inMemory/ImpressionCountsCacheInMemory';
 import { REFRESH_RATE } from '../inRedis/constants';
 import { IPluggableStorageWrapper } from '../types';
@@ -43,5 +44,49 @@ export class ImpressionCountsCachePluggable extends ImpressionCountsCacheInMemor
   stop() {
     clearInterval(this.intervalId);
     return this.storeImpressionCounts();
+  }
+
+  // Async consumer API, used by synchronizer
+  getImpressionsCount(): Promise<ImpressionCountsPayload | undefined> {
+    return this.wrapper.getKeysByPrefix(this.key)
+      .then(keys => {
+        return keys.length ? Promise.all(keys.map(key => this.wrapper.get(key)))
+          .then(counts => {
+            keys.forEach(key => this.wrapper.del(key));
+
+            const impressionsCount: ImpressionCountsPayload = { pf: [] };
+
+            for (let i = 0; i < keys.length; i++) {
+              const key = keys[i];
+              const count = counts[i];
+
+              const nameAndTime = key.split('::');
+              if (nameAndTime.length !== 2) {
+                this.log.error(`${LOG_PREFIX}Error spliting key ${key}`);
+                continue;
+              }
+
+              const timeFrame = parseInt(nameAndTime[1]);
+              if (isNaN(timeFrame)) {
+                this.log.error(`${LOG_PREFIX}Error parsing time frame ${nameAndTime[1]}`);
+                continue;
+              }
+              // @ts-ignore
+              const rawCount = parseInt(count);
+              if (isNaN(rawCount)) {
+                this.log.error(`${LOG_PREFIX}Error parsing raw count ${count}`);
+                continue;
+              }
+
+              impressionsCount.pf.push({
+                f: nameAndTime[0],
+                m: timeFrame,
+                rc: rawCount,
+              });
+            }
+
+            return impressionsCount;
+          }) : undefined;
+      });
   }
 }

--- a/src/storages/pluggable/UniqueKeysCachePluggable.ts
+++ b/src/storages/pluggable/UniqueKeysCachePluggable.ts
@@ -53,9 +53,14 @@ export class UniqueKeysCachePluggable extends UniqueKeysCacheInMemory implements
     return this.storeUniqueKeys();
   }
 
-  // Async consumer API, used by synchronizer
-  popNRaw(count: number): Promise<string[]> {
-    return this.wrapper.popItems(this.key, count);
+  /**
+   * Async consumer API, used by synchronizer.
+   * @param count number of items to pop from the queue. If not provided or equal 0, all items will be popped.
+   */
+  popNRaw(count = 0): Promise<string[]> {
+    return count ?
+      this.wrapper.popItems(this.key, count) :
+      this.wrapper.getItemsCount(this.key).then(count => this.wrapper.popItems(this.key, count));
   }
 
 }

--- a/src/storages/pluggable/UniqueKeysCachePluggable.ts
+++ b/src/storages/pluggable/UniqueKeysCachePluggable.ts
@@ -4,6 +4,7 @@ import { setToArray } from '../../utils/lang/sets';
 import { DEFAULT_CACHE_SIZE, REFRESH_RATE } from '../inRedis/constants';
 import { LOG_PREFIX } from './constants';
 import { ILogger } from '../../logger/types';
+import { UniqueKeysItemSs } from '../../sync/submitters/types';
 
 export class UniqueKeysCachePluggable extends UniqueKeysCacheInMemory implements IUniqueKeysCacheBase {
 
@@ -57,10 +58,10 @@ export class UniqueKeysCachePluggable extends UniqueKeysCacheInMemory implements
    * Async consumer API, used by synchronizer.
    * @param count number of items to pop from the queue. If not provided or equal 0, all items will be popped.
    */
-  popNRaw(count = 0): Promise<string[]> {
-    return count ?
-      this.wrapper.popItems(this.key, count) :
-      this.wrapper.getItemsCount(this.key).then(count => this.wrapper.popItems(this.key, count));
+  popNRaw(count = 0): Promise<UniqueKeysItemSs[]> {
+    return Promise.resolve(count || this.wrapper.getItemsCount(this.key))
+      .then(count => this.wrapper.popItems(this.key, count))
+      .then((uniqueKeyItems) => uniqueKeyItems.map(uniqueKeyItem => JSON.parse(uniqueKeyItem)));
   }
 
 }

--- a/src/storages/pluggable/UniqueKeysCachePluggable.ts
+++ b/src/storages/pluggable/UniqueKeysCachePluggable.ts
@@ -53,4 +53,9 @@ export class UniqueKeysCachePluggable extends UniqueKeysCacheInMemory implements
     return this.storeUniqueKeys();
   }
 
+  // Async consumer API, used by synchronizer
+  popNRaw(count: number): Promise<string[]> {
+    return this.wrapper.popItems(this.key, count);
+  }
+
 }

--- a/src/storages/pluggable/__tests__/ImpressionCountsCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/ImpressionCountsCachePluggable.spec.ts
@@ -61,7 +61,8 @@ describe('IMPRESSION COUNTS CACHE PLUGGABLE', () => {
 
   });
 
-  test('Should call "onFullQueueCb" when the queue is full.', async () => {
+  test('Should call "onFullQueueCb" when the queue is full. "getImpressionsCount" should pop data.', async () => {
+    const key = 'other_key';
     const counter = new ImpressionCountsCachePluggable(loggerMock, key, wrapperMock, 5);
 
     counter.track('feature1', timestamp + 1, 1);
@@ -83,5 +84,15 @@ describe('IMPRESSION COUNTS CACHE PLUGGABLE', () => {
     ]);
 
     expect(counter.isEmpty()).toBe(true);
+
+    // Validate `getImpressionsCount` method
+    expect(await counter.getImpressionsCount()).toStrictEqual({ // pop data
+      pf: [
+        { f: 'feature1', m: truncateTimeFrame(timestamp), rc: 2 },
+        { f: 'feature2', m: truncateTimeFrame(timestamp), rc: 2 },
+        { f: 'feature2', m: truncateTimeFrame(nextHourTimestamp), rc: 1 },
+      ]
+    });
+    expect(await counter.getImpressionsCount()).toStrictEqual(undefined); // try to pop data again
   });
 });

--- a/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
@@ -67,18 +67,18 @@ describe('UNIQUE KEYS CACHE PLUGGABLE', () => {
     await new Promise(resolve => setTimeout(resolve));
 
     expect(wrapperMock.pushItems.mock.calls).toEqual([
-      [key, [JSON.stringify({ 'f': 'feature1', 'ks': ['key1'] })]],
-      [key, [JSON.stringify({ 'f': 'feature2', 'ks': ['key1'] })]],
-      [key, [JSON.stringify({ 'f': 'feature3', 'ks': ['key2'] })]]
+      [key, [JSON.stringify({ f: 'feature1', ks: ['key1'] })]],
+      [key, [JSON.stringify({ f: 'feature2', ks: ['key1'] })]],
+      [key, [JSON.stringify({ f: 'feature3', ks: ['key2'] })]]
     ]);
 
     expect(cache.isEmpty()).toBe(true);
 
     // Validate `popNRaw` method
     let poped = await cache.popNRaw(2); // pop two items
-    expect(poped).toEqual([JSON.stringify({ 'f': 'feature1', 'ks': ['key1'] }), JSON.stringify({ 'f': 'feature2', 'ks': ['key1'] })]);
+    expect(poped).toEqual([{ f: 'feature1', ks: ['key1'] }, { f: 'feature2', ks: ['key1'] }]);
     poped = await cache.popNRaw(); // pop remaining items
-    expect(poped).toEqual([JSON.stringify({ 'f': 'feature3', 'ks': ['key2'] })]);
+    expect(poped).toEqual([{ f: 'feature3', ks: ['key2'] }]);
     poped = await cache.popNRaw(100); // try to pop more items when the queue is empty
     expect(poped).toEqual([]);
   });

--- a/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
@@ -1,6 +1,6 @@
 import { UniqueKeysCachePluggable } from '../UniqueKeysCachePluggable';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-import { wrapperMock, wrapperMockFactory } from './wrapper.mock';
+import { wrapperMock } from './wrapper.mock';
 
 describe('UNIQUE KEYS CACHE PLUGGABLE', () => {
   const key = 'unique_key_post';
@@ -50,7 +50,7 @@ describe('UNIQUE KEYS CACHE PLUGGABLE', () => {
   });
 
   test('Should call "onFullQueueCb" when the queue is full. "popNRaw" should pop items.', async () => {
-    const wrapperMock = wrapperMockFactory();
+    const key = 'other_key';
     const cache = new UniqueKeysCachePluggable(loggerMock, key, wrapperMock, 3);
 
     cache.track('key1', 'feature1');

--- a/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
+++ b/src/storages/pluggable/__tests__/UniqueKeysCachePluggable.spec.ts
@@ -77,7 +77,7 @@ describe('UNIQUE KEYS CACHE PLUGGABLE', () => {
     // Validate `popNRaw` method
     let poped = await cache.popNRaw(2); // pop two items
     expect(poped).toEqual([JSON.stringify({ 'f': 'feature1', 'ks': ['key1'] }), JSON.stringify({ 'f': 'feature2', 'ks': ['key1'] })]);
-    poped = await cache.popNRaw(100); // pop remaining items
+    poped = await cache.popNRaw(); // pop remaining items
     expect(poped).toEqual([JSON.stringify({ 'f': 'feature3', 'ks': ['key2'] })]);
     poped = await cache.popNRaw(100); // try to pop more items when the queue is empty
     expect(poped).toEqual([]);

--- a/src/storages/pluggable/__tests__/index.spec.ts
+++ b/src/storages/pluggable/__tests__/index.spec.ts
@@ -91,4 +91,16 @@ describe('PLUGGABLE STORAGE', () => {
     const impResult = storage.impressions.track(['some data']);
     expect(impResult).toBe(undefined);
   });
+
+  test('creates a storage instance for the synchronizer', async () => {
+    const storageFactory = PluggableStorage({ prefix, wrapper: wrapperMock });
+    const storage = storageFactory({ ...internalSdkParams, mode: undefined });
+
+    assertStorageInterface(storage);
+
+    // All caches are present
+    expect(storage.telemetry).toBeDefined();
+    expect(storage.impressionCounts).toBeDefined();
+    expect(storage.uniqueKeys).toBeDefined();
+  });
 });

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -349,12 +349,12 @@ export interface IEventsCacheAsync extends IEventsCacheBase, IRecorderCacheProdu
  * Only in memory. Named `ImpressionsCounter` in spec.
  */
 export interface IImpressionCountsCacheSync extends IRecorderCacheProducerSync<Record<string, number>> {
-// Used by impressions tracker
+  // Used by impressions tracker
   track(featureName: string, timeFrame: number, amount: number): void
 
   // Used by impressions count submitter in standalone and producer mode
   isEmpty(): boolean // check if cache is empty. Return true if the cache was just created or cleared.
-  pop(toMerge?: Record<string, number> ): Record<string, number> // pop cache data
+  pop(toMerge?: Record<string, number>): Record<string, number> // pop cache data
 }
 
 export interface IUniqueKeysCacheBase {

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -37,13 +37,15 @@ export type ImpressionCountsPayload = {
   }[]
 }
 
+export type UniqueKeysItemSs = {
+  /** Split name */
+  f: string
+  /** keyNames */
+  ks: string[]
+}
+
 export type UniqueKeysPayloadSs = {
-  keys: {
-    /** Split name */
-    f: string
-    /** keyNames */
-    ks: string[]
-  }[]
+  keys: UniqueKeysItemSs[]
 }
 
 export type UniqueKeysPayloadCs = {


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Added consumer methods (used by Synchronizer) of ImpressionCounts and UniqueKeys cache in Redis and Pluggable storage.
- Minor updates due to style formatting and variable renames.

## How do we test the changes introduced in this PR?

Unit tests

## Extra Notes