### PR TITLE
Update LocalStorage to clear storage if SDK key or filter criteria change

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 1.12.1 (December 12, 2023)
- - Updated PluggableStorage for producer mode, to clear the storage if it was previously synchronized with a different SDK key (i.e., a different environment) or different Split Filter criteria.
+ - Updated PluggableStorage, for producer mode, and LocalStorage, for standalone mode, to clear the storage before initiating the synchronization process if it was previously synchronized with a different SDK key (i.e., a different environment) or different Split Filter criteria.
 
 1.12.0 (December 4, 2023)
  - Added support for Flag Sets in "consumer" and "partial consumer" modes for Pluggable and Redis storages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.0",
+  "version": "1.12.1-rc.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.12.0",
+      "version": "1.12.1-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.5",
+  "version": "1.12.1-rc.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.12.1-rc.5",
+      "version": "1.12.1-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.7",
+  "version": "1.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.12.1-rc.7",
+      "version": "1.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.6",
+  "version": "1.12.1-rc.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.12.1-rc.6",
+      "version": "1.12.1-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.7",
+  "version": "1.12.1",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.6",
+  "version": "1.12.1-rc.7",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.1-rc.5",
+  "version": "1.12.1-rc.6",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.12.0",
+  "version": "1.12.1-rc.5",
   "description": "Split Javascript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/storages/KeyBuilderCS.ts
+++ b/src/storages/KeyBuilderCS.ts
@@ -45,8 +45,4 @@ export class KeyBuilderCS extends KeyBuilder {
   isSplitsCacheKey(key: string) {
     return this.regexSplitsCacheKey.test(key);
   }
-
-  buildSplitsFilterQueryKey() {
-    return `${this.prefix}.splits.filterQuery`;
-  }
 }

--- a/src/storages/KeyBuilderCS.ts
+++ b/src/storages/KeyBuilderCS.ts
@@ -9,7 +9,7 @@ export class KeyBuilderCS extends KeyBuilder {
   constructor(prefix: string, matchingKey: string) {
     super(prefix);
     this.matchingKey = matchingKey;
-    this.regexSplitsCacheKey = new RegExp(`^${prefix}\\.`);
+    this.regexSplitsCacheKey = new RegExp(`^${prefix}\\.(splits?|trafficType|flagSet)\\.`);
   }
 
   /**

--- a/src/storages/KeyBuilderCS.ts
+++ b/src/storages/KeyBuilderCS.ts
@@ -9,7 +9,7 @@ export class KeyBuilderCS extends KeyBuilder {
   constructor(prefix: string, matchingKey: string) {
     super(prefix);
     this.matchingKey = matchingKey;
-    this.regexSplitsCacheKey = new RegExp(`^${prefix}\\.(splits?|trafficType|flagSet)\\.`);
+    this.regexSplitsCacheKey = new RegExp(`^${prefix}\\.`);
   }
 
   /**

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -146,7 +146,7 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
     // when using a new split query, we must update it at the store
     if (this.updateNewFilter) {
-      this.log.info(LOG_PREFIX + 'SDK key or feature flag filter criteria was modified. Updating cache.');
+      this.log.info(LOG_PREFIX + 'SDK key or feature flag filter criteria was modified. Updating cache');
       const storageHashKey = this.keys.buildHashKey();
       try {
         localStorage.setItem(storageHashKey, this.storageHash);

--- a/src/storages/inLocalStorage/SplitsCacheInLocal.ts
+++ b/src/storages/inLocalStorage/SplitsCacheInLocal.ts
@@ -1,10 +1,12 @@
-import { ISplit, ISplitFiltersValidation } from '../../dtos/types';
+import { ISplit } from '../../dtos/types';
 import { AbstractSplitsCacheSync, usesSegments } from '../AbstractSplitsCacheSync';
 import { isFiniteNumber, toNumber, isNaNNumber } from '../../utils/lang';
 import { KeyBuilderCS } from '../KeyBuilderCS';
 import { ILogger } from '../../logger/types';
 import { LOG_PREFIX } from './constants';
 import { ISet, _Set, setToArray } from '../../utils/lang/sets';
+import { ISettings } from '../../types';
+import { getStorageHash } from '../KeyBuilder';
 
 /**
  * ISplitsCacheSync implementation that stores split definitions in browser LocalStorage.
@@ -12,7 +14,8 @@ import { ISet, _Set, setToArray } from '../../utils/lang/sets';
 export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
   private readonly keys: KeyBuilderCS;
-  private readonly splitFiltersValidation: ISplitFiltersValidation;
+  private readonly log: ILogger;
+  private readonly storageHash: string;
   private readonly flagSetsFilter: string[];
   private hasSync?: boolean;
   private updateNewFilter?: boolean;
@@ -22,11 +25,12 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
    * @param {number | undefined} expirationTimestamp
    * @param {ISplitFiltersValidation} splitFiltersValidation
    */
-  constructor(private readonly log: ILogger, keys: KeyBuilderCS, expirationTimestamp?: number, splitFiltersValidation: ISplitFiltersValidation = { queryString: null, groupedFilters: { bySet: [], byName: [], byPrefix: [] }, validFilters: [] }) {
+  constructor(settings: ISettings, keys: KeyBuilderCS, expirationTimestamp?: number) {
     super();
     this.keys = keys;
-    this.splitFiltersValidation = splitFiltersValidation;
-    this.flagSetsFilter = this.splitFiltersValidation.groupedFilters.bySet;
+    this.log = settings.log;
+    this.storageHash = getStorageHash(settings);
+    this.flagSetsFilter = settings.sync.__splitFiltersValidation.groupedFilters.bySet;
 
     this._checkExpiration(expirationTimestamp);
 
@@ -142,12 +146,10 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
 
     // when using a new split query, we must update it at the store
     if (this.updateNewFilter) {
-      this.log.info(LOG_PREFIX + 'Split filter query was modified. Updating cache.');
-      const queryKey = this.keys.buildSplitsFilterQueryKey();
-      const queryString = this.splitFiltersValidation.queryString;
+      this.log.info(LOG_PREFIX + 'SDK key or feature flag filter criteria was modified. Updating cache.');
+      const storageHashKey = this.keys.buildHashKey();
       try {
-        if (queryString) localStorage.setItem(queryKey, queryString);
-        else localStorage.removeItem(queryKey);
+        localStorage.setItem(storageHashKey, this.storageHash);
       } catch (e) {
         this.log.error(LOG_PREFIX + e);
       }
@@ -237,12 +239,12 @@ export class SplitsCacheInLocal extends AbstractSplitsCacheSync {
     }
   }
 
+  // @TODO eventually remove `_checkFilterQuery`. Cache should be cleared at the storage level, reusing same logic than PluggableStorage
   private _checkFilterQuery() {
-    const queryString = this.splitFiltersValidation.queryString;
-    const queryKey = this.keys.buildSplitsFilterQueryKey();
-    const currentQueryString = localStorage.getItem(queryKey);
+    const storageHashKey = this.keys.buildHashKey();
+    const storageHash = localStorage.getItem(storageHashKey);
 
-    if (currentQueryString !== queryString) {
+    if (storageHash !== this.storageHash) {
       try {
         // mark cache to update the new query filter on first successful splits fetch
         this.updateNewFilter = true;

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -230,9 +230,8 @@ test('SPLIT CACHE / LocalStorage / flag set cache tests without filters', () => 
   expect(cacheWithoutFilters.getNamesByFlagSets(['y'])).toEqual([emptySet]);
   expect(cacheWithoutFilters.getNamesByFlagSets(['o', 'n', 'e'])).toEqual([new _Set(['ff_one', 'ff_two']), new _Set(['ff_one']), new _Set(['ff_one', 'ff_three'])]);
 
-  // Validate that the cache is cleared when calling `clear` method
-  localStorage.setItem('something', 'something');
+  // Validate that the feature flag cache is cleared when calling `clear` method
   cacheWithoutFilters.clear();
-  expect(localStorage.length).toBe(1); // only 'something' should remain in localStorage
-  expect(localStorage.getItem(localStorage.key(0)!)).toBe('something');
+  expect(localStorage.length).toBe(1); // only 'SPLITIO.hash' should remain in localStorage
+  expect(localStorage.key(0)).toBe('SPLITIO.hash');
 });

--- a/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
+++ b/src/storages/inLocalStorage/__tests__/SplitsCacheInLocal.spec.ts
@@ -231,7 +231,8 @@ test('SPLIT CACHE / LocalStorage / flag set cache tests without filters', () => 
   expect(cacheWithoutFilters.getNamesByFlagSets(['o', 'n', 'e'])).toEqual([new _Set(['ff_one', 'ff_two']), new _Set(['ff_one']), new _Set(['ff_one', 'ff_three'])]);
 
   // Validate that the cache is cleared when calling `clear` method
+  localStorage.setItem('something', 'something');
   cacheWithoutFilters.clear();
-  expect(localStorage.length).toBe(1); // only 'SPLITIO.hash' should remain in localStorage
-  expect(localStorage.getItem(localStorage.key(0)!)).toBe('ccd10de1');
+  expect(localStorage.length).toBe(1); // only 'something' should remain in localStorage
+  expect(localStorage.getItem(localStorage.key(0)!)).toBe('something');
 });

--- a/src/storages/inLocalStorage/index.ts
+++ b/src/storages/inLocalStorage/index.ts
@@ -41,7 +41,7 @@ export function InLocalStorage(options: InLocalStorageOptions = {}): IStorageSyn
     const keys = new KeyBuilderCS(prefix, matchingKey as string);
     const expirationTimestamp = Date.now() - DEFAULT_CACHE_EXPIRATION_IN_MILLIS;
 
-    const splits = new SplitsCacheInLocal(log, keys, expirationTimestamp, __splitFiltersValidation);
+    const splits = new SplitsCacheInLocal(settings, keys, expirationTimestamp);
     const segments = new MySegmentsCacheInLocal(log, keys);
 
     return {


### PR DESCRIPTION
# Javascript commons library

## What did you accomplish?

- Update LocalStorage to clear storage and so do not emit SDK_READY_FROM_CACHE, if the SDK key or filter criteria change. Backward compatible with previous versions. 

## How do we test the changes introduced in this PR?

- Update E2E tests in SDKs

## Extra Notes