### PR TITLE
Update manager methods to return a promise in consumer modes while the SDK is not operational

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+1.11.1 (December XX, 2023)
+  - Bugfixing - Fixed manager methods to return a promise in consumer modes when called while the SDK is not operational (not ready or destroyed).
+
 1.11.0 (November 3, 2023)
   - Added support for Flag Sets on the SDK, which enables grouping feature flags and interacting with the group rather than individually (more details in our documentation):
     - Added new variations of the get treatment methods to support evaluating flags in given flag set/s.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 1.11.1 (December XX, 2023)
-  - Bugfixing - Fixed manager methods to return a promise in consumer modes when called while the SDK is not operational (not ready or destroyed).
+  - Bugfixing - Fixed manager methods in consumer modes to return results in a promise when the SDK is not operational (not ready or destroyed).
 
 1.11.0 (November 3, 2023)
   - Added support for Flag Sets on the SDK, which enables grouping feature flags and interacting with the group rather than individually (more details in our documentation):

--- a/src/sdkFactory/index.ts
+++ b/src/sdkFactory/index.ts
@@ -83,7 +83,7 @@ export function sdkFactory(params: ISdkFactoryParams): SplitIO.ICsSDK | SplitIO.
 
   // SDK client and manager
   const clientMethod = sdkClientMethodFactory(ctx);
-  const managerInstance = sdkManagerFactory(log, storage.splits, sdkReadinessManager);
+  const managerInstance = sdkManagerFactory(settings, storage.splits, sdkReadinessManager);
 
   syncManager && syncManager.start();
   signalListener && signalListener.start();

--- a/src/sdkFactory/types.ts
+++ b/src/sdkFactory/types.ts
@@ -1,9 +1,9 @@
 import { IIntegrationManager, IIntegrationFactoryParams } from '../integrations/types';
 import { ISignalListener } from '../listeners/types';
-import { ILogger } from '../logger/types';
 import { IReadinessManager, ISdkReadinessManager } from '../readiness/types';
+import type { sdkManagerFactory } from '../sdkManager';
 import { IFetch, ISplitApi, IEventSourceConstructor } from '../services/types';
-import { IStorageAsync, IStorageSync, ISplitsCacheSync, ISplitsCacheAsync, IStorageFactoryParams } from '../storages/types';
+import { IStorageAsync, IStorageSync, IStorageFactoryParams } from '../storages/types';
 import { ISyncManager } from '../sync/types';
 import { IImpressionObserver } from '../trackers/impressionObserver/types';
 import { IImpressionsTracker, IEventTracker, ITelemetryTracker, IFilterAdapter, IUniqueKeysTracker } from '../trackers/types';
@@ -87,11 +87,7 @@ export interface ISdkFactoryParams {
   syncManagerFactory?: (params: ISdkFactoryContextSync) => ISyncManager,
 
   // Sdk manager factory
-  sdkManagerFactory: (
-    log: ILogger,
-    splits: ISplitsCacheSync | ISplitsCacheAsync,
-    sdkReadinessManager: ISdkReadinessManager
-  ) => SplitIO.IManager | SplitIO.IAsyncManager,
+  sdkManagerFactory: typeof sdkManagerFactory,
 
   // Sdk client method factory (ISDK::client method).
   // It Allows to distinguish SDK clients with the client-side API (`ICsSDK`) or server-side API (`ISDK` or `IAsyncSDK`).

--- a/src/sdkManager/__tests__/index.asyncCache.spec.ts
+++ b/src/sdkManager/__tests__/index.asyncCache.spec.ts
@@ -9,6 +9,7 @@ import { KeyBuilderSS } from '../../storages/KeyBuilderSS';
 import { ISdkReadinessManager } from '../../readiness/types';
 import { loggerMock } from '../../logger/__tests__/sdkLogger.mock';
 import { metadata } from '../../storages/__tests__/KeyBuilder.spec';
+import { SplitIO } from '../../types';
 
 // @ts-expect-error
 const sdkReadinessManagerMock = {
@@ -21,16 +22,16 @@ const sdkReadinessManagerMock = {
 
 const keys = new KeyBuilderSS('prefix', metadata);
 
-describe('MANAGER API', () => {
+describe('Manager with async cache', () => {
 
   afterEach(() => { loggerMock.mockClear(); });
 
-  test('Async cache (In Redis)', async () => {
+  test('returns the expected data from the cache', async () => {
 
     /** Setup: create manager */
     const connection = new Redis({});
     const cache = new SplitsCacheInRedis(loggerMock, keys, connection);
-    const manager = sdkManagerFactory(loggerMock, cache, sdkReadinessManagerMock);
+    const manager = sdkManagerFactory({ mode: 'consumer', log: loggerMock }, cache, sdkReadinessManagerMock);
     await cache.clear();
     await cache.addSplit(splitObject.name, splitObject as any);
 
@@ -42,7 +43,6 @@ describe('MANAGER API', () => {
 
     const split = await manager.split(splitObject.name);
     expect(split).toEqual(splitView);
-
 
     /** List all the split names */
 
@@ -66,24 +66,51 @@ describe('MANAGER API', () => {
     expect(await manager.splits()).toEqual([]); // If the factory/client is destroyed, `manager.splits()` will return empty array either way since the storage is not valid.
     expect(await manager.names()).toEqual([]); // If the factory/client is destroyed, `manager.names()` will return empty array either way since the storage is not valid.
 
-
-
     /** Teardown */
     await cache.removeSplit(splitObject.name);
     await connection.quit();
   });
 
-  test('Async cache with error', async () => {
+  test('handles storage errors', async () => {
     // passing an empty object as wrapper, to make method calls of splits cache fail returning a rejected promise.
     // @ts-expect-error
     const cache = new SplitsCachePluggable(loggerMock, keys, wrapperAdapter(loggerMock, {}));
-    const manager = sdkManagerFactory(loggerMock, cache, sdkReadinessManagerMock);
+    const manager = sdkManagerFactory({ mode: 'consumer_partial', log: loggerMock }, cache, sdkReadinessManagerMock);
 
     expect(await manager.split('some_spplit')).toEqual(null);
     expect(await manager.splits()).toEqual([]);
     expect(await manager.names()).toEqual([]);
 
     expect(loggerMock.error).toBeCalledTimes(3); // 3 error logs, one for each attempt to call a wrapper method
+  });
+
+  test('returns empty results when not operational', async () => {
+    // SDK is flagged as destroyed
+    const sdkReadinessManagerMock = {
+      readinessManager: {
+        isReady: () => true,
+        isReadyFromCache: () => true,
+        isDestroyed: () => true
+      },
+      sdkStatus: {}
+    };
+    // @ts-expect-error
+    const manager = sdkManagerFactory({ mode: 'consumer_partial', log: loggerMock }, {}, sdkReadinessManagerMock) as SplitIO.IAsyncManager;
+
+    function validateManager() {
+      expect(manager.split('some_spplit')).resolves.toBe(null);
+      expect(manager.splits()).resolves.toEqual([]);
+      expect(manager.names()).resolves.toEqual([]);
+    }
+
+    validateManager();
+
+    // SDK is not ready
+    sdkReadinessManagerMock.readinessManager.isReady = () => false;
+    sdkReadinessManagerMock.readinessManager.isReadyFromCache = () => false;
+    sdkReadinessManagerMock.readinessManager.isDestroyed = () => false;
+
+    validateManager();
   });
 
 });

--- a/src/sdkManager/__tests__/index.syncCache.spec.ts
+++ b/src/sdkManager/__tests__/index.syncCache.spec.ts
@@ -14,11 +14,11 @@ const sdkReadinessManagerMock = {
   sdkStatus: jest.fn()
 } as ISdkReadinessManager;
 
-describe('MANAGER API / Sync cache (In Memory)', () => {
+describe('Manager with sync cache (In Memory)', () => {
 
   /** Setup: create manager */
   const cache = new SplitsCacheInMemory();
-  const manager = sdkManagerFactory(loggerMock, cache, sdkReadinessManagerMock);
+  const manager = sdkManagerFactory({ mode: 'standalone', log: loggerMock }, cache, sdkReadinessManagerMock);
   cache.addSplit(splitObject.name, splitObject as any);
 
   test('List all splits', () => {
@@ -55,6 +55,28 @@ describe('MANAGER API / Sync cache (In Memory)', () => {
     expect(manager.split(splitObject.name)).toBe(null); // If the factory/client is destroyed, `manager.split(validName)` will return null either way since the storage is not valid.
     expect(manager.splits()).toEqual([]); // If the factory/client is destroyed, `manager.splits()` will return empty array either way since the storage is not valid.
     expect(manager.names()).toEqual([]); // If the factory/client is destroyed, `manager.names()` will return empty array either way since the storage is not valid.
+  });
+
+  // @TODO tests for not operational
+
+  test('returns empty results when not operational', async () => {
+    // SDK is flagged as destroyed
+    sdkReadinessManagerMock.readinessManager.isDestroyed = () => true;
+
+    function validateManager() {
+      expect(manager.split('some_spplit')).toBe(null);
+      expect(manager.splits()).toEqual([]);
+      expect(manager.names()).toEqual([]);
+    }
+
+    validateManager();
+
+    // SDK is not ready
+    sdkReadinessManagerMock.readinessManager.isReady = () => false;
+    sdkReadinessManagerMock.readinessManager.isReadyFromCache = () => false;
+    sdkReadinessManagerMock.readinessManager.isDestroyed = () => false;
+
+    validateManager();
   });
 
 });

--- a/src/sdkManager/__tests__/index.syncCache.spec.ts
+++ b/src/sdkManager/__tests__/index.syncCache.spec.ts
@@ -57,8 +57,6 @@ describe('Manager with sync cache (In Memory)', () => {
     expect(manager.names()).toEqual([]); // If the factory/client is destroyed, `manager.names()` will return empty array either way since the storage is not valid.
   });
 
-  // @TODO tests for not operational
-
   test('returns empty results when not operational', async () => {
     // SDK is flagged as destroyed
     sdkReadinessManagerMock.readinessManager.isDestroyed = () => true;

--- a/src/trackers/impressionObserver/utils.ts
+++ b/src/trackers/impressionObserver/utils.ts
@@ -4,6 +4,6 @@ import { ISettings } from '../../types';
 /**
  * Storage is async if mode is consumer or partial consumer
  */
-export function isStorageSync(settings: ISettings) {
+export function isStorageSync(settings: Pick<ISettings, 'mode'>) {
   return [CONSUMER_MODE, CONSUMER_PARTIAL_MODE].indexOf(settings.mode) === -1 ? true : false;
 }


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Fixed manager methods to return the value wrapped in a promise in consumer modes when called while the SDK is not operational (i.e., not ready or destroyed).

## How do we test the changes introduced in this PR?

- Unit tests

## Extra Notes