### PR TITLE
Polishing

### DIFF
--- a/src/storages/inRedis/index.ts
+++ b/src/storages/inRedis/index.ts
@@ -45,7 +45,7 @@ export function InRedisStorage(options: InRedisStorageOptions = {}): IStorageAsy
     });
 
     return {
-      splits: new SplitsCacheInRedis(log, keys, redisClient),
+      splits: new SplitsCacheInRedis(log, keys, redisClient, settings.sync.__splitFiltersValidation),
       segments: new SegmentsCacheInRedis(log, keys, redisClient),
       impressions: new ImpressionsCacheInRedis(log, keys.buildImpressionsKey(), redisClient, metadata),
       impressionCounts: impressionCountsCache,


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

Added the `__splitFiltersValidation` argument to `SplitsCacheInRedis`, although it's not used at the moment as it's for 'producer' mode with Redis storage. This was done for code completeness and consistency with Pluggable storage.

## How do we test the changes introduced in this PR?

## Extra Notes