### PR TITLE
Update SDK key validation in NodeJS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@
     - Added a new optional Split Filter configuration option. This allows the SDK and Split services to only synchronize the flags in the specified flag sets, avoiding unused or unwanted flags from being synced on the SDK instance, bringing all the benefits from a reduced payload.
       - Note: Only applicable when the SDK is in charge of the rollout data synchronization. When not applicable, the SDK will log a warning on init.
     - Added `sets` property to the `SplitView` object returned by the `split` and `splits` methods of the SDK manager to expose flag sets on flag views.
+  - Bugfixing - Fixed SDK key validation in NodeJS to ensure the SDK_READY_TIMED_OUT event is emitted when a client-side type SDK key is provided instead of a server-side one (Related to issue https://github.com/splitio/javascript-client/issues/768).
 
 1.10.0 (October 20, 2023)
  - Added `defaultTreatment` property to the `SplitView` object returned by the `split` and `splits` methods of the SDK manager (Related to issue https://github.com/splitio/javascript-commons/issues/225).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.10.1-rc.3",
+  "version": "1.10.1-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.10.1-rc.3",
+      "version": "1.10.1-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.10.1-rc.3",
+  "version": "1.10.1-rc.4",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/readiness/readinessManager.ts
+++ b/src/readiness/readinessManager.ts
@@ -112,7 +112,12 @@ export function readinessManagerFactory(
       return readinessManagerFactory(EventEmitter, readyTimeout, splits);
     },
 
+    // @TODO review/remove next methods when non-recoverable errors are reworked
+    // Called on consumer mode, when storage fails to connect
     timeout,
+    // Called on 403 error (client-side SDK key on server-side), to set the SDK as destroyed for
+    // tracking and evaluations, while keeping event listeners to emit SDK_READY_TIMED_OUT event
+    setDestroyed() { isDestroyed = true; },
 
     destroy() {
       isDestroyed = true;

--- a/src/readiness/types.ts
+++ b/src/readiness/types.ts
@@ -55,6 +55,7 @@ export interface IReadinessManager {
   isOperational(): boolean,
 
   timeout(): void,
+  setDestroyed(): void,
   destroy(): void,
 
   /** for client-side */

--- a/src/sync/polling/updaters/segmentChangesUpdater.ts
+++ b/src/sync/polling/updaters/segmentChangesUpdater.ts
@@ -96,7 +96,7 @@ export function segmentChangesUpdaterFactory(
         if (error && error.statusCode === 403) {
           // If the operation is forbidden, it may be due to permissions. Destroy the SDK instance.
           // @TODO although factory status is destroyed, synchronization is not stopped
-          if (readiness) readiness.destroy();
+          if (readiness) readiness.setDestroyed();
           log.error(`${LOG_PREFIX_INSTANTIATION}: you passed a client-side type authorizationKey, please grab an SDK Key from the Split user interface that is of type server-side.`);
         } else {
           log.warn(`${LOG_PREFIX_SYNC_SEGMENTS}Error while doing fetch of segments. ${error}`);


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

Fixed SDK key validation in NodeJS to ensure the SDK_READY_TIMED_OUT event is emitted when a client-side type SDK key is provided instead of a server-side one.

## How do we test the changes introduced in this PR?

E2E test in javascript-client rep.

## Extra Notes

Related to issue https://github.com/splitio/javascript-client/issues/768