### PR TITLE
Update regexp to allow to start with a letter or number

### DIFF
--- a/src/__tests__/mocks/fetchSpecificSplits.ts
+++ b/src/__tests__/mocks/fetchSpecificSplits.ts
@@ -14,7 +14,7 @@ const valuesExamples = [
   [' set_1','set_3 ',' set_a ','set_2','set_c','set_b'], // [9] trim
   ['set_1','set_2','set_3','set_a','set_b','set_c'], // [10] sanitized [9]
   ['set_ 1','set _3','3set_a','_set_2','seT_c','set_B','set_1234567890_1234567890_234567890_1234567890_1234567890','set_a','set_2'], // [11] lowercase & regexp
-  ['set_2','set_a','set_b','set_c'], // [12] sanitized [11]
+  ['3set_a','set_2','set_a','set_b','set_c'], // [12] sanitized [11]
   ['set_2','set_a','SET_2','set_a','set_b','set_B','set_1','set_3!'], // [13] dedupe, dedupe with case sensitive
   ['set_1','set_2','set_a','set_b'], // [14] sanitized [13]
 ];
@@ -77,7 +77,7 @@ export const queryStrings = [
   '&names=%25,%2525,__a,__%D1%88', // [5]
   // FlagSet filters
   '&sets=set_1,set_2,set_3,set_a,set_b,set_c', // [6]
-  '&sets=set_2,set_a,set_b,set_c', // [7]
+  '&sets=3set_a,set_2,set_a,set_b,set_c', // [7]
   '&sets=set_1,set_2,set_a,set_b', // [8]
 ];
 

--- a/src/logger/messages/warn.ts
+++ b/src/logger/messages/warn.ts
@@ -33,6 +33,6 @@ export const codesWarn: [number, string][] = codesError.concat([
 
   [c.STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, c.LOG_PREFIX_SYNC_STREAMING + 'Fetching MySegments due to an error processing %s notification: %s'],
   [c.STREAMING_PARSING_SPLIT_UPDATE, c.LOG_PREFIX_SYNC_STREAMING + 'Fetching SplitChanges due to an error processing SPLIT_UPDATE notification: %s'],
-  [c.WARN_SPLITS_FILTER_INVALID_SET, c.LOG_PREFIX_SETTINGS+': you passed %s, flag set must adhere to the regular expressions %s. This means a flag set must start with a letter, be in lowercase, alphanumeric and have a max length of 50 characteres. %s was discarded.'],
+  [c.WARN_SPLITS_FILTER_INVALID_SET, c.LOG_PREFIX_SETTINGS+': you passed %s, flag set must adhere to the regular expressions %s. This means a flag set must start with a letter or number, be in lowercase, alphanumeric and have a max length of 50 characters. %s was discarded.'],
   [c.WARN_SPLITS_FILTER_LOWERCASE_SET, c.LOG_PREFIX_SETTINGS+': flag set %s should be all lowercase - converting string to lowercase.'],
 ]);

--- a/src/utils/settingsValidation/__tests__/splitFilters.spec.ts
+++ b/src/utils/settingsValidation/__tests__/splitFilters.spec.ts
@@ -26,7 +26,7 @@ describe('validateSplitFilters', () => {
     };
   };
 
-  const regexp = /^[a-z][_a-z0-9]{0,49}$/;
+  const regexp = /^[a-z0-9][_a-z0-9]{0,49}$/;
 
   afterEach(() => { loggerMock.mockClear(); });
 
@@ -115,18 +115,17 @@ describe('validateSplitFilters', () => {
     expect(loggerMock.warn.mock.calls[4]).toEqual([WARN_SPLITS_FILTER_LOWERCASE_SET, ['set_B']]); // lowercase
     expect(loggerMock.warn.mock.calls[5]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set_ 1', regexp, 'set_ 1']]); // empty spaces
     expect(loggerMock.warn.mock.calls[6]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set _3', regexp, 'set _3']]); // empty spaces
-    expect(loggerMock.warn.mock.calls[7]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['3set_a', regexp, '3set_a']]); // start with a letter
-    expect(loggerMock.warn.mock.calls[8]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['_set_2', regexp, '_set_2']]); // start with a letter
-    expect(loggerMock.warn.mock.calls[9]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set_1234567890_1234567890_234567890_1234567890_1234567890', regexp, 'set_1234567890_1234567890_234567890_1234567890_1234567890']]); // max of 50 characters
+    expect(loggerMock.warn.mock.calls[7]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['_set_2', regexp, '_set_2']]); // start with a letter
+    expect(loggerMock.warn.mock.calls[8]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set_1234567890_1234567890_234567890_1234567890_1234567890', regexp, 'set_1234567890_1234567890_234567890_1234567890_1234567890']]); // max of 50 characters
     expect(loggerMock.error.mock.calls[1]).toEqual([ERROR_SPLITS_FILTER_NAME_AND_SET]);
 
     expect(validateSplitFilters(loggerMock, splitFilters[8], STANDALONE_MODE)).toEqual(getOutput(8)); // lowercase and dedupe
-    expect(loggerMock.warn.mock.calls[10]).toEqual([WARN_SPLITS_FILTER_LOWERCASE_SET, ['SET_2']]); // lowercase
-    expect(loggerMock.warn.mock.calls[11]).toEqual([WARN_SPLITS_FILTER_LOWERCASE_SET, ['set_B']]); // lowercase
-    expect(loggerMock.warn.mock.calls[12]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set_3!', regexp, 'set_3!']]); // special character
+    expect(loggerMock.warn.mock.calls[9]).toEqual([WARN_SPLITS_FILTER_LOWERCASE_SET, ['SET_2']]); // lowercase
+    expect(loggerMock.warn.mock.calls[10]).toEqual([WARN_SPLITS_FILTER_LOWERCASE_SET, ['set_B']]); // lowercase
+    expect(loggerMock.warn.mock.calls[11]).toEqual([WARN_SPLITS_FILTER_INVALID_SET, ['set_3!', regexp, 'set_3!']]); // special character
     expect(loggerMock.error.mock.calls[2]).toEqual([ERROR_SPLITS_FILTER_NAME_AND_SET]);
 
-    expect(loggerMock.warn.mock.calls.length).toEqual(13);
+    expect(loggerMock.warn.mock.calls.length).toEqual(12);
     expect(loggerMock.error.mock.calls.length).toEqual(3);
   });
 });

--- a/src/utils/settingsValidation/splitFilters.ts
+++ b/src/utils/settingsValidation/splitFilters.ts
@@ -94,7 +94,7 @@ function queryStringBuilder(groupedFilters: Record<SplitIO.SplitFilterType, stri
  *   - must start with a letter or number
  *   - Be in lowercase
  *   - Be alphanumeric
- *   - have a max length of 50 characteres
+ *   - have a max length of 50 characters
  *
  * @param {ILogger} log
  * @param {string[]} flagsets

--- a/src/utils/settingsValidation/splitFilters.ts
+++ b/src/utils/settingsValidation/splitFilters.ts
@@ -27,7 +27,7 @@ const FILTERS_METADATA = [
   }
 ];
 
-const VALID_FLAGSET_REGEX = /^[a-z][_a-z0-9]{0,49}$/;
+const VALID_FLAGSET_REGEX = /^[a-z0-9][_a-z0-9]{0,49}$/;
 const CAPITAL_LETTERS_REGEX = /[A-Z]/;
 
 /**
@@ -90,8 +90,8 @@ function queryStringBuilder(groupedFilters: Record<SplitIO.SplitFilterType, stri
 /**
  * Sanitizes set names list taking in account:
  *  - It should be lowercase
- *  - Must adhere the following regular expression /^[a-z][_a-z0-9]{0,49}$/ that means
- *   - must start with a letter
+ *  - Must adhere the following regular expression /^[a-z0-9][_a-z0-9]{0,49}$/ that means
+ *   - must start with a letter or number
  *   - Be in lowercase
  *   - Be alphanumeric
  *   - have a max length of 50 characteres


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
Update regexp to allow to start with a letter or number

## How do we test the changes introduced in this PR?
Unit tests fixed

## Extra Notes