### PR TITLE
Fixes for localhost mode on client-side SDKs (Browser SDK, React Native SDK, etc)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 1.15.1 (May 28, 2024)
  - Updated the Redis storage to lazily import the `ioredis` dependency when the storage is created. This prevents errors when the SDK is imported or bundled in a .mjs file, as `ioredis` is a CommonJS module.
  - Bugfixing - Restored some input validation error logs that were removed in version 1.12.0. The logs inform the user when the `getTreatment(s)` methods are called with an invalid value as feature flag name or flag set name.
+ - Bugfixing - Fixed localhost mode for client-side SDKs to emit SDK_UPDATE when mocked feature flags are updated in the `features` property of the config object (Related to issue https://github.com/splitio/javascript-browser-client/issues/119).
 
 1.15.0 (May 13, 2024)
  - Added an optional settings validation parameter to let overwrite the default flag spec version, used by the JS Synchronizer.

--- a/src/sync/offline/splitsParser/__tests__/splitsParserFromSettings.spec.ts
+++ b/src/sync/offline/splitsParser/__tests__/splitsParserFromSettings.spec.ts
@@ -1,0 +1,50 @@
+import { SplitIO } from '../../../../types';
+import { splitsParserFromSettingsFactory } from '../splitsParserFromSettings';
+
+const FEATURE_ON = { conditions: [{ conditionType: 'ROLLOUT', label: 'default rule', matcherGroup: { combiner: 'AND', matchers: [{ keySelector: null, matcherType: 'ALL_KEYS', negate: false }] }, partitions: [{ size: 100, treatment: 'on' }] }], configurations: {}, trafficTypeName: 'localhost' };
+const FEATURE_OFF = { conditions: [{ conditionType: 'ROLLOUT', label: 'default rule', matcherGroup: { combiner: 'AND', matchers: [{ keySelector: null, matcherType: 'ALL_KEYS', negate: false }] }, partitions: [{ size: 100, treatment: 'off' }] }], configurations: {}, trafficTypeName: 'localhost' };
+
+test('splitsParserFromSettingsFactory', () => {
+
+  const instance = splitsParserFromSettingsFactory();
+
+  const settings = { features: {} as SplitIO.MockedFeaturesMap };
+  expect(instance(settings)).toEqual({});
+
+  // Pass the same settings
+  expect(instance(settings)).toEqual(false);
+
+  // New features object with new content
+  settings.features = { feature1: 'on' };
+  expect(instance(settings)).toEqual({ feature1: FEATURE_ON });
+
+  // New features object but same content
+  settings.features = { feature1: 'on' };
+  expect(instance(settings)).toEqual(false);
+
+  // Update property
+  settings.features['feature1'] = 'off';
+  expect(instance(settings)).toEqual({ feature1: FEATURE_OFF });
+
+  // New settings object but same content
+  expect(instance({ features: { feature1: 'off' } })).toEqual(false);
+
+  // Update property. Same content but in a different format
+  settings.features['feature1'] = { treatment: 'off', config: null };
+  expect(instance(settings)).toEqual({ feature1: FEATURE_OFF });
+
+  // Add new feature flag property
+  settings.features['feature2'] = { treatment: 'on', config: null };
+  expect(instance(settings)).toEqual({ feature1: FEATURE_OFF, feature2: FEATURE_ON });
+
+  // New settings object but same content
+  expect(instance({ features: { feature1: { treatment: 'off', config: null }, feature2: { treatment: 'on', config: null } } })).toEqual(false);
+
+  // Update property
+  settings.features['feature2'].config = 'some_config';
+  expect(instance(settings)).toEqual({ feature1: FEATURE_OFF, feature2: { ...FEATURE_ON, configurations: { on: 'some_config' } } });
+
+  // @ts-expect-error No object implies no features
+  settings.features = undefined;
+  expect(instance(settings)).toEqual({});
+});

--- a/src/sync/offline/splitsParser/splitsParserFromSettings.ts
+++ b/src/sync/offline/splitsParser/splitsParserFromSettings.ts
@@ -1,6 +1,6 @@
 import { ISplitPartial } from '../../../dtos/types';
 import { ISettings, SplitIO } from '../../../types';
-import { isObject, forOwn } from '../../../utils/lang';
+import { isObject, forOwn, merge } from '../../../utils/lang';
 import { parseCondition } from './parseCondition';
 
 function hasTreatmentChanged(prev: string | SplitIO.TreatmentWithConfig, curr: string | SplitIO.TreatmentWithConfig) {
@@ -22,7 +22,7 @@ export function splitsParserFromSettingsFactory() {
 
     // Different amount of items
     if (names.length !== Object.keys(previousMock).length) {
-      previousMock = currentData;
+      previousMock = merge({}, currentData) as SplitIO.MockedFeaturesMap;
       return true;
     }
 
@@ -31,7 +31,7 @@ export function splitsParserFromSettingsFactory() {
       const newTreatment = hasTreatmentChanged(previousMock[name], currentData[name]);
       const changed = newSplit || newTreatment;
 
-      if (changed) previousMock = currentData;
+      if (changed) previousMock = merge({}, currentData) as SplitIO.MockedFeaturesMap;
 
       return changed;
     });
@@ -41,7 +41,7 @@ export function splitsParserFromSettingsFactory() {
    *
    * @param settings validated object with mocked features mapping.
    */
-  return function splitsParserFromSettings(settings: ISettings): false | Record<string, ISplitPartial> {
+  return function splitsParserFromSettings(settings: Pick<ISettings, 'features'>): false | Record<string, ISplitPartial> {
     const features = settings.features as SplitIO.MockedFeaturesMap || {};
 
     if (!mockUpdated(features)) return false;

--- a/src/utils/settingsValidation/index.ts
+++ b/src/utils/settingsValidation/index.ts
@@ -109,6 +109,8 @@ export function settingsValidation(config: unknown, validationParams: ISettingsV
 
   // creates a settings object merging base, defaults and config objects.
   const withDefaults = merge({}, base, defaults, config) as ISettings;
+  // Keeps reference to the `features` property
+  withDefaults.features = get(config, 'features');
 
   // ensure a valid logger.
   // First thing to validate, since other validators might use the logger.


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

 - Bugfixing - Fixed localhost mode for client-side SDKs to emit SDK_UPDATE when mocked feature flags are updated in the `features` property of the config object (Related to issue https://github.com/splitio/javascript-browser-client/issues/119).

## How do we test the changes introduced in this PR?

- Unit tests and integration test in the corresponding SDKs.

## Extra Notes
