### PR TITLE
[SDKS-8273] Update WHITELIST and IN_LIST_SEMVER matchers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.14.0 (April XX, 2024)
+ - Added support for Semver matchers.
  - Updated impression label to 'unsupported matcher type' when the matcher type is not supported by the SDK.
 
 1.13.1 (January 10, 2024)

--- a/src/evaluator/matchers/__tests__/semver_inlist.spec.ts
+++ b/src/evaluator/matchers/__tests__/semver_inlist.spec.ts
@@ -2,16 +2,13 @@ import { matcherTypes } from '../matcherTypes';
 import { matcherFactory } from '../index';
 import { IMatcher, IMatcherDto } from '../../types';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
-import { _Set } from '../../../utils/lang/sets';
 
 describe('MATCHER IN LIST SEMVER', () => {
 
   test('List with some values', () => {
-    const list = new _Set(['1.1.1', '1.1.1+build']);
-
     const matcher = matcherFactory(loggerMock, {
       type: matcherTypes.IN_LIST_SEMVER,
-      value: list
+      value: ['1.1.1', '1.1.1+build']
     } as IMatcherDto) as IMatcher;
 
     expect(matcher('1.1.1+build')).toBe(true); // "key1" should be true
@@ -24,7 +21,7 @@ describe('MATCHER IN LIST SEMVER', () => {
     expect(() => {
       matcherFactory(loggerMock, {
         type: matcherTypes.IN_LIST_SEMVER,
-        value: new _Set()
+        value: [] as string[]
       } as IMatcherDto) as IMatcher;
     }).toThrowError('whitelistMatcherData is required for IN_LIST_SEMVER matcher type');
   });
@@ -33,7 +30,7 @@ describe('MATCHER IN LIST SEMVER', () => {
     expect(() => {
       matcherFactory(loggerMock, {
         type: matcherTypes.IN_LIST_SEMVER,
-        value: new _Set(['invalid', '1.2.3'])
+        value: ['invalid', '1.2.3']
       } as IMatcherDto) as IMatcher;
     }).toThrowError('Unable to convert to Semver, incorrect format: invalid');
   });

--- a/src/evaluator/matchers/__tests__/whitelist.spec.ts
+++ b/src/evaluator/matchers/__tests__/whitelist.spec.ts
@@ -1,13 +1,12 @@
 import { matcherTypes } from '../matcherTypes';
 import { matcherFactory } from '..';
-import { _Set } from '../../../utils/lang/sets';
 import { IMatcher, IMatcherDto } from '../../types';
 import { loggerMock } from '../../../logger/__tests__/sdkLogger.mock';
 
-test('MATCHER WHITELIST / should return true ONLY when the key is defined', function () {
+test('MATCHER WHITELIST / should return true ONLY when the value is in the list', function () {
   const matcher = matcherFactory(loggerMock, {
     type: matcherTypes.WHITELIST,
-    value: new _Set(['key'])
+    value: ['key']
   } as IMatcherDto) as IMatcher;
 
   expect(matcher('key')).toBe(true); // "key" should be true

--- a/src/evaluator/matchers/semver_inlist.ts
+++ b/src/evaluator/matchers/semver_inlist.ts
@@ -1,12 +1,12 @@
-import { setToArray, ISet, _Set } from '../../utils/lang/sets';
+import { _Set } from '../../utils/lang/sets';
 import { ILogger } from '../../logger/types';
 import { Semver } from '../../utils/Semver';
 
-export function inListSemverMatcherContext(log: ILogger, ruleAttr: ISet<string>) {
-  // @TODO move eventually to `matchersTransform` and validate for all matchers
-  if (!ruleAttr || ruleAttr.size === 0) throw new Error('whitelistMatcherData is required for IN_LIST_SEMVER matcher type');
+export function inListSemverMatcherContext(log: ILogger, ruleAttr: string[]) {
+  // @TODO ruleAttr validation should be done at the `parser` or `matchersTransform` level to reuse for all matchers
+  if (!ruleAttr || ruleAttr.length === 0) throw new Error('whitelistMatcherData is required for IN_LIST_SEMVER matcher type');
 
-  const listOfSemvers = new _Set(setToArray(ruleAttr).map((version) => new Semver(version).version));
+  const listOfSemvers = new _Set(ruleAttr.map((version) => new Semver(version).version));
 
   return function inListSemverMatcher(runtimeAttr: string): boolean {
     const runtimeSemver = new Semver(runtimeAttr).version;

--- a/src/evaluator/matchers/whitelist.ts
+++ b/src/evaluator/matchers/whitelist.ts
@@ -1,12 +1,14 @@
-import { setToArray, ISet } from '../../utils/lang/sets';
+import { _Set } from '../../utils/lang/sets';
 import { ILogger } from '../../logger/types';
 import { ENGINE_MATCHER_WHITELIST } from '../../logger/constants';
 
-export function whitelistMatcherContext(log: ILogger, ruleAttr: ISet<string>) {
-  return function whitelistMatcher(runtimeAttr: string): boolean {
-    let isInWhitelist = ruleAttr.has(runtimeAttr);
+export function whitelistMatcherContext(log: ILogger, ruleAttr: string[]) {
+  const whitelistSet = new _Set(ruleAttr);
 
-    log.debug(ENGINE_MATCHER_WHITELIST, [runtimeAttr, setToArray(ruleAttr).join(','), isInWhitelist]);
+  return function whitelistMatcher(runtimeAttr: string): boolean {
+    const isInWhitelist = whitelistSet.has(runtimeAttr);
+
+    log.debug(ENGINE_MATCHER_WHITELIST, [runtimeAttr, ruleAttr.join(','), isInWhitelist]);
 
     return isInWhitelist;
   };

--- a/src/evaluator/matchersTransform/__tests__/whitelist.spec.ts
+++ b/src/evaluator/matchersTransform/__tests__/whitelist.spec.ts
@@ -1,6 +1,6 @@
 import { whitelistTransform } from '../whitelist';
 
-test('TRANSFORMS / a whitelist Array should be casted into a Set', function () {
+test('TRANSFORMS / the whitelist array should be extracted', function () {
   let sample = {
     whitelist: [
       'u1',
@@ -9,17 +9,10 @@ test('TRANSFORMS / a whitelist Array should be casted into a Set', function () {
     ]
   };
 
-  let sampleSet = whitelistTransform(sample);
-
-  sample.whitelist.forEach(item => {
-    if (!sampleSet.has(item)) {
-      throw new Error(`Missing item ${item}`);
-    }
-  });
+  expect(whitelistTransform(sample)).toEqual(sample.whitelist);
 
   // @ts-ignore
-  sampleSet = whitelistTransform({});
-  expect(sampleSet.size).toBe(0); // Empty Set if passed an object without a whitelist
+  expect(whitelistTransform({ whitelist: null })).toBe(null); // Empty Set if passed an object without a whitelist
 
-  expect(true).toBe(true); // Everything looks fine
+  expect(whitelistTransform(null)).toBe(null); // Everything looks fine
 });

--- a/src/evaluator/matchersTransform/index.ts
+++ b/src/evaluator/matchersTransform/index.ts
@@ -2,7 +2,6 @@ import { findIndex } from '../../utils/lang';
 import { matcherTypes, matcherTypesMapper, matcherDataTypes } from '../matchers/matcherTypes';
 import { segmentTransform } from './segment';
 import { whitelistTransform } from './whitelist';
-import { setTransform } from './set';
 import { numericTransform } from './unaryNumeric';
 import { zeroSinceHH, zeroSinceSS } from '../convertions';
 import { IBetweenMatcherData, IInSegmentMatcherData, ISplitMatcher, IUnaryNumericMatcherData } from '../../dtos/types';
@@ -36,11 +35,6 @@ export function matchersTransform(matchers: ISplitMatcher[]): IMatcherDto[] {
 
     if (type === matcherTypes.IN_SEGMENT) {
       value = segmentTransform(userDefinedSegmentMatcherData as IInSegmentMatcherData);
-    } else if (
-      type === matcherTypes.WHITELIST ||
-      type === matcherTypes.IN_LIST_SEMVER
-    ) {
-      value = whitelistTransform(whitelistMatcherData);
     } else if (type === matcherTypes.EQUAL_TO) {
       value = numericTransform(unaryNumericMatcherData as IUnaryNumericMatcherData);
       dataType = matcherDataTypes.NUMBER;
@@ -75,14 +69,16 @@ export function matchersTransform(matchers: ISplitMatcher[]): IMatcherDto[] {
       type === matcherTypes.CONTAINS_ALL_OF_SET ||
       type === matcherTypes.PART_OF_SET
     ) {
-      value = setTransform(whitelistMatcherData);
+      value = whitelistTransform(whitelistMatcherData);
       dataType = matcherDataTypes.SET;
     } else if (
+      type === matcherTypes.WHITELIST ||
+      type === matcherTypes.IN_LIST_SEMVER ||
       type === matcherTypes.STARTS_WITH ||
       type === matcherTypes.ENDS_WITH ||
       type === matcherTypes.CONTAINS_STRING
     ) {
-      value = setTransform(whitelistMatcherData);
+      value = whitelistTransform(whitelistMatcherData);
     } else if (type === matcherTypes.IN_SPLIT_TREATMENT) {
       value = dependencyMatcherData;
       dataType = matcherDataTypes.NOT_SPECIFIED;

--- a/src/evaluator/matchersTransform/set.ts
+++ b/src/evaluator/matchersTransform/set.ts
@@ -1,8 +1,0 @@
-import { ISplitMatcher } from '../../dtos/types';
-
-/**
- * Extract whitelist array. Used by set and string matchers
- */
-export function setTransform(whitelistObject: ISplitMatcher['whitelistMatcherData']) {
-  return whitelistObject && whitelistObject.whitelist;
-}

--- a/src/evaluator/matchersTransform/whitelist.ts
+++ b/src/evaluator/matchersTransform/whitelist.ts
@@ -1,9 +1,8 @@
 import { ISplitMatcher } from '../../dtos/types';
-import { _Set } from '../../utils/lang/sets';
 
 /**
- * Extract whitelist as a set. Used by 'WHITELIST' matcher.
+ * Extract whitelist array.
  */
 export function whitelistTransform(whitelistObject: ISplitMatcher['whitelistMatcherData']) {
-  return new _Set(whitelistObject && whitelistObject.whitelist);
+  return whitelistObject && whitelistObject.whitelist;
 }

--- a/src/evaluator/types.ts
+++ b/src/evaluator/types.ts
@@ -1,6 +1,5 @@
 import { IBetweenMatcherData, IBetweenStringMatcherData, IDependencyMatcherData, MaybeThenable } from '../dtos/types';
 import { IStorageAsync, IStorageSync } from '../storages/types';
-import { ISet } from '../utils/lang/sets';
 import { SplitIO } from '../types';
 import { ILogger } from '../logger/types';
 
@@ -12,7 +11,7 @@ export interface IDependencyMatcherValue {
 export interface IMatcherDto {
   type: number
   name: string
-  value?: string | number | boolean | string[] | IDependencyMatcherData | ISet<string> | IBetweenMatcherData | IBetweenStringMatcherData | null
+  value?: string | number | boolean | string[] | IDependencyMatcherData | IBetweenMatcherData | IBetweenStringMatcherData | null
 
   attribute: string | null
   negate: boolean


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

- Removed the `set` matcher transform. All the matchers that uses the `whitelistMatcherData` property, reuse the `whitelist` matcher transform.
- Updated `WHITELIST` and `IN_LIST_SEMVER` matchers that now receive an array as ruleAttr from the `whitelist` matcher transform.

## How do we test the changes introduced in this PR?

## Extra Notes