### PR TITLE
Include default treatment in split view

### DIFF
--- a/src/sdkManager/__tests__/mocks/output.json
+++ b/src/sdkManager/__tests__/mocks/output.json
@@ -6,5 +6,6 @@
   "treatments": ["on", "off"],
   "configs": {
     "on": "\"color\": \"green\""
-  }
+  },
+  "defaultTreatment": "off"
 }

--- a/src/sdkManager/index.ts
+++ b/src/sdkManager/index.ts
@@ -31,7 +31,8 @@ function objectToView(splitObject: ISplit | null): SplitIO.SplitView | null {
     killed: splitObject.killed,
     changeNumber: splitObject.changeNumber || 0,
     treatments: collectTreatments(splitObject),
-    configs: splitObject.configurations || {}
+    configs: splitObject.configurations || {},
+    defaultTreatment: splitObject.defaultTreatment
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -610,6 +610,11 @@ export namespace SplitIO {
     configs: {
       [treatmentName: string]: string
     }
+    /**
+     * Default treatment value for feature flag.
+     * @property {string} defaultTreatment
+     */
+    defaultTreatment: string,
   };
   /**
    * A promise that resolves to a feature flag view.


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
Added the `defaultTreatment` property to the SplitView type and updated the Manager's `split(split(featureFlagName: string)` and `splits()` methods will include `defaultTreatment` in the returned SplitView objects.

## How do we test the changes introduced in this PR?
Updated the test file to expect the additional property in the `output`

## Extra Notes
Additional context/conversation: https://github.com/splitio/javascript-commons/issues/225