### PR TITLE
Fix flagsets typo in storage

### DIFF
--- a/src/storages/AbstractSplitsCacheAsync.ts
+++ b/src/storages/AbstractSplitsCacheAsync.ts
@@ -1,6 +1,7 @@
 import { ISplitsCacheAsync } from './types';
 import { ISplit } from '../dtos/types';
 import { objectAssign } from '../utils/lang/objectAssign';
+import { ISet } from '../utils/lang/sets';
 
 /**
  * This class provides a skeletal implementation of the ISplitsCacheAsync interface
@@ -17,6 +18,7 @@ export abstract class AbstractSplitsCacheAsync implements ISplitsCacheAsync {
   abstract getChangeNumber(): Promise<number>
   abstract getAll(): Promise<ISplit[]>
   abstract getSplitNames(): Promise<string[]>
+  abstract getNamesByFlagSets(flagsets: string[]): Promise<ISet<string>>
   abstract trafficTypeExists(trafficType: string): Promise<boolean>
   abstract clear(): Promise<boolean | void>
 

--- a/src/storages/AbstractSplitsCacheAsync.ts
+++ b/src/storages/AbstractSplitsCacheAsync.ts
@@ -18,7 +18,7 @@ export abstract class AbstractSplitsCacheAsync implements ISplitsCacheAsync {
   abstract getChangeNumber(): Promise<number>
   abstract getAll(): Promise<ISplit[]>
   abstract getSplitNames(): Promise<string[]>
-  abstract getNamesByFlagSets(flagsets: string[]): Promise<ISet<string>>
+  abstract getNamesByFlagSets(flagSets: string[]): Promise<ISet<string>>
   abstract trafficTypeExists(trafficType: string): Promise<boolean>
   abstract clear(): Promise<boolean | void>
 

--- a/src/storages/AbstractSplitsCacheSync.ts
+++ b/src/storages/AbstractSplitsCacheSync.ts
@@ -1,7 +1,7 @@
 import { ISplitsCacheSync } from './types';
 import { ISplit } from '../dtos/types';
 import { objectAssign } from '../utils/lang/objectAssign';
-import { ISet, _Set } from '../utils/lang/sets';
+import { ISet } from '../utils/lang/sets';
 
 /**
  * This class provides a skeletal implementation of the ISplitsCacheSync interface
@@ -78,11 +78,8 @@ export abstract class AbstractSplitsCacheSync implements ISplitsCacheSync {
     }
     return false;
   }
-  /** NO-OP */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getNamesByFlagSets(flagsets: string[]): ISet<string> {
-    return new _Set([]);
-  }
+
+  abstract getNamesByFlagSets(flagSets: string[]): ISet<string>
 
 }
 

--- a/src/storages/AbstractSplitsCacheSync.ts
+++ b/src/storages/AbstractSplitsCacheSync.ts
@@ -1,6 +1,7 @@
 import { ISplitsCacheSync } from './types';
 import { ISplit } from '../dtos/types';
 import { objectAssign } from '../utils/lang/objectAssign';
+import { ISet, _Set } from '../utils/lang/sets';
 
 /**
  * This class provides a skeletal implementation of the ISplitsCacheSync interface
@@ -76,6 +77,11 @@ export abstract class AbstractSplitsCacheSync implements ISplitsCacheSync {
       return this.addSplit(name, newSplit);
     }
     return false;
+  }
+  /** NO-OP */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getNamesByFlagSets(flagsets: string[]): ISet<string> {
+    return new _Set([]);
   }
 
 }

--- a/src/storages/KeyBuilder.ts
+++ b/src/storages/KeyBuilder.ts
@@ -20,7 +20,7 @@ export class KeyBuilder {
     return `${this.prefix}.trafficType.${trafficType}`;
   }
 
-  buildFlagsetKey(flagset: string) {
+  buildFlagSetKey(flagset: string) {
     return `${this.prefix}.flagset.${flagset}`;
   }
 

--- a/src/storages/KeyBuilder.ts
+++ b/src/storages/KeyBuilder.ts
@@ -20,8 +20,8 @@ export class KeyBuilder {
     return `${this.prefix}.trafficType.${trafficType}`;
   }
 
-  buildFlagSetKey(flagset: string) {
-    return `${this.prefix}.flagset.${flagset}`;
+  buildFlagSetKey(flagSet: string) {
+    return `${this.prefix}.flagset.${flagSet}`;
   }
 
   buildSplitKey(splitName: string) {

--- a/src/storages/__tests__/KeyBuilder.spec.ts
+++ b/src/storages/__tests__/KeyBuilder.spec.ts
@@ -74,7 +74,7 @@ test('KEYS / flagset keys', () => {
   const flagsetName = 'flagset_x';
   const expectedKey = `${prefix}.flagset.${flagsetName}`;
 
-  expect(builder.buildFlagsetKey(flagsetName)).toBe(expectedKey);
+  expect(builder.buildFlagSetKey(flagsetName)).toBe(expectedKey);
 
 });
 

--- a/src/storages/__tests__/KeyBuilder.spec.ts
+++ b/src/storages/__tests__/KeyBuilder.spec.ts
@@ -67,14 +67,14 @@ test('KEYS / traffic type keys', () => {
 
 });
 
-test('KEYS / flagset keys', () => {
+test('KEYS / flag set keys', () => {
   const prefix = 'unit_test.SPLITIO';
   const builder = new KeyBuilder(prefix);
 
-  const flagsetName = 'flagset_x';
-  const expectedKey = `${prefix}.flagset.${flagsetName}`;
+  const flagSetName = 'flagset_x';
+  const expectedKey = `${prefix}.flagset.${flagSetName}`;
 
-  expect(builder.buildFlagSetKey(flagsetName)).toBe(expectedKey);
+  expect(builder.buildFlagSetKey(flagSetName)).toBe(expectedKey);
 
 });
 

--- a/src/storages/__tests__/testUtils.ts
+++ b/src/storages/__tests__/testUtils.ts
@@ -33,7 +33,7 @@ export const something: ISplit = { name: 'something' };
 //@ts-ignore
 export const somethingElse: ISplit = { name: 'something else' };
 
-// - With flagsets
+// - With flag sets
 
 //@ts-ignore
 export const featureFlagWithEmptyFS: ISplit = { name: 'ff_empty', sets: [] };

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -257,15 +257,15 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     // if the filter didn't change, nothing is done
   }
 
-  getNamesByFlagSets(flagsets: string[]): ISet<string>{
+  getNamesByFlagSets(flagSets: string[]): ISet<string>{
     let toReturn: ISet<string> = new _Set([]);
-    flagsets.forEach(flagset => {
-      const flagsetKey = this.keys.buildFlagSetKey(flagset);
-      let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
+    flagSets.forEach(flagSet => {
+      const flagSetKey = this.keys.buildFlagSetKey(flagSet);
+      let flagSetFromLocalStorage = localStorage.getItem(flagSetKey);
 
-      if (flagsetFromLocalStorage) {
-        const flagsetCache = new _Set(JSON.parse(flagsetFromLocalStorage));
-        toReturn = returnSetsUnion(toReturn, flagsetCache);
+      if (flagSetFromLocalStorage) {
+        const flagSetCache = new _Set(JSON.parse(flagSetFromLocalStorage));
+        toReturn = returnSetsUnion(toReturn, flagSetCache);
       }
     });
     return toReturn;

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -108,8 +108,8 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
       this._incrementCounts(split);
       this._decrementCounts(previousSplit);
 
-      if (previousSplit) this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
-      this.addToFlagsets(split);
+      if (previousSplit) this.removeFromFlagSets(previousSplit.name, previousSplit.sets);
+      this.addToFlagSets(split);
 
       return true;
     } catch (e) {
@@ -124,7 +124,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
       localStorage.removeItem(this.keys.buildSplitKey(name));
 
       this._decrementCounts(split);
-      if (split) this.removeFromFlagsets(split.name, split.sets);
+      if (split) this.removeFromFlagSets(split.name, split.sets);
 
       return true;
     } catch (e) {
@@ -257,10 +257,10 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     // if the filter didn't change, nothing is done
   }
 
-  getNamesByFlagsets(flagsets: string[]): ISet<string>{
+  getNamesByFlagSets(flagsets: string[]): ISet<string>{
     let toReturn: ISet<string> = new _Set([]);
     flagsets.forEach(flagset => {
-      const flagsetKey = this.keys.buildFlagsetKey(flagset);
+      const flagsetKey = this.keys.buildFlagSetKey(flagset);
       let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
 
       if (flagsetFromLocalStorage) {
@@ -272,14 +272,14 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
   }
 
-  private addToFlagsets(featureFlag: ISplit) {
+  private addToFlagSets(featureFlag: ISplit) {
     if (!featureFlag.sets) return;
 
-    featureFlag.sets.forEach(featureFlagset => {
+    featureFlag.sets.forEach(featureFlagSet => {
 
-      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagset => filterFlagset === featureFlagset)) return;
+      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
 
-      const flagsetKey = this.keys.buildFlagsetKey(featureFlagset);
+      const flagsetKey = this.keys.buildFlagSetKey(featureFlagSet);
 
       let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
       if (!flagsetFromLocalStorage) flagsetFromLocalStorage = '[]';
@@ -291,7 +291,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     });
   }
 
-  private removeFromFlagsets(featureFlagName: string, flagsets?: string[]) {
+  private removeFromFlagSets(featureFlagName: string, flagsets?: string[]) {
     if (!flagsets) return;
 
     flagsets.forEach(flagset => {
@@ -300,7 +300,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
   }
 
   private removeNames(flagsetName: string, featureFlagName: string) {
-    const flagsetKey = this.keys.buildFlagsetKey(flagsetName);
+    const flagsetKey = this.keys.buildFlagSetKey(flagsetName);
 
     let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
 

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -13,7 +13,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
   private readonly keys: KeyBuilderCS;
   private readonly splitFiltersValidation: ISplitFiltersValidation;
-  private readonly flagsetsFilter: string[];
+  private readonly flagSetsFilter: string[];
   private hasSync?: boolean;
   private updateNewFilter?: boolean;
 
@@ -26,7 +26,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     super();
     this.keys = keys;
     this.splitFiltersValidation = splitFiltersValidation;
-    this.flagsetsFilter = this.splitFiltersValidation.groupedFilters.bySet;
+    this.flagSetsFilter = this.splitFiltersValidation.groupedFilters.bySet;
 
     this._checkExpiration(expirationTimestamp);
 
@@ -277,44 +277,44 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
     featureFlag.sets.forEach(featureFlagSet => {
 
-      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
+      if (this.flagSetsFilter.length > 0 && !this.flagSetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
 
-      const flagsetKey = this.keys.buildFlagSetKey(featureFlagSet);
+      const flagSetKey = this.keys.buildFlagSetKey(featureFlagSet);
 
-      let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
-      if (!flagsetFromLocalStorage) flagsetFromLocalStorage = '[]';
+      let flagSetFromLocalStorage = localStorage.getItem(flagSetKey);
+      if (!flagSetFromLocalStorage) flagSetFromLocalStorage = '[]';
 
-      const flagsetCache = new _Set(JSON.parse(flagsetFromLocalStorage));
-      flagsetCache.add(featureFlag.name);
+      const flagSetCache = new _Set(JSON.parse(flagSetFromLocalStorage));
+      flagSetCache.add(featureFlag.name);
 
-      localStorage.setItem(flagsetKey, JSON.stringify(setToArray(flagsetCache)));
+      localStorage.setItem(flagSetKey, JSON.stringify(setToArray(flagSetCache)));
     });
   }
 
-  private removeFromFlagSets(featureFlagName: string, flagsets?: string[]) {
-    if (!flagsets) return;
+  private removeFromFlagSets(featureFlagName: string, flagSets?: string[]) {
+    if (!flagSets) return;
 
-    flagsets.forEach(flagset => {
-      this.removeNames(flagset, featureFlagName);
+    flagSets.forEach(flagSet => {
+      this.removeNames(flagSet, featureFlagName);
     });
   }
 
-  private removeNames(flagsetName: string, featureFlagName: string) {
-    const flagsetKey = this.keys.buildFlagSetKey(flagsetName);
+  private removeNames(flagSetName: string, featureFlagName: string) {
+    const flagSetKey = this.keys.buildFlagSetKey(flagSetName);
 
-    let flagsetFromLocalStorage = localStorage.getItem(flagsetKey);
+    let flagSetFromLocalStorage = localStorage.getItem(flagSetKey);
 
-    if (!flagsetFromLocalStorage) return;
+    if (!flagSetFromLocalStorage) return;
 
-    const flagsetCache = new _Set(JSON.parse(flagsetFromLocalStorage));
-    flagsetCache.delete(featureFlagName);
+    const flagSetCache = new _Set(JSON.parse(flagSetFromLocalStorage));
+    flagSetCache.delete(featureFlagName);
 
-    if (flagsetCache.size === 0) {
-      localStorage.removeItem(flagsetKey);
+    if (flagSetCache.size === 0) {
+      localStorage.removeItem(flagSetKey);
       return;
     }
 
-    localStorage.setItem(flagsetKey, JSON.stringify(setToArray(flagsetCache)));
+    localStorage.setItem(flagSetKey, JSON.stringify(setToArray(flagSetCache)));
   }
 
 }

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -162,7 +162,7 @@ test('SPLIT CACHE / LocalStorage / usesSegments', () => {
   expect(cache.usesSegments()).toBe(false); // 0 splits using segments
 });
 
-test('SPLIT CACHE / LocalStorage / flagset cache tests', () => {
+test('SPLIT CACHE / LocalStorage / flag set cache tests', () => {
   // @ts-ignore
   const cache = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'), undefined, { groupedFilters: { bySet: ['o', 'n', 'e', 'x'] } });
   const emptySet = new _Set([]);
@@ -203,7 +203,7 @@ test('SPLIT CACHE / LocalStorage / flagset cache tests', () => {
 });
 
 // if FlagSets are not defined, it should store all FlagSets in memory.
-test('SPLIT CACHE / LocalStorage / flagset cache tests without filters', () => {
+test('SPLIT CACHE / LocalStorage / flag set cache tests without filters', () => {
   const cacheWithoutFilters = new SplitsCacheInLocal(loggerMock, new KeyBuilderCS('SPLITIO', 'user'));
   const emptySet = new _Set([]);
 

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -174,32 +174,32 @@ test('SPLIT CACHE / LocalStorage / flagset cache tests', () => {
   ]);
   cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
 
-  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
-  expect(cache.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
-  expect(cache.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
-  expect(cache.getNamesByFlagsets(['t'])).toEqual(emptySet); // 't' not in filter
-  expect(cache.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cache.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cache.getNamesByFlagSets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagSets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cache.getNamesByFlagSets(['t'])).toEqual(emptySet); // 't' not in filter
+  expect(cache.getNamesByFlagSets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 
   cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['1']});
 
-  expect(cache.getNamesByFlagsets(['1'])).toEqual(emptySet); // '1' not in filter
-  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_two']));
-  expect(cache.getNamesByFlagsets(['n'])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['1'])).toEqual(emptySet); // '1' not in filter
+  expect(cache.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_two']));
+  expect(cache.getNamesByFlagSets(['n'])).toEqual(emptySet);
 
   cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['x']});
-  expect(cache.getNamesByFlagsets(['x'])).toEqual(new _Set(['ff_one']));
-  expect(cache.getNamesByFlagsets(['o','e','x'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cache.getNamesByFlagSets(['x'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagSets(['o','e','x'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 
 
   cache.removeSplit(featureFlagOne.name);
-  expect(cache.getNamesByFlagsets(['x'])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['x'])).toEqual(emptySet);
 
   cache.removeSplit(featureFlagOne.name);
-  expect(cache.getNamesByFlagsets(['y'])).toEqual(emptySet); // 'y' not in filter
-  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['y'])).toEqual(emptySet); // 'y' not in filter
+  expect(cache.getNamesByFlagSets([])).toEqual(emptySet);
 
   cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithoutFS);
-  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets([])).toEqual(emptySet);
 });
 
 // if FlagSets are not defined, it should store all FlagSets in memory.
@@ -214,10 +214,10 @@ test('SPLIT CACHE / LocalStorage / flagset cache tests without filters', () => {
   ]);
   cacheWithoutFilters.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
 
-  expect(cacheWithoutFilters.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['t'])).toEqual(new _Set(['ff_two','ff_three']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['y'])).toEqual(emptySet);
-  expect(cacheWithoutFilters.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['t'])).toEqual(new _Set(['ff_two','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['y'])).toEqual(emptySet);
+  expect(cacheWithoutFilters.getNamesByFlagSets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 });

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -9,16 +9,16 @@ import { ISet, _Set, returnSetsUnion } from '../../utils/lang/sets';
  */
 export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
-  private flagsetsFilter: string[];
+  private flagSetsFilter: string[];
   private splitsCache: Record<string, ISplit> = {};
   private ttCache: Record<string, number> = {};
   private changeNumber: number = -1;
   private splitsWithSegmentsCount: number = 0;
-  private flagsetsCache: Record<string, ISet<string>> = {};
+  private flagSetsCache: Record<string, ISet<string>> = {};
 
   constructor(splitFiltersValidation: ISplitFiltersValidation = { queryString: null, groupedFilters: { bySet: [], byName: [], byPrefix: [] }, validFilters: [] }) {
     super();
-    this.flagsetsFilter = splitFiltersValidation.groupedFilters.bySet;
+    this.flagSetsFilter = splitFiltersValidation.groupedFilters.bySet;
   }
 
   clear() {
@@ -105,10 +105,10 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
     return this.getChangeNumber() === -1 || this.splitsWithSegmentsCount > 0;
   }
 
-  getNamesByFlagSets(flagsets: string[]): ISet<string>{
+  getNamesByFlagSets(flagSets: string[]): ISet<string>{
     let toReturn: ISet<string> = new _Set([]);
-    flagsets.forEach(flagset => {
-      const featureFlagNames = this.flagsetsCache[flagset];
+    flagSets.forEach(flagSet => {
+      const featureFlagNames = this.flagSetsCache[flagSet];
       if (featureFlagNames) {
         toReturn = returnSetsUnion(toReturn, featureFlagNames);
       }
@@ -121,11 +121,11 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
     if (!featureFlag.sets) return;
     featureFlag.sets.forEach(featureFlagSet => {
 
-      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
+      if (this.flagSetsFilter.length > 0 && !this.flagSetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
 
-      if (!this.flagsetsCache[featureFlagSet]) this.flagsetsCache[featureFlagSet] = new _Set([]);
+      if (!this.flagSetsCache[featureFlagSet]) this.flagSetsCache[featureFlagSet] = new _Set([]);
 
-      this.flagsetsCache[featureFlagSet].add(featureFlag.name);
+      this.flagSetsCache[featureFlagSet].add(featureFlag.name);
     });
   }
 
@@ -137,9 +137,9 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
   }
 
   private removeNames(flagsetName: string, featureFlagName: string) {
-    if (!this.flagsetsCache[flagsetName]) return;
-    this.flagsetsCache[flagsetName].delete(featureFlagName);
-    if (this.flagsetsCache[flagsetName].size === 0) delete this.flagsetsCache[flagsetName];
+    if (!this.flagSetsCache[flagsetName]) return;
+    this.flagSetsCache[flagsetName].delete(featureFlagName);
+    if (this.flagSetsCache[flagsetName].size === 0) delete this.flagSetsCache[flagsetName];
   }
 
 }

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -129,17 +129,17 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
     });
   }
 
-  private removeFromFlagSets(featureFlagName :string, flagsets: string[] | undefined) {
-    if (!flagsets) return;
-    flagsets.forEach(flagset => {
-      this.removeNames(flagset, featureFlagName);
+  private removeFromFlagSets(featureFlagName :string, flagSets: string[] | undefined) {
+    if (!flagSets) return;
+    flagSets.forEach(flagSet => {
+      this.removeNames(flagSet, featureFlagName);
     });
   }
 
-  private removeNames(flagsetName: string, featureFlagName: string) {
-    if (!this.flagSetsCache[flagsetName]) return;
-    this.flagSetsCache[flagsetName].delete(featureFlagName);
-    if (this.flagSetsCache[flagsetName].size === 0) delete this.flagSetsCache[flagsetName];
+  private removeNames(flagSetName: string, featureFlagName: string) {
+    if (!this.flagSetsCache[flagSetName]) return;
+    this.flagSetsCache[flagSetName].delete(featureFlagName);
+    if (this.flagSetsCache[flagSetName].size === 0) delete this.flagSetsCache[flagSetName];
   }
 
 }

--- a/src/storages/inMemory/SplitsCacheInMemory.ts
+++ b/src/storages/inMemory/SplitsCacheInMemory.ts
@@ -36,7 +36,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
       this.ttCache[previousTtName]--;
       if (!this.ttCache[previousTtName]) delete this.ttCache[previousTtName];
 
-      this.removeFromFlagsets(previousSplit.name, previousSplit.sets);
+      this.removeFromFlagSets(previousSplit.name, previousSplit.sets);
 
       if (usesSegments(previousSplit)) { // Substract from segments count for the previous version of this Split.
         this.splitsWithSegmentsCount--;
@@ -49,7 +49,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
       // Update TT cache
       const ttName = split.trafficTypeName;
       this.ttCache[ttName] = (this.ttCache[ttName] || 0) + 1;
-      this.addToFlagsets(split);
+      this.addToFlagSets(split);
 
       // Add to segments count for the new version of the Split
       if (usesSegments(split)) this.splitsWithSegmentsCount++;
@@ -69,7 +69,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
       const ttName = split.trafficTypeName;
       this.ttCache[ttName]--; // Update tt cache
       if (!this.ttCache[ttName]) delete this.ttCache[ttName];
-      this.removeFromFlagsets(split.name, split.sets);
+      this.removeFromFlagSets(split.name, split.sets);
 
       // Update the segments count.
       if (usesSegments(split)) this.splitsWithSegmentsCount--;
@@ -105,7 +105,7 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
     return this.getChangeNumber() === -1 || this.splitsWithSegmentsCount > 0;
   }
 
-  getNamesByFlagsets(flagsets: string[]): ISet<string>{
+  getNamesByFlagSets(flagsets: string[]): ISet<string>{
     let toReturn: ISet<string> = new _Set([]);
     flagsets.forEach(flagset => {
       const featureFlagNames = this.flagsetsCache[flagset];
@@ -117,19 +117,19 @@ export class SplitsCacheInMemory extends AbstractSplitsCacheSync {
 
   }
 
-  private addToFlagsets(featureFlag: ISplit) {
+  private addToFlagSets(featureFlag: ISplit) {
     if (!featureFlag.sets) return;
-    featureFlag.sets.forEach(featureFlagset => {
+    featureFlag.sets.forEach(featureFlagSet => {
 
-      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagset => filterFlagset === featureFlagset)) return;
+      if (this.flagsetsFilter.length > 0 && !this.flagsetsFilter.some(filterFlagSet => filterFlagSet === featureFlagSet)) return;
 
-      if (!this.flagsetsCache[featureFlagset]) this.flagsetsCache[featureFlagset] = new _Set([]);
+      if (!this.flagsetsCache[featureFlagSet]) this.flagsetsCache[featureFlagSet] = new _Set([]);
 
-      this.flagsetsCache[featureFlagset].add(featureFlag.name);
+      this.flagsetsCache[featureFlagSet].add(featureFlag.name);
     });
   }
 
-  private removeFromFlagsets(featureFlagName :string, flagsets: string[] | undefined) {
+  private removeFromFlagSets(featureFlagName :string, flagsets: string[] | undefined) {
     if (!flagsets) return;
     flagsets.forEach(flagset => {
       this.removeNames(flagset, featureFlagName);

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -181,7 +181,7 @@ export class TelemetryCacheInMemory implements ITelemetryCacheSync {
     this.e = false;
   }
 
-  private streamingEvents: StreamingEvent[] = []
+  private streamingEvents: StreamingEvent[] = [];
 
   popStreamingEvents() {
     return this.streamingEvents.splice(0);

--- a/src/storages/inMemory/__tests__/SplitsCacheInMemory.spec.ts
+++ b/src/storages/inMemory/__tests__/SplitsCacheInMemory.spec.ts
@@ -127,32 +127,32 @@ test('SPLITS CACHE / In Memory / flagset cache tests', () => {
   ]);
   cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
 
-  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
-  expect(cache.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
-  expect(cache.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
-  expect(cache.getNamesByFlagsets(['t'])).toEqual(emptySet); // 't' not in filter
-  expect(cache.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cache.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cache.getNamesByFlagSets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagSets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cache.getNamesByFlagSets(['t'])).toEqual(emptySet); // 't' not in filter
+  expect(cache.getNamesByFlagSets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 
   cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['1']});
 
-  expect(cache.getNamesByFlagsets(['1'])).toEqual(emptySet); // '1' not in filter
-  expect(cache.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_two']));
-  expect(cache.getNamesByFlagsets(['n'])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['1'])).toEqual(emptySet); // '1' not in filter
+  expect(cache.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_two']));
+  expect(cache.getNamesByFlagSets(['n'])).toEqual(emptySet);
 
   cache.addSplit(featureFlagOne.name, {...featureFlagOne, sets: ['x']});
-  expect(cache.getNamesByFlagsets(['x'])).toEqual(new _Set(['ff_one']));
-  expect(cache.getNamesByFlagsets(['o','e','x'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cache.getNamesByFlagSets(['x'])).toEqual(new _Set(['ff_one']));
+  expect(cache.getNamesByFlagSets(['o','e','x'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 
 
   cache.removeSplit(featureFlagOne.name);
-  expect(cache.getNamesByFlagsets(['x'])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['x'])).toEqual(emptySet);
 
   cache.removeSplit(featureFlagOne.name);
-  expect(cache.getNamesByFlagsets(['y'])).toEqual(emptySet); // 'y' not in filter
-  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets(['y'])).toEqual(emptySet); // 'y' not in filter
+  expect(cache.getNamesByFlagSets([])).toEqual(emptySet);
 
   cache.addSplit(featureFlagWithEmptyFS.name, featureFlagWithoutFS);
-  expect(cache.getNamesByFlagsets([])).toEqual(emptySet);
+  expect(cache.getNamesByFlagSets([])).toEqual(emptySet);
 });
 
 // if FlagSets are not defined, it should store all FlagSets in memory.
@@ -167,10 +167,10 @@ test('SPLIT CACHE / LocalStorage / flagset cache tests without filters', () => {
   ]);
   cacheWithoutFilters.addSplit(featureFlagWithEmptyFS.name, featureFlagWithEmptyFS);
 
-  expect(cacheWithoutFilters.getNamesByFlagsets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['n'])).toEqual(new _Set(['ff_one']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['t'])).toEqual(new _Set(['ff_two','ff_three']));
-  expect(cacheWithoutFilters.getNamesByFlagsets(['y'])).toEqual(emptySet);
-  expect(cacheWithoutFilters.getNamesByFlagsets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['o'])).toEqual(new _Set(['ff_one', 'ff_two']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['n'])).toEqual(new _Set(['ff_one']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['e'])).toEqual(new _Set(['ff_one','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['t'])).toEqual(new _Set(['ff_two','ff_three']));
+  expect(cacheWithoutFilters.getNamesByFlagSets(['y'])).toEqual(emptySet);
+  expect(cacheWithoutFilters.getNamesByFlagSets(['o','n','e'])).toEqual(new _Set(['ff_one','ff_two','ff_three']));
 });

--- a/src/storages/inMemory/__tests__/SplitsCacheInMemory.spec.ts
+++ b/src/storages/inMemory/__tests__/SplitsCacheInMemory.spec.ts
@@ -115,7 +115,7 @@ test('SPLITS CACHE / In Memory / killLocally', () => {
 
 });
 
-test('SPLITS CACHE / In Memory / flagset cache tests', () => {
+test('SPLITS CACHE / In Memory / flag set cache tests', () => {
   // @ts-ignore
   const cache = new SplitsCacheInMemory({ groupedFilters: { bySet: ['o', 'n', 'e', 'x'] } });
   const emptySet = new _Set([]);
@@ -156,7 +156,7 @@ test('SPLITS CACHE / In Memory / flagset cache tests', () => {
 });
 
 // if FlagSets are not defined, it should store all FlagSets in memory.
-test('SPLIT CACHE / LocalStorage / flagset cache tests without filters', () => {
+test('SPLIT CACHE / LocalStorage / flag set cache tests without filters', () => {
   const cacheWithoutFilters = new SplitsCacheInMemory();
   const emptySet = new _Set([]);
 

--- a/src/storages/inRedis/RedisAdapter.ts
+++ b/src/storages/inRedis/RedisAdapter.ts
@@ -33,7 +33,7 @@ interface IRedisCommand {
  * Redis adapter on top of the library of choice (written with ioredis) for some extra control.
  */
 export class RedisAdapter extends ioredis {
-  private readonly log: ILogger
+  private readonly log: ILogger;
   private _options: object;
   private _notReadyCommandsQueue?: IRedisCommand[];
   private _runningCommands: ISet<Promise<any>>;

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -5,6 +5,7 @@ import { ILogger } from '../../logger/types';
 import { LOG_PREFIX } from './constants';
 import { ISplit } from '../../dtos/types';
 import { AbstractSplitsCacheAsync } from '../AbstractSplitsCacheAsync';
+import { ISet, _Set } from '../../utils/lang/sets';
 
 /**
  * Discard errors for an answer of multiple operations.
@@ -186,6 +187,17 @@ export class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
     return this.redis.keys(this.keys.searchPatternForSplitKeys()).then(
       (listOfKeys) => listOfKeys.map(this.keys.extractKey)
     );
+  }
+
+  /**
+   * Get list of split names related to a given flagset names list.
+   * The returned promise is resolved with the list of split names,
+   * or rejected if wrapper operation fails.
+   * @todo this is a no-op method to be implemented
+  */
+  getNamesByFlagSets(): Promise<ISet<string>> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return new Promise(flagSets => new _Set([]));
   }
 
   /**

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -190,7 +190,7 @@ export class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
   }
 
   /**
-   * Get list of split names related to a given flagset names list.
+   * Get list of split names related to a given flag set names list.
    * The returned promise is resolved with the list of split names,
    * or rejected if wrapper operation fails.
    * @todo this is a no-op method to be implemented

--- a/src/storages/pluggable/SplitsCachePluggable.ts
+++ b/src/storages/pluggable/SplitsCachePluggable.ts
@@ -156,7 +156,7 @@ export class SplitsCachePluggable extends AbstractSplitsCacheAsync {
   }
 
   /**
-   * Get list of split names related to a given flagset names list.
+   * Get list of split names related to a given flag set names list.
    * The returned promise is resolved with the list of split names,
    * or rejected if wrapper operation fails.
    * @todo this is a no-op method to be implemented

--- a/src/storages/pluggable/SplitsCachePluggable.ts
+++ b/src/storages/pluggable/SplitsCachePluggable.ts
@@ -5,6 +5,7 @@ import { ILogger } from '../../logger/types';
 import { ISplit } from '../../dtos/types';
 import { LOG_PREFIX } from './constants';
 import { AbstractSplitsCacheAsync } from '../AbstractSplitsCacheAsync';
+import { ISet, _Set } from '../../utils/lang/sets';
 
 /**
  * ISplitsCacheAsync implementation for pluggable storages.
@@ -152,6 +153,17 @@ export class SplitsCachePluggable extends AbstractSplitsCacheAsync {
     return this.wrapper.getKeysByPrefix(this.keys.buildSplitKeyPrefix()).then(
       (listOfKeys) => listOfKeys.map(this.keys.extractKey)
     );
+  }
+
+  /**
+   * Get list of split names related to a given flagset names list.
+   * The returned promise is resolved with the list of split names,
+   * or rejected if wrapper operation fails.
+   * @todo this is a no-op method to be implemented
+  */
+  getNamesByFlagSets(): Promise<ISet<string>> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return new Promise(flagSets => new _Set([]));
   }
 
   /**

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -1,6 +1,7 @@
 import { MaybeThenable, ISplit } from '../dtos/types';
 import { EventDataType, HttpErrors, HttpLatencies, ImpressionDataType, LastSync, Method, MethodExceptions, MethodLatencies, MultiMethodExceptions, MultiMethodLatencies, MultiConfigs, OperationType, StoredEventWithMetadata, StoredImpressionWithMetadata, StreamingEvent, UniqueKeysPayloadCs, UniqueKeysPayloadSs, TelemetryUsageStatsPayload, UpdatesFromSSEEnum } from '../sync/submitters/types';
 import { SplitIO, ImpressionDTO, ISettings } from '../types';
+import { ISet } from '../utils/lang/sets';
 
 /**
  * Interface of a pluggable storage wrapper.
@@ -208,7 +209,8 @@ export interface ISplitsCacheBase {
   clear(): MaybeThenable<boolean | void>,
   // should never reject or throw an exception. Instead return false by default, to avoid emitting SDK_READY_FROM_CACHE.
   checkCache(): MaybeThenable<boolean>,
-  killLocally(name: string, defaultTreatment: string, changeNumber: number): MaybeThenable<boolean>
+  killLocally(name: string, defaultTreatment: string, changeNumber: number): MaybeThenable<boolean>,
+  getNamesByFlagSets(flagsets: string[]): MaybeThenable<ISet<string>>
 }
 
 export interface ISplitsCacheSync extends ISplitsCacheBase {
@@ -224,7 +226,8 @@ export interface ISplitsCacheSync extends ISplitsCacheBase {
   usesSegments(): boolean,
   clear(): void,
   checkCache(): boolean,
-  killLocally(name: string, defaultTreatment: string, changeNumber: number): boolean
+  killLocally(name: string, defaultTreatment: string, changeNumber: number): boolean,
+  getNamesByFlagSets(flagsets: string[]): ISet<string>
 }
 
 export interface ISplitsCacheAsync extends ISplitsCacheBase {
@@ -240,7 +243,8 @@ export interface ISplitsCacheAsync extends ISplitsCacheBase {
   usesSegments(): Promise<boolean>,
   clear(): Promise<boolean | void>,
   checkCache(): Promise<boolean>,
-  killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean>
+  killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean>,
+  getNamesByFlagSets(flagsets: string[]): Promise<ISet<string>>
 }
 
 /** Segments cache */

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -210,7 +210,7 @@ export interface ISplitsCacheBase {
   // should never reject or throw an exception. Instead return false by default, to avoid emitting SDK_READY_FROM_CACHE.
   checkCache(): MaybeThenable<boolean>,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): MaybeThenable<boolean>,
-  getNamesByFlagSets(flagsets: string[]): MaybeThenable<ISet<string>>
+  getNamesByFlagSets(flagSets: string[]): MaybeThenable<ISet<string>>
 }
 
 export interface ISplitsCacheSync extends ISplitsCacheBase {
@@ -227,7 +227,7 @@ export interface ISplitsCacheSync extends ISplitsCacheBase {
   clear(): void,
   checkCache(): boolean,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): boolean,
-  getNamesByFlagSets(flagsets: string[]): ISet<string>
+  getNamesByFlagSets(flagSets: string[]): ISet<string>
 }
 
 export interface ISplitsCacheAsync extends ISplitsCacheBase {
@@ -244,7 +244,7 @@ export interface ISplitsCacheAsync extends ISplitsCacheBase {
   clear(): Promise<boolean | void>,
   checkCache(): Promise<boolean>,
   killLocally(name: string, defaultTreatment: string, changeNumber: number): Promise<boolean>,
-  getNamesByFlagSets(flagsets: string[]): Promise<ISet<string>>
+  getNamesByFlagSets(flagSets: string[]): Promise<ISet<string>>
 }
 
 /** Segments cache */

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -40,7 +40,7 @@ function getRedundantActiveFactories() {
 }
 
 function getTelemetryFlagSetsStats(splitFiltersValidation: ISplitFiltersValidation) {
-  // Group every configured flagset in an unique array called originalSets
+  // Group every configured flag set in an unique array called originalSets
   let flagSetsTotal = 0;
   splitFiltersValidation.validFilters.forEach((filter: SplitIO.SplitFilter) => {
     if (filter.type === 'bySet') flagSetsTotal += filter.values.length;

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -234,8 +234,8 @@ export type TelemetryConfigStatsPayload = TelemetryConfigStats & {
   nR: number, // SDKNotReadyUsage
   i?: Array<string>, // integrations
   uC: number, // userConsent
-  fsT: number, // flagsetsTotal
-  fsI: number, // flagsetsInvalid
+  fsT: number, // flagSetsTotal
+  fsI: number, // flagSetsInvalid
 }
 
 export interface ISubmitterManager extends ISyncTask {

--- a/src/utils/settingsValidation/splitFilters.ts
+++ b/src/utils/settingsValidation/splitFilters.ts
@@ -97,11 +97,11 @@ function queryStringBuilder(groupedFilters: Record<SplitIO.SplitFilterType, stri
  *   - have a max length of 50 characters
  *
  * @param {ILogger} log
- * @param {string[]} flagsets
+ * @param {string[]} flagSets
  * @returns sanitized list of set names
  */
-function sanitizeFlagSets(log: ILogger, flagsets: string[]) {
-  let sanitizedSets = flagsets
+function sanitizeFlagSets(log: ILogger, flagSets: string[]) {
+  let sanitizedSets = flagSets
     .map(flagSet => {
       if (CAPITAL_LETTERS_REGEX.test(flagSet)){
         log.warn(WARN_SPLITS_FILTER_LOWERCASE_SET,[flagSet]);


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?
- replace `Flagset` with `FlagSet`
- no-op `getNamesByFlagSets` method for in redis & pluggable storage

## How do we test the changes introduced in this PR?

## Extra Notes