### PR TITLE
segmentChangesUpdated convert to async/await syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ end_of_line = lf
 [*.{js,json,ts}]
 indent_style = space
 indent_size = 2
+quote_type = single

--- a/src/sync/polling/updaters/segmentChangesUpdater.ts
+++ b/src/sync/polling/updaters/segmentChangesUpdater.ts
@@ -5,10 +5,18 @@ import { MaybeThenable } from '../../../dtos/types';
 import { findIndex } from '../../../utils/lang';
 import { SDK_SEGMENTS_ARRIVED } from '../../../readiness/constants';
 import { ILogger } from '../../../logger/types';
-import { LOG_PREFIX_INSTANTIATION, LOG_PREFIX_SYNC_SEGMENTS } from '../../../logger/constants';
+import {
+  LOG_PREFIX_INSTANTIATION,
+  LOG_PREFIX_SYNC_SEGMENTS,
+} from '../../../logger/constants';
 import { thenable } from '../../../utils/promise/thenable';
 
-type ISegmentChangesUpdater = (fetchOnlyNew?: boolean, segmentName?: string, noCache?: boolean, till?: number) => Promise<boolean>
+type ISegmentChangesUpdater = (
+  fetchOnlyNew?: boolean,
+  segmentName?: string,
+  noCache?: boolean,
+  till?: number
+) => Promise<boolean>;
 
 /**
  * Factory of SegmentChanges updater, a task that:
@@ -25,37 +33,48 @@ export function segmentChangesUpdaterFactory(
   log: ILogger,
   segmentChangesFetcher: ISegmentChangesFetcher,
   segments: ISegmentsCacheBase,
-  readiness?: IReadinessManager,
+  readiness?: IReadinessManager
 ): ISegmentChangesUpdater {
-
   let readyOnAlreadyExistentState = true;
 
-  function updateSegment(segmentName: string, noCache?: boolean, till?: number, fetchOnlyNew?: boolean) {
+  async function updateSegment(
+    segmentName: string,
+    noCache?: boolean,
+    till?: number,
+    fetchOnlyNew?: boolean
+  ) {
     log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processing segment ${segmentName}`);
-    let sincePromise = Promise.resolve(segments.getChangeNumber(segmentName));
+    const since = await segments.getChangeNumber(segmentName);
 
-    return sincePromise.then(since => {
-      // if fetchOnlyNew flag, avoid processing already fetched segments
-      if (fetchOnlyNew && since !== -1) return -1;
+    // if fetchOnlyNew flag, avoid processing already fetched segments
+    if (fetchOnlyNew && since !== -1) return -1;
+    const changes = await segmentChangesFetcher(
+      since,
+      segmentName,
+      noCache,
+      till
+    );
 
-      return segmentChangesFetcher(since, segmentName, noCache, till).then(function (changes) {
-        let changeNumber = -1;
-        const results: MaybeThenable<boolean | void>[] = [];
-        changes.forEach(x => {
-          if (x.added.length > 0) results.push(segments.addToSegment(segmentName, x.added));
-          if (x.removed.length > 0) results.push(segments.removeFromSegment(segmentName, x.removed));
-          if (x.added.length > 0 || x.removed.length > 0) {
-            results.push(segments.setChangeNumber(segmentName, x.till));
-            changeNumber = x.till;
-          }
+    let changeNumber = -1;
+    const results: MaybeThenable<boolean | void>[] = [];
+    changes.forEach((x) => {
+      if (x.added.length > 0)
+        results.push(segments.addToSegment(segmentName, x.added));
+      if (x.removed.length > 0)
+        results.push(segments.removeFromSegment(segmentName, x.removed));
+      if (x.added.length > 0 || x.removed.length > 0) {
+        results.push(segments.setChangeNumber(segmentName, x.till));
+        changeNumber = x.till;
+      }
 
-          log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`);
-        });
-        // If at least one storage operation result is a promise, join all in a single promise.
-        if (results.some(result => thenable(result))) return Promise.all(results).then(() => changeNumber);
-        return changeNumber;
-      });
+      log.debug(
+        `${LOG_PREFIX_SYNC_SEGMENTS}Processed ${segmentName} with till = ${x.till}. Added: ${x.added.length}. Removed: ${x.removed.length}`
+      );
     });
+    // If at least one storage operation result is a promise, join all in a single promise.
+    if (results.some((result) => thenable(result)))
+      return Promise.all(results).then(() => changeNumber);
+    return changeNumber;
   }
   /**
    * Segments updater returns a promise that resolves with a `false` boolean value if it fails at least to fetch a segment or synchronize it with the storage.
@@ -68,41 +87,59 @@ export function segmentChangesUpdaterFactory(
    * @param {boolean | undefined} noCache true to revalidate data to fetch on a SEGMENT_UPDATE notifications.
    * @param {number | undefined} till till target for the provided segmentName, for CDN bypass.
    */
-  return function segmentChangesUpdater(fetchOnlyNew?: boolean, segmentName?: string, noCache?: boolean, till?: number) {
+  return async function segmentChangesUpdater(
+    fetchOnlyNew?: boolean,
+    segmentName?: string,
+    noCache?: boolean,
+    till?: number
+  ) {
     log.debug(`${LOG_PREFIX_SYNC_SEGMENTS}Started segments update`);
 
     // If not a segment name provided, read list of available segments names to be updated.
-    let segmentsPromise = Promise.resolve(segmentName ? [segmentName] : segments.getRegisteredSegments());
-
-    return segmentsPromise.then(segmentNames => {
+    const segmentNames = await (segmentName
+      ? [segmentName]
+      : segments.getRegisteredSegments());
+    try {
       // Async fetchers are collected here.
       const updaters: Promise<number>[] = [];
 
       for (let index = 0; index < segmentNames.length; index++) {
-        updaters.push(updateSegment(segmentNames[index], noCache, till, fetchOnlyNew));
+        updaters.push(
+          updateSegment(segmentNames[index], noCache, till, fetchOnlyNew)
+        );
+      }
+      const shouldUpdateFlags = await Promise.all(updaters);
+
+      // if at least one segment fetch succeeded, mark segments ready
+      if (
+        findIndex(shouldUpdateFlags, (v) => v !== -1) !== -1 ||
+        readyOnAlreadyExistentState
+      ) {
+        readyOnAlreadyExistentState = false;
+        if (readiness) readiness.segments.emit(SDK_SEGMENTS_ARRIVED);
+      }
+      return true;
+    } catch (error) {
+      // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
+      if (
+        error &&
+        typeof error === 'object' &&
+        'statusCode' in error &&
+        error.statusCode === 403
+      ) {
+        // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
+        // @TODO although factory status is destroyed, synchronization is not stopped
+        if (readiness) readiness.destroy();
+        log.error(
+          `${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an SDK Key from the Split user interface that is of type server-side.`
+        );
+      } else {
+        log.warn(
+          `${LOG_PREFIX_SYNC_SEGMENTS}Error while doing fetch of segments. ${error}`
+        );
       }
 
-      return Promise.all(updaters).then(shouldUpdateFlags => {
-        // if at least one segment fetch succeeded, mark segments ready
-        if (findIndex(shouldUpdateFlags, v => v !== -1) !== -1 || readyOnAlreadyExistentState) {
-          readyOnAlreadyExistentState = false;
-          if (readiness) readiness.segments.emit(SDK_SEGMENTS_ARRIVED);
-        }
-        return true;
-      });
-    })
-      // Handles rejected promises at `segmentChangesFetcher`, `segments.getRegisteredSegments` and other segment storage operations.
-      .catch(error => {
-        if (error && error.statusCode === 403) {
-          // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
-          // @TODO although factory status is destroyed, synchronization is not stopped
-          if (readiness) readiness.destroy();
-          log.error(`${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an SDK Key from the Split user interface that is of type server-side.`);
-        } else {
-          log.warn(`${LOG_PREFIX_SYNC_SEGMENTS}Error while doing fetch of segments. ${error}`);
-        }
-
-        return false;
-      });
+      return false;
+    }
   };
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

Segment fetching was currently doing a Promise.all across every segment on startup. This would result in [# of segments] simultaneous IO requests, which can cause troubles for node. It is better to ensure a max # of concurrent requests.

- converted the segmentChangesUpdater to use async/await syntax instead of promise chains
- updated .editorconfig to include quote preference
- made the segment fetching happen in chunks of 10 rather than all at once

## How do we test the changes introduced in this PR?

- ensure segment syncing still works

## Extra Notes

- the chunk size could be configurable, but hard-coding 10 seems a marked improvement over hard-coding "infinite"