### PR TITLE
[SDKS-7498] flagsets cache storage in memory & local storage

### DIFF
--- a/src/storages/KeyBuilder.ts
+++ b/src/storages/KeyBuilder.ts
@@ -20,6 +20,10 @@ export class KeyBuilder {
     return `${this.prefix}.trafficType.${trafficType}`;
   }
 
+  buildFlagsetKey(flagset: string) {
+    return `${this.prefix}.flagset.${flagset}`;
+  }
+
   buildSplitKey(splitName: string) {
     return `${this.prefix}.split.${splitName}`;
   }

--- a/src/storages/__tests__/KeyBuilder.spec.ts
+++ b/src/storages/__tests__/KeyBuilder.spec.ts
@@ -67,6 +67,17 @@ test('KEYS / traffic type keys', () => {
 
 });
 
+test('KEYS / flagset keys', () => {
+  const prefix = 'unit_test.SPLITIO';
+  const builder = new KeyBuilder(prefix);
+
+  const flagsetName = 'flagset_x';
+  const expectedKey = `${prefix}.flagset.${flagsetName}`;
+
+  expect(builder.buildFlagsetKey(flagsetName)).toBe(expectedKey);
+
+});
+
 test('KEYS / impressions', () => {
   const builder = new KeyBuilderSS(prefix, metadata);
 

--- a/src/storages/__tests__/testUtils.ts
+++ b/src/storages/__tests__/testUtils.ts
@@ -32,3 +32,16 @@ export const splitWithAccountTTAndUsesSegments: ISplit = { trafficTypeName: 'acc
 export const something: ISplit = { name: 'something' };
 //@ts-ignore
 export const somethingElse: ISplit = { name: 'something else' };
+
+// - With flagsets
+
+//@ts-ignore
+export const featureFlagWithEmptyFS: ISplit = { name: 'ff_empty', sets: [] };
+//@ts-ignore
+export const featureFlagOne: ISplit = { name: 'ff_one', sets: ['o','n','e'] };
+//@ts-ignore
+export const featureFlagTwo: ISplit = { name: 'ff_two', sets: ['t','w','o'] };
+//@ts-ignore
+export const featureFlagThree: ISplit = { name: 'ff_three', sets: ['t','h','r','e'] };
+//@ts-ignore
+export const featureFlagWithoutFS: ISplit = { name: 'ff_four' };

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -108,7 +108,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
       this._incrementCounts(split);
       this._decrementCounts(previousSplit);
 
-      if (previousSplit && previousSplit.sets) this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
+      if (previousSplit) this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
       this.addToFlagsets(split);
 
       return true;
@@ -124,7 +124,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
       localStorage.removeItem(this.keys.buildSplitKey(name));
 
       this._decrementCounts(split);
-      if (split && split.sets) this.removeFromFlagsets(split.name, split.sets);
+      if (split) this.removeFromFlagsets(split.name, split.sets);
 
       return true;
     } catch (e) {
@@ -291,7 +291,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     });
   }
 
-  removeFromFlagsets(featureFlagName: string, flagsets: string[]) {
+  private removeFromFlagsets(featureFlagName: string, flagsets?: string[]) {
     if (!flagsets) return;
 
     flagsets.forEach(flagset => {
@@ -299,7 +299,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     });
   }
 
-  removeNames(flagsetName: string, featureFlagName: string) {
+  private removeNames(flagsetName: string, featureFlagName: string) {
     const flagsetKey = this.keys.buildFlagsetKey(flagsetName);
 
     let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -272,7 +272,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
   }
 
-  addToFlagsets(featureFlag: ISplit) {
+  private addToFlagsets(featureFlag: ISplit) {
     if (!featureFlag.sets) return;
 
     featureFlag.sets.forEach(featureFlagset => {

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -1,8 +1,9 @@
 import { SplitsCacheInLocal } from '../SplitsCacheInLocal';
 import { KeyBuilderCS } from '../../KeyBuilderCS';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-import { splitWithUserTT, splitWithAccountTT, splitWithAccountTTAndUsesSegments, something, somethingElse } from '../../__tests__/testUtils';
+import { splitWithUserTT, splitWithAccountTT, splitWithAccountTTAndUsesSegments, something, somethingElse, featureFlagOne, featureFlagTwo, featureFlagThree, featureFlagWithEmptyFS, featureFlagWithoutFS } from '../../__tests__/testUtils';
 import { ISplit } from '../../../dtos/types';
+import { _Set } from '../../../utils/lang/sets';
 
 test('SPLIT CACHE / LocalStorage', () => {
   const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
@@ -159,4 +160,64 @@ test('SPLIT CACHE / LocalStorage / usesSegments', () => {
 
   cache.removeSplit('split4');
   expect(cache.usesSegments()).toBe(false); // 0 splits using segments
+});
+
+test('SPLIT CACHE / LocalStorage / flagset cache tests', () => {
+  // @ts-ignore
+  const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'), undefined, { groupedFilters: { bySet: ['o', 'n', 'e', 'x'] } });
+  const emptySet = new _Set([]);
+
+  cache.addSplits([
+    [featureFlagOne.name, featureFlagOne],
+    [featureFlagTwo.name, featureFlagTwo],
+    [featureFlagThree.name, featureFlagThree],
+  ]);
+  cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
+
+  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cache.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cache.getNamesByFlagsets(['t'])).toEqual(emptySet); // 't' not in filter
+  expect(cache.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+
+  cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['1']});
+
+  expect(cache.getNamesByFlagsets(['1'])).toEqual(emptySet); // '1' not in filter
+  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_two']));
+  expect(cache.getNamesByFlagsets(['n'])).toEqual(emptySet);
+
+  cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['x']});
+  expect(cache.getNamesByFlagsets(['x'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagsets(['o','e','x'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+
+
+  cache.removeSplit(featureFlagOne.name);
+  expect(cache.getNamesByFlagsets(['x'])).toEqual(emptySet);
+
+  cache.removeSplit(featureFlagOne.name);
+  expect(cache.getNamesByFlagsets(['y'])).toEqual(emptySet); // 'y' not in filter
+  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+
+  cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithoutFS);
+  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+});
+
+// if FlagSets are not defined, it should store all FlagSets in memory.
+test('SPLIT CACHE / LocalStorage / flagset cache tests without filters', () => {
+  const cacheWithoutFilters = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
+  const emptySet = new _Set([]);
+
+  cacheWithoutFilters.addSplits([
+    [featureFlagOne.name, featureFlagOne],
+    [featureFlagTwo.name, featureFlagTwo],
+    [featureFlagThree.name, featureFlagThree],
+  ]);
+  cacheWithoutFilters.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
+
+  expect(cacheWithoutFilters.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cacheWithoutFilters.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cacheWithoutFilters.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagsets(['t'])).toEqual(new _Set(['ff_two','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagsets(['y'])).toEqual(emptySet);
+  expect(cacheWithoutFilters.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 });

--- a/src/storages/inLocalStorage/index.ts
+++ b/src/storages/inLocalStorage/index.ts
@@ -54,7 +54,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
       uniqueKeys: impressionsMode === NONE ? new UniqueKeysCacheInMemoryCS() : undefined,
 
       destroy() {
-        this.splits = new SplitsCacheInMemory();
+        this.splits = new SplitsCacheInMemory(__splitFiltersValidation);
         this.segments = new MySegmentsCacheInMemory();
         this.impressions.clear();
         this.impressionCounts && this.impressionCounts.clear();
@@ -75,7 +75,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
           telemetry: this.telemetry,
 
           destroy() {
-            this.splits = new SplitsCacheInMemory();
+            this.splits = new SplitsCacheInMemory(__splitFiltersValidation);
             this.segments = new MySegmentsCacheInMemory();
           }
         };

--- a/src/storages/inMemory/InMemoryStorage.ts
+++ b/src/storages/inMemory/InMemoryStorage.ts
@@ -14,9 +14,9 @@ import { UniqueKeysCacheInMemory } from './UniqueKeysCacheInMemory';
  * @param params parameters required by EventsCacheSync
  */
 export function InMemoryStorageFactory(params: IStorageFactoryParams): IStorageSync {
-  const { settings: { scheduler: { impressionsQueueSize, eventsQueueSize, }, sync: { impressionsMode } } } = params;
+  const { settings: { scheduler: { impressionsQueueSize, eventsQueueSize, }, sync: { impressionsMode, __splitFiltersValidation } } } = params;
 
-  const splits = new SplitsCacheInMemory();
+  const splits = new SplitsCacheInMemory(__splitFiltersValidation);
   const segments = new SegmentsCacheInMemory();
 
   const storage = {

--- a/src/storages/inMemory/InMemoryStorageCS.ts
+++ b/src/storages/inMemory/InMemoryStorageCS.ts
@@ -14,9 +14,9 @@ import { UniqueKeysCacheInMemoryCS } from './UniqueKeysCacheInMemoryCS';
  * @param params parameters required by EventsCacheSync
  */
 export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorageSync {
-  const { settings: { scheduler: { impressionsQueueSize, eventsQueueSize, }, sync: { impressionsMode } } } = params;
+  const { settings: { scheduler: { impressionsQueueSize, eventsQueueSize, }, sync: { impressionsMode, __splitFiltersValidation } } } = params;
 
-  const splits = new SplitsCacheInMemory();
+  const splits = new SplitsCacheInMemory(__splitFiltersValidation);
   const segments = new MySegmentsCacheInMemory();
 
   const storage = {
@@ -50,7 +50,7 @@ export function InMemoryStorageCSFactory(params: IStorageFactoryParams): IStorag
 
         // Set a new splits cache to clean it for the client without affecting other clients
         destroy() {
-          this.splits = new SplitsCacheInMemory();
+          this.splits = new SplitsCacheInMemory(__splitFiltersValidation);
           this.segments.clear();
         }
       };

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -117,7 +117,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
   }
 
-  addToFlagsets(featureFlag: ISplit) {
+  private addToFlagsets(featureFlag: ISplit) {
     if (!featureFlag.sets) return;
     featureFlag.sets.forEach(featureFlagset => {
 

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -34,8 +34,9 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
       const previousTtName = previousSplit.trafficTypeName;
       this.ttCache[previousTtName]--;
-      this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
       if (!this.ttCache[previousTtName]) delete this.ttCache[previousTtName];
+
+      this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
 
       if (usesSegments(previousSplit)) { // Substract from segments count for the previous version of this Split.
         this.splitsWithSegmentsCount--;
@@ -128,14 +129,14 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
     });
   }
 
-  removeFromFlagsets(featureFlagName :string, flagsets: string[] | undefined) {
+  private removeFromFlagsets(featureFlagName :string, flagsets: string[] | undefined) {
     if (!flagsets) return;
     flagsets.forEach(flagset => {
       this.removeNames(flagset, featureFlagName);
     });
   }
 
-  removeNames(flagsetName: string, featureFlagName: string) {
+  private removeNames(flagsetName: string, featureFlagName: string) {
     if (!this.flagsetsCache[flagsetName]) return;
     this.flagsetsCache[flagsetName].delete(featureFlagName);
     if (this.flagsetsCache[flagsetName].size === 0) delete this.flagsetsCache[flagsetName];

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -1,6 +1,7 @@
-import { ISplit } from '../../dtos/types';
+import { ISplit, ISplitFiltersValidation } from '../../dtos/types';
 import { AbstractSplitsCacheSync, usesSegments } from '../AbstractSplitsCacheSync';
 import { isFiniteNumber } from '../../utils/lang';
+import { ISet, _Set, returnSetsUnion } from '../../utils/lang/sets';
 
 /**
  * Default ISplitsCacheSync implementation that stores split definitions in memory.
@@ -8,10 +9,17 @@ import { isFiniteNumber } from '../../utils/lang';
  */
 export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
+  private flagsetsFilter: string[];
   private splitsCache: Record<string, ISplit> = {};
   private ttCache: Record<string, number> = {};
   private changeNumber: number = -1;
   private splitsWithSegmentsCount: number = 0;
+  private flagsetsCache: Record<string, ISet<string>> = {};
+
+  constructor(splitFiltersValidation: ISplitFiltersValidation = { queryString: null, groupedFilters: { bySet: [], byName: [], byPrefix: [] }, validFilters: [] }) {
+    super();
+    this.flagsetsFilter = splitFiltersValidation.groupedFilters.bySet;
+  }
 
   clear() {
     this.splitsCache = {};
@@ -26,6 +34,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
       const previousTtName = previousSplit.trafficTypeName;
       this.ttCache[previousTtName]--;
+      this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
       if (!this.ttCache[previousTtName]) delete this.ttCache[previousTtName];
 
       if (usesSegments(previousSplit)) { // Substract from segments count for the previous version of this Split.
@@ -39,6 +48,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
       // Update TT cache
       const ttName = split.trafficTypeName;
       this.ttCache[ttName] = (this.ttCache[ttName] || 0) + 1;
+      this.addToFlagsets(split);
 
       // Add to segments count for the new version of the Split
       if (usesSegments(split)) this.splitsWithSegmentsCount++;
@@ -58,6 +68,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
       const ttName = split.trafficTypeName;
       this.ttCache[ttName]--; // Update tt cache
       if (!this.ttCache[ttName]) delete this.ttCache[ttName];
+      this.removeFromFlagsets(split.name, split.sets);
 
       // Update the segments count.
       if (usesSegments(split)) this.splitsWithSegmentsCount--;
@@ -91,6 +102,43 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
   usesSegments(): boolean {
     return this.getChangeNumber() === -1 || this.splitsWithSegmentsCount > 0;
+  }
+
+  getNamesByFlagsets(flagsets: string[]): ISet<string>{
+    let toReturn: ISet<string> = new _Set([]);
+    flagsets.forEach(flagset => {
+      const featureFlagNames = this.flagsetsCache[flagset];
+      if (featureFlagNames) {
+        toReturn = returnSetsUnion(toReturn, featureFlagNames);
+      }
+    });
+    return toReturn;
+
+  }
+
+  addToFlagsets(featureFlag: ISplit) {
+    if (!featureFlag.sets) return;
+    featureFlag.sets.forEach(featureFlagset => {
+
+      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagset => filterFlagset === featureFlagset)) return;
+
+      if (!this.flagsetsCache[featureFlagset]) this.flagsetsCache[featureFlagset] = new _Set([]);
+
+      this.flagsetsCache[featureFlagset].add(featureFlag.name);
+    });
+  }
+
+  removeFromFlagsets(featureFlagName :string, flagsets: string[] | undefined) {
+    if (!flagsets) return;
+    flagsets.forEach(flagset => {
+      this.removeNames(flagset, featureFlagName);
+    });
+  }
+
+  removeNames(flagsetName: string, featureFlagName: string) {
+    if (!this.flagsetsCache[flagsetName]) return;
+    this.flagsetsCache[flagsetName].delete(featureFlagName);
+    if (this.flagsetsCache[flagsetName].size === 0) delete this.flagsetsCache[flagsetName];
   }
 
 }

--- a/src/sync/polling/updaters/splitChangesUpdater.ts
+++ b/src/sync/polling/updaters/splitChangesUpdater.ts
@@ -7,7 +7,6 @@ import { timeout } from '../../../utils/promise/timeout';
 import { SDK_SPLITS_ARRIVED, SDK_SPLITS_CACHE_LOADED } from '../../../readiness/constants';
 import { ILogger } from '../../../logger/types';
 import { SYNC_SPLITS_FETCH, SYNC_SPLITS_NEW, SYNC_SPLITS_REMOVED, SYNC_SPLITS_SEGMENTS, SYNC_SPLITS_FETCH_FAILS, SYNC_SPLITS_FETCH_RETRY } from '../../../logger/constants';
-import { find } from '../../../utils/lang';
 
 type ISplitChangesUpdater = (noCache?: boolean, till?: number, splitUpdateNotification?: { payload: ISplit, changeNumber: number }) => Promise<boolean>
 
@@ -55,7 +54,7 @@ interface ISplitMutations {
  */
 function matchFilters(featureFlag: ISplit, filters: ISplitFiltersValidation) {
   const { bySet: setsFilter, byName: namesFilter } = filters.groupedFilters;
-  if (setsFilter.length > 0) return featureFlag.sets && find(featureFlag.sets, (featureFlagSet: string) => setsFilter.indexOf(featureFlagSet) > -1);
+  if (setsFilter.length > 0) return featureFlag.sets && featureFlag.sets.some((featureFlagSet: string) => setsFilter.indexOf(featureFlagSet) > -1);
   if (namesFilter.length > 0) return namesFilter.indexOf(featureFlag.name) > -1;
   return true;
 }

--- a/src/utils/lang/__tests__/sets.spec.ts
+++ b/src/utils/lang/__tests__/sets.spec.ts
@@ -1,4 +1,4 @@
-import { __getSetConstructor, SetPoly } from '../sets';
+import { __getSetConstructor, _Set, returnSetsUnion, SetPoly } from '../sets';
 
 test('__getSetConstructor', () => {
 
@@ -13,4 +13,12 @@ test('__getSetConstructor', () => {
 
   global.Set = originalSet; // restore original global Set
 
+});
+
+test('returnSetsUnion', () => {
+  const set = new _Set(['1','2','3']);
+  const set2 = new _Set(['4','5','6']);
+  expect(returnSetsUnion(set, set2)).toEqual(new _Set(['1','2','3','4','5','6']));
+  expect(set).toEqual(new _Set(['1','2','3']));
+  expect(set2).toEqual(new _Set(['4','5','6']));
 });

--- a/src/utils/lang/__tests__/sets.spec.ts
+++ b/src/utils/lang/__tests__/sets.spec.ts
@@ -21,4 +21,9 @@ test('returnSetsUnion', () => {
   expect(returnSetsUnion(set, set2)).toEqual(new _Set(['1','2','3','4','5','6']));
   expect(set).toEqual(new _Set(['1','2','3']));
   expect(set2).toEqual(new _Set(['4','5','6']));
+
+  const emptySet = new _Set([]);
+  expect(returnSetsUnion(emptySet, emptySet)).toEqual(emptySet);
+  expect(returnSetsUnion(set, emptySet)).toEqual(set);
+  expect(returnSetsUnion(emptySet, set2)).toEqual(set2);
 });

--- a/src/utils/lang/sets.ts
+++ b/src/utils/lang/sets.ts
@@ -111,3 +111,11 @@ export function __getSetConstructor(): ISetConstructor {
 }
 
 export const _Set = __getSetConstructor();
+
+export function returnSetsUnion<T>(set: ISet<T>, set2: ISet<T>): ISet<T> {
+  const result = new _Set(setToArray(set));
+  set2.forEach( value => {
+    result.add(value);
+  });
+  return result;
+}


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
- Added Methods to `SplitsCacheInMemory` & `SplitsCacheInLocal` to handle flagsets cache:
   - getNamesByFlagsets
   - addToFlagsets
   - removeFromFlagsets
   - removeNames
- added `returnSetsUnion` sets utility function 

## How do we test the changes introduced in this PR?
Unit tests included

## Extra Notes