### PR TITLE
Handle new MY_LARGE_SEGMENTS_UPDATE streaming event

### DIFF
--- a/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.SEGMENT_REMOVAL.1457552653000.json
+++ b/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.SEGMENT_REMOVAL.1457552653000.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"data\":\"{\\\"type\\\":\\\"MY_LARGE_SEGMENTS_UPDATE\\\",\\\"changeNumber\\\":1457552653000,\\\"largeSegments\\\":[\\\"employees\\\"],\\\"c\\\": 0,\\\"u\\\": 3,\\\"d\\\":\\\"\\\"}\"}"
+}

--- a/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.UNBOUNDED.1457552650000.json
+++ b/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.UNBOUNDED.1457552650000.json
@@ -1,0 +1,4 @@
+{
+  "type": "message",
+  "data": "{\"data\":\"{\\\"type\\\":\\\"MY_LARGE_SEGMENTS_UPDATE\\\",\\\"changeNumber\\\":1457552650000,\\\"largeSegments\\\":[],\\\"c\\\": 0,\\\"u\\\": 0,\\\"d\\\":\\\"\\\",\\\"i\\\":300,\\\"h\\\":0,\\\"s\\\":0}\"}"
+}

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -1,4 +1,4 @@
-import { ImpressionDataType, EventDataType, LastSync, HttpErrors, HttpLatencies, StreamingEvent, Method, OperationType, MethodExceptions, MethodLatencies, TelemetryUsageStatsPayload, UpdatesFromSSEEnum } from '../../sync/submitters/types';
+import { ImpressionDataType, EventDataType, LastSync, HttpErrors, HttpLatencies, StreamingEvent, Method, OperationType, MethodExceptions, MethodLatencies, TelemetryUsageStatsPayload, UpdatesFromSSEEnum, UpdatesFromSSE } from '../../sync/submitters/types';
 import { DEDUPED, DROPPED, LOCALHOST_MODE, QUEUED } from '../../utils/constants';
 import { findLatencyIndex } from '../findLatencyIndex';
 import { ISegmentsCacheSync, ISplitsCacheSync, IStorageFactoryParams, ITelemetryCacheSync } from '../types';
@@ -245,22 +245,16 @@ export class TelemetryCacheInMemory implements ITelemetryCacheSync {
     this.e = false;
   }
 
-  private updatesFromSSE = {
-    sp: 0,
-    ms: 0
-  };
+  private updatesFromSSE: UpdatesFromSSE = {};
 
   popUpdatesFromSSE() {
     const result = this.updatesFromSSE;
-    this.updatesFromSSE = {
-      sp: 0,
-      ms: 0,
-    };
+    this.updatesFromSSE = {};
     return result;
   }
 
   recordUpdatesFromSSE(type: UpdatesFromSSEEnum) {
-    this.updatesFromSSE[type]++;
+    this.updatesFromSSE[type] = (this.updatesFromSSE[type] || 0) + 1;
     this.e = false;
   }
 

--- a/src/storages/inMemory/__tests__/TelemetryCacheInMemory.spec.ts
+++ b/src/storages/inMemory/__tests__/TelemetryCacheInMemory.spec.ts
@@ -211,7 +211,7 @@ describe('TELEMETRY CACHE', () => {
   test('"isEmpty" and "pop" methods', () => {
     const cache = new TelemetryCacheInMemory();
     const expectedEmptyPayload = {
-      lS: {}, mL: {}, mE: {}, hE: {}, hL: {}, tR: 0, aR: 0, iQ: 0, iDe: 0, iDr: 0, spC: undefined, seC: undefined, skC: undefined, eQ: 0, eD: 0, sE: [], t: [], ufs:{ sp: 0, ms: 0 }
+      lS: {}, mL: {}, mE: {}, hE: {}, hL: {}, tR: 0, aR: 0, iQ: 0, iDe: 0, iDr: 0, spC: undefined, seC: undefined, skC: undefined, eQ: 0, eD: 0, sE: [], t: [], ufs: {}
     };
 
     // Initially, the cache is empty
@@ -228,20 +228,20 @@ describe('TELEMETRY CACHE', () => {
   });
 
   test('updates from SSE', () => {
-    expect(cache.popUpdatesFromSSE()).toEqual({sp: 0, ms: 0});
+    expect(cache.popUpdatesFromSSE()).toEqual({});
     cache.recordUpdatesFromSSE(SPLITS);
     cache.recordUpdatesFromSSE(SPLITS);
     cache.recordUpdatesFromSSE(SPLITS);
     cache.recordUpdatesFromSSE(MY_SEGMENT);
     cache.recordUpdatesFromSSE(MY_SEGMENT);
-    expect(cache.popUpdatesFromSSE()).toEqual({sp: 3, ms: 2});
-    expect(cache.popUpdatesFromSSE()).toEqual({sp: 0, ms: 0});
+    expect(cache.popUpdatesFromSSE()).toEqual({ sp: 3, ms: 2 });
+    expect(cache.popUpdatesFromSSE()).toEqual({});
     cache.recordUpdatesFromSSE(SPLITS);
     cache.recordUpdatesFromSSE(MY_SEGMENT);
     cache.recordUpdatesFromSSE(SPLITS);
     cache.recordUpdatesFromSSE(MY_SEGMENT);
-    expect(cache.popUpdatesFromSSE()).toEqual({sp: 2, ms: 2});
-    expect(cache.popUpdatesFromSSE()).toEqual({sp: 0, ms: 0});
+    expect(cache.popUpdatesFromSSE()).toEqual({ sp: 2, ms: 2 });
+    expect(cache.popUpdatesFromSSE()).toEqual({});
   });
 
 });

--- a/src/storages/pluggable/inMemoryWrapper.ts
+++ b/src/storages/pluggable/inMemoryWrapper.ts
@@ -7,7 +7,7 @@ import { ISet, setToArray, _Set } from '../../utils/lang/sets';
  * The `_cache` property is the object were items are stored.
  * Intended for testing purposes.
  *
- * @param connDelay delay in millis for `connect` resolve. If not provided, `connect` resolves inmediatelly.
+ * @param connDelay delay in millis for `connect` resolve. If not provided, `connect` resolves immediately.
  */
 export function inMemoryWrapperFactory(connDelay?: number): IPluggableStorageWrapper & { _cache: Record<string, string | string[] | ISet<string>>, _setConnDelay(connDelay: number): void } {
 

--- a/src/sync/__tests__/syncManagerOnline.spec.ts
+++ b/src/sync/__tests__/syncManagerOnline.spec.ts
@@ -29,7 +29,9 @@ const pollingManagerMock = {
   start: jest.fn(),
   stop: jest.fn(),
   isRunning: jest.fn(),
-  add: jest.fn(()=>{return {isrunning: () => true};}),
+  add: jest.fn(() => ({
+    msSyncTask: { isRunning: () => true }
+  })),
   get: jest.fn()
 };
 

--- a/src/sync/__tests__/syncTask.spec.ts
+++ b/src/sync/__tests__/syncTask.spec.ts
@@ -24,7 +24,7 @@ test('syncTaskFactory / start & stop methods for periodic execution', async () =
     // Calling `start` again has not effect
     expect(syncTask.start(...startArgs)).toBe(undefined);
 
-    // Calling `execute` inmediatelly executes the given task and returns its result
+    // Calling `execute` immediately executes the given task and returns its result
     result = await syncTask.execute(3, 4);
     expect(result).toBe(taskResult);
     expect(asyncTask).toHaveBeenLastCalledWith(3, 4);

--- a/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
+++ b/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { SSEHandlerFactory } from '..';
-import { PUSH_SUBSYSTEM_UP, PUSH_NONRETRYABLE_ERROR, PUSH_SUBSYSTEM_DOWN, PUSH_RETRYABLE_ERROR, MY_SEGMENTS_UPDATE, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE, MY_SEGMENTS_UPDATE_V2, ControlType } from '../../constants';
+import { PUSH_SUBSYSTEM_UP, PUSH_NONRETRYABLE_ERROR, PUSH_SUBSYSTEM_DOWN, PUSH_RETRYABLE_ERROR, MY_SEGMENTS_UPDATE, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE, MY_SEGMENTS_UPDATE_V2, MY_LARGE_SEGMENTS_UPDATE, ControlType } from '../../constants';
 import { loggerMock } from '../../../../logger/__tests__/sdkLogger.mock';
 
 // update messages
@@ -15,6 +15,10 @@ import boundedGzipMessage from '../../../../__tests__/mocks/message.V2.BOUNDED.G
 import keylistGzipMessage from '../../../../__tests__/mocks/message.V2.KEYLIST.GZIP.1457552652000.json';
 import segmentRemovalMessage from '../../../../__tests__/mocks/message.V2.SEGMENT_REMOVAL.1457552653000.json';
 import { keylists, bitmaps } from '../../__tests__/dataMocks';
+
+// update messages MY_LARGE_SEGMENTS_UPDATE
+import largeSegmentUnboundedMessage from '../../../../__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.UNBOUNDED.1457552650000.json';
+import largeSegmentRemovalMessage from '../../../../__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.SEGMENT_REMOVAL.1457552653000.json';
 
 // occupancy messages
 import occupancy1ControlPri from '../../../../__tests__/mocks/message.OCCUPANCY.1.control_pri.1586987434450.json';
@@ -168,6 +172,14 @@ test('`handlerMessage` for update notifications (NotificationProcessor) and stre
   expectedParams = [{ type: 'MY_SEGMENTS_UPDATE_V2', changeNumber: 1457552653000, c: 0, d: '', u: 3, segmentName: 'splitters' }];
   sseHandler.handleMessage(segmentRemovalMessage);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(MY_SEGMENTS_UPDATE_V2, ...expectedParams); // must emit MY_SEGMENTS_UPDATE_V2 with the message parsed data
+
+  expectedParams = [{ type: 'MY_LARGE_SEGMENTS_UPDATE', changeNumber: 1457552650000, c: 0, d: '', u: 0, largeSegments: [], i: 300, h: 0, s: 0 }];
+  sseHandler.handleMessage(largeSegmentUnboundedMessage);
+  expect(pushEmitter.emit).toHaveBeenLastCalledWith(MY_LARGE_SEGMENTS_UPDATE, ...expectedParams); // must emit MY_SEGMENTS_UPDATE_V2 with the message parsed data
+
+  expectedParams = [{ type: 'MY_LARGE_SEGMENTS_UPDATE', changeNumber: 1457552653000, c: 0, d: '', u: 3, largeSegments: ['employees'] }];
+  sseHandler.handleMessage(largeSegmentRemovalMessage);
+  expect(pushEmitter.emit).toHaveBeenLastCalledWith(MY_LARGE_SEGMENTS_UPDATE, ...expectedParams); // must emit MY_SEGMENTS_UPDATE_V2 with the message parsed data
 
   sseHandler.handleMessage(streamingReset);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(ControlType.STREAMING_RESET); // must emit STREAMING_RESET

--- a/src/sync/streaming/SSEHandler/index.ts
+++ b/src/sync/streaming/SSEHandler/index.ts
@@ -1,6 +1,6 @@
 import { errorParser, messageParser } from './NotificationParser';
 import { notificationKeeperFactory } from './NotificationKeeper';
-import { PUSH_RETRYABLE_ERROR, PUSH_NONRETRYABLE_ERROR, OCCUPANCY, CONTROL, MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE } from '../constants';
+import { PUSH_RETRYABLE_ERROR, PUSH_NONRETRYABLE_ERROR, OCCUPANCY, CONTROL, MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE, MY_LARGE_SEGMENTS_UPDATE } from '../constants';
 import { IPushEventEmitter } from '../types';
 import { ISseEventHandler } from '../SSEClient/types';
 import { INotificationError, INotificationMessage } from './types';
@@ -83,6 +83,7 @@ export function SSEHandlerFactory(log: ILogger, pushEmitter: IPushEventEmitter, 
         case SPLIT_UPDATE:
         case SEGMENT_UPDATE:
         case MY_SEGMENTS_UPDATE_V2:
+        case MY_LARGE_SEGMENTS_UPDATE:
         case SPLIT_KILL:
           pushEmitter.emit(parsedData.type, parsedData);
           break;

--- a/src/sync/streaming/SSEHandler/types.ts
+++ b/src/sync/streaming/SSEHandler/types.ts
@@ -38,7 +38,7 @@ export interface IMySegmentsUpdateV2Data {
 export interface IMyLargeSegmentsUpdateData {
   type: MY_LARGE_SEGMENTS_UPDATE,
   changeNumber: number,
-  largeSegment: string,
+  largeSegments: string[],
   c: Compression,
   d: string,
   u: UpdateStrategy,

--- a/src/sync/streaming/SSEHandler/types.ts
+++ b/src/sync/streaming/SSEHandler/types.ts
@@ -1,5 +1,5 @@
 import { ControlType } from '../constants';
-import { MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, SEGMENT_UPDATE, SPLIT_UPDATE, SPLIT_KILL, CONTROL, OCCUPANCY } from '../types';
+import { MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, SEGMENT_UPDATE, SPLIT_UPDATE, SPLIT_KILL, CONTROL, OCCUPANCY, MY_LARGE_SEGMENTS_UPDATE } from '../types';
 
 export interface IMySegmentsUpdateData {
   type: MY_SEGMENTS_UPDATE,
@@ -35,6 +35,18 @@ export interface IMySegmentsUpdateV2Data {
   u: UpdateStrategy,
 }
 
+export interface IMyLargeSegmentsUpdateData {
+  type: MY_LARGE_SEGMENTS_UPDATE,
+  changeNumber: number,
+  largeSegment: string,
+  c: Compression,
+  d: string,
+  u: UpdateStrategy,
+  i?: number, // time interval in millis
+  h?: number, // hash function. 0 for murmur3_32, 1 for murmur3_64
+  s?: number, // seed for hash function
+}
+
 export interface ISegmentUpdateData {
   type: SEGMENT_UPDATE,
   changeNumber: number,
@@ -68,6 +80,6 @@ export interface IOccupancyData {
   }
 }
 
-export type INotificationData = IMySegmentsUpdateData | IMySegmentsUpdateV2Data | ISegmentUpdateData | ISplitUpdateData | ISplitKillData | IControlData | IOccupancyData
+export type INotificationData = IMySegmentsUpdateData | IMySegmentsUpdateV2Data | IMyLargeSegmentsUpdateData | ISegmentUpdateData | ISplitUpdateData | ISplitKillData | IControlData | IOccupancyData
 export type INotificationMessage = { parsedData: INotificationData, channel: string, timestamp: number, data: string }
 export type INotificationError = Event & { parsedData?: any, message?: string }

--- a/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
@@ -1,13 +1,13 @@
 import { IMySegmentsSyncTask, MySegmentsData } from '../../polling/types';
 import { Backoff } from '../../../utils/Backoff';
 import { IUpdateWorker } from './types';
-import { MY_SEGMENT } from '../../../utils/constants';
 import { ITelemetryTracker } from '../../../trackers/types';
+import { UpdatesFromSSEEnum } from '../../submitters/types';
 
 /**
  * MySegmentsUpdateWorker factory
  */
-export function MySegmentsUpdateWorker(mySegmentsSyncTask: IMySegmentsSyncTask, telemetryTracker: ITelemetryTracker): IUpdateWorker {
+export function MySegmentsUpdateWorker(mySegmentsSyncTask: IMySegmentsSyncTask, telemetryTracker: ITelemetryTracker, updateType: UpdatesFromSSEEnum): IUpdateWorker {
 
   let maxChangeNumber = 0; // keeps the maximum changeNumber among queued events
   let currentChangeNumber = -1;
@@ -26,7 +26,7 @@ export function MySegmentsUpdateWorker(mySegmentsSyncTask: IMySegmentsSyncTask, 
       mySegmentsSyncTask.execute(_segmentsData, true).then((result) => {
         if (!isHandlingEvent) return; // halt if `stop` has been called
         if (result !== false) {// Unlike `Splits|SegmentsUpdateWorker`, we cannot use `mySegmentsCache.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
-          if (_segmentsData) telemetryTracker.trackUpdatesFromSSE(MY_SEGMENT);
+          if (_segmentsData) telemetryTracker.trackUpdatesFromSSE(updateType);
           currentChangeNumber = Math.max(currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `maxChangeNumber` was updated during fetch.
         }
         if (handleNewEvent) {

--- a/src/sync/streaming/__tests__/pushManager.spec.ts
+++ b/src/sync/streaming/__tests__/pushManager.spec.ts
@@ -33,7 +33,7 @@ test('pushManagerFactory returns undefined if EventSource is not available', () 
 
 describe('pushManager in client-side', () => {
 
-  test('does not connect to streaming if it is stopped inmediatelly after being started', async () => {
+  test('does not connect to streaming if it is stopped immediately after being started', async () => {
     const fetchAuthMock = jest.fn();
 
     const pushManager = pushManagerFactory({ // @ts-ignore
@@ -122,7 +122,7 @@ describe('pushManager in client-side', () => {
 
 describe('pushManager in server-side', () => {
 
-  test('does not connect to streaming if it is stopped inmediatelly after being started', async () => {
+  test('does not connect to streaming if it is stopped immediately after being started', async () => {
     const fetchAuthMock = jest.fn();
 
     const pushManager = pushManagerFactory({ // @ts-ignore

--- a/src/sync/streaming/constants.ts
+++ b/src/sync/streaming/constants.ts
@@ -30,6 +30,7 @@ export const MY_SEGMENTS_UPDATE_V2 = 'MY_SEGMENTS_UPDATE_V2';
 export const SEGMENT_UPDATE = 'SEGMENT_UPDATE';
 export const SPLIT_KILL = 'SPLIT_KILL';
 export const SPLIT_UPDATE = 'SPLIT_UPDATE';
+export const MY_LARGE_SEGMENTS_UPDATE = 'MY_LARGE_SEGMENTS_UPDATE';
 
 // Control-type push notifications, handled by NotificationKeeper
 export const CONTROL = 'CONTROL';

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -11,14 +11,14 @@ import { authenticateFactory, hashUserKey } from './AuthClient';
 import { forOwn } from '../../utils/lang';
 import { SSEClient } from './SSEClient';
 import { getMatching } from '../../utils/key';
-import { MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, PUSH_NONRETRYABLE_ERROR, PUSH_SUBSYSTEM_DOWN, SECONDS_BEFORE_EXPIRATION, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE, PUSH_RETRYABLE_ERROR, PUSH_SUBSYSTEM_UP, ControlType } from './constants';
+import { MY_SEGMENTS_UPDATE, MY_SEGMENTS_UPDATE_V2, PUSH_NONRETRYABLE_ERROR, PUSH_SUBSYSTEM_DOWN, SECONDS_BEFORE_EXPIRATION, SEGMENT_UPDATE, SPLIT_KILL, SPLIT_UPDATE, PUSH_RETRYABLE_ERROR, PUSH_SUBSYSTEM_UP, ControlType, MY_LARGE_SEGMENTS_UPDATE } from './constants';
 import { STREAMING_FALLBACK, STREAMING_REFRESH_TOKEN, STREAMING_CONNECTING, STREAMING_DISABLED, ERROR_STREAMING_AUTH, STREAMING_DISCONNECTING, STREAMING_RECONNECT, STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, STREAMING_PARSING_SPLIT_UPDATE } from '../../logger/constants';
-import { KeyList, UpdateStrategy } from './SSEHandler/types';
+import { IMyLargeSegmentsUpdateData, IMySegmentsUpdateV2Data, KeyList, UpdateStrategy } from './SSEHandler/types';
 import { isInBitmap, parseBitmap, parseFFUpdatePayload, parseKeyList } from './parseUtils';
 import { ISet, _Set } from '../../utils/lang/sets';
 import { Hash64, hash64 } from '../../utils/murmur3/murmur3_64';
 import { IAuthTokenPushEnabled } from './AuthClient/types';
-import { TOKEN_REFRESH, AUTH_REJECTION } from '../../utils/constants';
+import { TOKEN_REFRESH, AUTH_REJECTION, MY_LARGE_SEGMENT, MY_SEGMENT } from '../../utils/constants';
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 import { IUpdateWorker } from './UpdateWorkers/types';
 
@@ -64,7 +64,7 @@ export function pushManagerFactory(
   const userKeyHashes: Record<string, string> = {};
   // [Only for client-side] map of user keys to their corresponding hash64 and MySegmentsUpdateWorkers.
   // Hash64 is used to process MY_SEGMENTS_UPDATE_V2 events and dispatch actions to the corresponding MySegmentsUpdateWorker.
-  const clients: Record<string, { hash64: Hash64, worker: IUpdateWorker }> = {};
+  const clients: Record<string, { hash64: Hash64, worker: IUpdateWorker, workerLarge?: IUpdateWorker }> = {};
 
   // [Only for client-side] variable to flag that a new client was added. It is needed to reconnect streaming.
   let connectForNewClient = false;
@@ -171,7 +171,10 @@ export function pushManagerFactory(
   // cancel scheduled fetch retries of Splits, Segments, and MySegments Update Workers
   function stopWorkers() {
     splitsUpdateWorker.stop();
-    if (userKey) forOwn(clients, ({ worker }) => worker.stop());
+    if (userKey) forOwn(clients, ({ worker, workerLarge }) => {
+      worker.stop();
+      workerLarge && workerLarge.stop();
+    });
     else segmentsUpdateWorker!.stop();
   }
 
@@ -236,6 +239,83 @@ export function pushManagerFactory(
     splitsUpdateWorker.put(parsedData);
   });
 
+  function handleMySegmentsUpdate(parsedData: IMySegmentsUpdateV2Data | IMyLargeSegmentsUpdateData) {
+    const isLS = parsedData.type === MY_LARGE_SEGMENTS_UPDATE;
+
+    switch (parsedData.u) {
+      case UpdateStrategy.BoundedFetchRequest: {
+        let bitmap: Uint8Array;
+        try {
+          bitmap = parseBitmap(parsedData.d, parsedData.c);
+        } catch (e) {
+          log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['BoundedFetchRequest', e]);
+          break;
+        }
+
+        forOwn(clients, ({ hash64, worker, workerLarge }) => {
+          if (isInBitmap(bitmap, hash64.hex)) {
+            isLS ?
+              workerLarge && workerLarge.put(parsedData.changeNumber) :
+              worker.put(parsedData.changeNumber);
+          }
+        });
+        return;
+      }
+      case UpdateStrategy.KeyList: {
+        let keyList: KeyList, added: ISet<string>, removed: ISet<string>;
+        try {
+          keyList = parseKeyList(parsedData.d, parsedData.c);
+          added = new _Set(keyList.a);
+          removed = new _Set(keyList.r);
+        } catch (e) {
+          log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['KeyList', e]);
+          break;
+        }
+
+        forOwn(clients, ({ hash64, worker, workerLarge }) => {
+          const add = added.has(hash64.dec) ? true : removed.has(hash64.dec) ? false : undefined;
+          if (add !== undefined) {
+            isLS ?
+              workerLarge && workerLarge.put(parsedData.changeNumber, {
+                name: parsedData.largeSegment,
+                add
+              }) :
+              worker.put(parsedData.changeNumber, {
+                name: parsedData.segmentName,
+                add
+              });
+          }
+        });
+        return;
+      }
+      case UpdateStrategy.SegmentRemoval:
+        if (!(parsedData as IMySegmentsUpdateV2Data).segmentName && !(parsedData as IMyLargeSegmentsUpdateData).largeSegment) {
+          log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['SegmentRemoval', 'No segment name was provided']);
+          break;
+        }
+
+        forOwn(clients, ({ worker, workerLarge }) => {
+          isLS ?
+            workerLarge && workerLarge.put(parsedData.changeNumber, {
+              name: parsedData.largeSegment,
+              add: false
+            }) :
+            worker.put(parsedData.changeNumber, {
+              name: parsedData.segmentName,
+              add: false
+            });
+        });
+        return;
+    }
+
+    // `UpdateStrategy.UnboundedFetchRequest` and fallbacks of other cases
+    forOwn(clients, ({ worker, workerLarge }) => {
+      isLS ?
+        workerLarge && workerLarge.put(parsedData.changeNumber) :
+        worker.put(parsedData.changeNumber);
+    });
+  }
+
   if (userKey) {
     pushEmitter.on(MY_SEGMENTS_UPDATE, function handleMySegmentsUpdate(parsedData, channel) {
       const userKeyHash = channel.split('_')[2];
@@ -246,66 +326,9 @@ export function pushManagerFactory(
           parsedData.includesPayload ? parsedData.segmentList ? parsedData.segmentList : [] : undefined);
       }
     });
-    pushEmitter.on(MY_SEGMENTS_UPDATE_V2, function handleMySegmentsUpdate(parsedData) {
-      switch (parsedData.u) {
-        case UpdateStrategy.BoundedFetchRequest: {
-          let bitmap: Uint8Array;
-          try {
-            bitmap = parseBitmap(parsedData.d, parsedData.c);
-          } catch (e) {
-            log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['BoundedFetchRequest', e]);
-            break;
-          }
 
-          forOwn(clients, ({ hash64, worker }) => {
-            if (isInBitmap(bitmap, hash64.hex)) {
-              worker.put(parsedData.changeNumber); // fetch mySegments
-            }
-          });
-          return;
-        }
-        case UpdateStrategy.KeyList: {
-          let keyList: KeyList, added: ISet<string>, removed: ISet<string>;
-          try {
-            keyList = parseKeyList(parsedData.d, parsedData.c);
-            added = new _Set(keyList.a);
-            removed = new _Set(keyList.r);
-          } catch (e) {
-            log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['KeyList', e]);
-            break;
-          }
-
-          forOwn(clients, ({ hash64, worker }) => {
-            const add = added.has(hash64.dec) ? true : removed.has(hash64.dec) ? false : undefined;
-            if (add !== undefined) {
-              worker.put(parsedData.changeNumber, {
-                name: parsedData.segmentName,
-                add
-              });
-            }
-          });
-          return;
-        }
-        case UpdateStrategy.SegmentRemoval:
-          if (!parsedData.segmentName) {
-            log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['SegmentRemoval', 'No segment name was provided']);
-            break;
-          }
-
-          forOwn(clients, ({ worker }) =>
-            worker.put(parsedData.changeNumber, {
-              name: parsedData.segmentName,
-              add: false
-            })
-          );
-          return;
-      }
-
-      // `UpdateStrategy.UnboundedFetchRequest` and fallbacks of other cases
-      forOwn(clients, ({ worker }) => {
-        worker.put(parsedData.changeNumber);
-      });
-    });
+    pushEmitter.on(MY_SEGMENTS_UPDATE_V2, handleMySegmentsUpdate);
+    pushEmitter.on(MY_LARGE_SEGMENTS_UPDATE, handleMySegmentsUpdate);
   } else {
     pushEmitter.on(SEGMENT_UPDATE, segmentsUpdateWorker!.put);
   }
@@ -328,7 +351,7 @@ export function pushManagerFactory(
         if (disabled || disconnected === false) return;
         disconnected = false;
 
-        if (userKey) this.add(userKey, pollingManager.segmentsSyncTask as IMySegmentsSyncTask); // client-side
+        if (userKey) this.add(userKey, pollingManager.segmentsSyncTask, pollingManager.largeSegmentsSyncTask!); // client-side
         else setTimeout(connectPush); // server-side runs in next cycle as in client-side, for consistency with client-side
       },
 
@@ -338,12 +361,16 @@ export function pushManagerFactory(
       },
 
       // [Only for client-side]
-      add(userKey: string, mySegmentsSyncTask: IMySegmentsSyncTask) {
+      add(userKey: string, mySegmentsSyncTask: IMySegmentsSyncTask, myLargeSegmentsSyncTask?: IMySegmentsSyncTask) {
         const hash = hashUserKey(userKey);
 
         if (!userKeyHashes[hash]) {
           userKeyHashes[hash] = userKey;
-          clients[userKey] = { hash64: hash64(userKey), worker: MySegmentsUpdateWorker(mySegmentsSyncTask, telemetryTracker) };
+          clients[userKey] = {
+            hash64: hash64(userKey),
+            worker: MySegmentsUpdateWorker(mySegmentsSyncTask, telemetryTracker, MY_SEGMENT),
+            workerLarge: myLargeSegmentsSyncTask ? MySegmentsUpdateWorker(myLargeSegmentsSyncTask, telemetryTracker, MY_LARGE_SEGMENT) : undefined
+          };
           connectForNewClient = true; // we must reconnect on start, to listen the channel for the new user key
 
           // Reconnects in case of a new client.

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -277,7 +277,7 @@ export function pushManagerFactory(
           if (add !== undefined) {
             isLS ?
               workerLarge && workerLarge.put(parsedData.changeNumber, {
-                name: parsedData.largeSegment,
+                name: parsedData.largeSegments[0],
                 add
               }) :
               worker.put(parsedData.changeNumber, {
@@ -289,16 +289,18 @@ export function pushManagerFactory(
         return;
       }
       case UpdateStrategy.SegmentRemoval:
-        if (!(parsedData as IMySegmentsUpdateV2Data).segmentName && !(parsedData as IMyLargeSegmentsUpdateData).largeSegment) {
+        if ((isLS && parsedData.largeSegments.length === 0) || (!isLS && !parsedData.segmentName)) {
           log.warn(STREAMING_PARSING_MY_SEGMENTS_UPDATE_V2, ['SegmentRemoval', 'No segment name was provided']);
           break;
         }
 
         forOwn(clients, ({ worker, workerLarge }) => {
           isLS ?
-            workerLarge && workerLarge.put(parsedData.changeNumber, {
-              name: parsedData.largeSegment,
-              add: false
+            workerLarge && parsedData.largeSegments.forEach(largeSegment => {
+              workerLarge.put(parsedData.changeNumber, {
+                name: largeSegment,
+                add: false
+              });
             }) :
             worker.put(parsedData.changeNumber, {
               name: parsedData.segmentName,

--- a/src/sync/streaming/types.ts
+++ b/src/sync/streaming/types.ts
@@ -1,4 +1,4 @@
-import { IMySegmentsUpdateData, IMySegmentsUpdateV2Data, ISegmentUpdateData, ISplitUpdateData, ISplitKillData } from './SSEHandler/types';
+import { IMySegmentsUpdateData, IMySegmentsUpdateV2Data, ISegmentUpdateData, ISplitUpdateData, ISplitKillData, IMyLargeSegmentsUpdateData } from './SSEHandler/types';
 import { ITask } from '../types';
 import { IMySegmentsSyncTask } from '../polling/types';
 import { IEventEmitter } from '../../types';
@@ -16,16 +16,18 @@ export type MY_SEGMENTS_UPDATE_V2 = 'MY_SEGMENTS_UPDATE_V2';
 export type SEGMENT_UPDATE = 'SEGMENT_UPDATE';
 export type SPLIT_KILL = 'SPLIT_KILL';
 export type SPLIT_UPDATE = 'SPLIT_UPDATE';
+export type MY_LARGE_SEGMENTS_UPDATE = 'MY_LARGE_SEGMENTS_UPDATE';
 
 // Control-type push notifications, handled by NotificationKeeper
 export type CONTROL = 'CONTROL';
 export type OCCUPANCY = 'OCCUPANCY';
 
-export type IPushEvent = PUSH_SUBSYSTEM_UP | PUSH_SUBSYSTEM_DOWN | PUSH_NONRETRYABLE_ERROR | PUSH_RETRYABLE_ERROR | MY_SEGMENTS_UPDATE | MY_SEGMENTS_UPDATE_V2 | SEGMENT_UPDATE | SPLIT_UPDATE | SPLIT_KILL | ControlType.STREAMING_RESET
+export type IPushEvent = PUSH_SUBSYSTEM_UP | PUSH_SUBSYSTEM_DOWN | PUSH_NONRETRYABLE_ERROR | PUSH_RETRYABLE_ERROR | MY_SEGMENTS_UPDATE | MY_SEGMENTS_UPDATE_V2 | SEGMENT_UPDATE | SPLIT_UPDATE | SPLIT_KILL | MY_LARGE_SEGMENTS_UPDATE | ControlType.STREAMING_RESET
 
 type IParsedData<T extends IPushEvent> =
   T extends MY_SEGMENTS_UPDATE ? IMySegmentsUpdateData :
   T extends MY_SEGMENTS_UPDATE_V2 ? IMySegmentsUpdateV2Data :
+  T extends MY_LARGE_SEGMENTS_UPDATE ? IMyLargeSegmentsUpdateData :
   T extends SEGMENT_UPDATE ? ISegmentUpdateData :
   T extends SPLIT_UPDATE ? ISplitUpdateData :
   T extends SPLIT_KILL ? ISplitKillData : undefined;
@@ -45,6 +47,6 @@ export interface IPushEventEmitter extends IEventEmitter {
  */
 export interface IPushManager extends ITask, IPushEventEmitter {
   // Methods used in client-side, to support multiple clients
-  add(userKey: string, mySegmentsSyncTask: IMySegmentsSyncTask): void,
+  add(userKey: string, mySegmentsSyncTask: IMySegmentsSyncTask, myLargeSegmentsSyncTask?: IMySegmentsSyncTask): void,
   remove(userKey: string): void
 }

--- a/src/sync/submitters/__tests__/eventsSubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/eventsSubmitter.spec.ts
@@ -31,7 +31,7 @@ describe('Events submitter', () => {
 
     eventsSubmitter.start();
     expect(eventsSubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running
-    expect(eventsSubmitter.isExecuting()).toEqual(false); // but not executed immediatelly if there is a push window
+    expect(eventsSubmitter.isExecuting()).toEqual(false); // but not executed immediately if there is a push window
     expect(eventsCacheMock.isEmpty).not.toBeCalled();
 
     // If queue is full, submitter should be executed
@@ -55,7 +55,7 @@ describe('Events submitter', () => {
 
     eventsSubmitter.start();
     expect(eventsSubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running
-    expect(eventsSubmitter.isExecuting()).toEqual(true); // and executes immediatelly if there isn't a push window
+    expect(eventsSubmitter.isExecuting()).toEqual(true); // and executes immediately if there isn't a push window
     expect(eventsCacheMock.isEmpty).toBeCalledTimes(1);
 
     // If queue is full, submitter is executed again after current execution is resolved

--- a/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
@@ -39,7 +39,7 @@ describe('Telemetry submitter', () => {
 
     telemetrySubmitter.start();
     expect(telemetrySubmitter.isRunning()).toEqual(true); // Submitter should be flagged as running
-    expect(telemetrySubmitter.isExecuting()).toEqual(false); // but not executed immediatelly (first push window)
+    expect(telemetrySubmitter.isExecuting()).toEqual(false); // but not executed immediately (first push window)
     expect(popSpy).toBeCalledTimes(0);
 
     // Await first periodic execution

--- a/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
+++ b/src/sync/submitters/__tests__/telemetrySubmitter.spec.ts
@@ -48,7 +48,7 @@ describe('Telemetry submitter', () => {
     expect(isEmptySpy).toBeCalledTimes(1);
     expect(popSpy).toBeCalledTimes(1);
     expect(postMetricsUsage).toBeCalledWith(JSON.stringify({
-      lS: {}, mL: {}, mE: {}, hE: {}, hL: {}, tR: 0, aR: 0, iQ: 0, iDe: 0, iDr: 0, spC: 0, seC: 0, skC: 0, eQ: 0, eD: 0, sE: [], t: ['tag1'], ufs:{ sp: 0, ms: 0 }
+      lS: {}, mL: {}, mE: {}, hE: {}, hL: {}, tR: 0, aR: 0, iQ: 0, iDe: 0, iDr: 0, spC: 0, seC: 0, skC: 0, eQ: 0, eD: 0, sE: [], t: ['tag1'], ufs: {}
     }));
 
     // Await second periodic execution

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -159,7 +159,7 @@ export type TelemetryUsageStats = {
 
 // amount of instant updates that we are doing by avoiding fetching to Split servers
 export type UpdatesFromSSE = {
-  sp: number, // splits
+  sp?: number, // splits
   ms?: number, // my segments
   mls?: number // my large segments
 }

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -103,7 +103,7 @@ export type DROPPED = 1;
 export type DEDUPED = 2;
 export type ImpressionDataType = QUEUED | DROPPED | DEDUPED
 export type EventDataType = QUEUED | DROPPED;
-export type UpdatesFromSSEEnum = SPLITS | MY_SEGMENT;
+export type UpdatesFromSSEEnum = SPLITS | MY_SEGMENT | MY_LARGE_SEGMENT;
 
 export type SPLITS = 'sp';
 export type IMPRESSIONS = 'im';
@@ -161,6 +161,7 @@ export type TelemetryUsageStats = {
 export type UpdatesFromSSE = {
   sp: number, // splits
   ms?: number, // my segments
+  mls?: number // my large segments
 }
 
 // 'metrics/usage' JSON request body
@@ -181,7 +182,7 @@ export type TelemetryUsageStatsPayload = TelemetryUsageStats & {
   eD: number, // eventsDropped
   sE: Array<StreamingEvent>, // streamingEvents
   t?: Array<string>, // tags
-  ufs?: UpdatesFromSSE, //UpdatesFromSSE
+  ufs?: UpdatesFromSSE, // instant updates
 }
 
 /**

--- a/src/sync/syncManagerOnline.ts
+++ b/src/sync/syncManagerOnline.ts
@@ -7,7 +7,7 @@ import { IPollingManager, IPollingManagerCS } from './polling/types';
 import { PUSH_SUBSYSTEM_UP, PUSH_SUBSYSTEM_DOWN } from './streaming/constants';
 import { SYNC_START_POLLING, SYNC_CONTINUE_POLLING, SYNC_STOP_POLLING } from '../logger/constants';
 import { isConsentGranted } from '../consent';
-import { IN_SEGMENT, POLLING, STREAMING, SYNC_MODE_UPDATE } from '../utils/constants';
+import { IN_LARGE_SEGMENT, IN_SEGMENT, POLLING, STREAMING, SYNC_MODE_UPDATE } from '../utils/constants';
 import { ISdkFactoryContextSync } from '../sdkFactory/types';
 
 /**
@@ -141,36 +141,44 @@ export function syncManagerOnlineFactory(
       shared(matchingKey: string, readinessManager: IReadinessManager, storage: IStorageSync) {
         if (!pollingManager) return;
 
-        const mySegmentsSyncTask = (pollingManager as IPollingManagerCS).add(matchingKey, readinessManager, storage);
+        const { msSyncTask, mlsSyncTask } = (pollingManager as IPollingManagerCS).add(matchingKey, readinessManager, storage);
 
         return {
-          isRunning: mySegmentsSyncTask.isRunning,
+          isRunning: msSyncTask.isRunning,
           start() {
             if (syncEnabled) {
               if (pushManager) {
                 if (pollingManager!.isRunning()) {
                   // if doing polling, we must start the periodic fetch of data
-                  if (storage.splits.usesMatcher(IN_SEGMENT)) mySegmentsSyncTask.start();
+                  if (storage.splits.usesMatcher(IN_SEGMENT)) msSyncTask.start();
+                  if (mlsSyncTask && storage.splits.usesMatcher(IN_LARGE_SEGMENT)) mlsSyncTask.start();
                 } else {
                   // if not polling, we must execute the sync task for the initial fetch
                   // of segments since `syncAll` was already executed when starting the main client
-                  mySegmentsSyncTask.execute();
+                  msSyncTask.execute();
+                  mlsSyncTask && mlsSyncTask.execute();
                 }
-                pushManager.add(matchingKey, mySegmentsSyncTask);
+                pushManager.add(matchingKey, msSyncTask, mlsSyncTask);
               } else {
-                if (storage.splits.usesMatcher(IN_SEGMENT)) mySegmentsSyncTask.start();
+                if (storage.splits.usesMatcher(IN_SEGMENT)) msSyncTask.start();
+                if (mlsSyncTask && storage.splits.usesMatcher(IN_LARGE_SEGMENT)) mlsSyncTask.start();
               }
             } else {
-              if (!readinessManager.isReady()) mySegmentsSyncTask.execute();
+              if (!readinessManager.isReady()) {
+                msSyncTask.execute();
+                mlsSyncTask && mlsSyncTask.execute();
+              }
             }
           },
           stop() {
             // check in case `client.destroy()` has been invoked more than once for the same client
-            const mySegmentsSyncTask = (pollingManager as IPollingManagerCS).get(matchingKey);
-            if (mySegmentsSyncTask) {
+            const syncTasks = (pollingManager as IPollingManagerCS).get(matchingKey);
+            if (syncTasks) {
+              const { msSyncTask, mlsSyncTask } = syncTasks;
               // stop syncing
               if (pushManager) pushManager.remove(matchingKey);
-              if (mySegmentsSyncTask.isRunning()) mySegmentsSyncTask.stop();
+              if (msSyncTask.isRunning()) msSyncTask.stop();
+              if (mlsSyncTask && mlsSyncTask.isRunning()) mlsSyncTask.stop();
 
               (pollingManager as IPollingManagerCS).remove(matchingKey);
             }


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

- Add handler for new `MY_LARGE_SEGMENTS_UPDATE` event, refactoring and reusing the same handler as `MY_SEGMENTS_UPDATE_V2`, since they share similar update strategies (at the moment, removal and unbound).
- Updated telemetry to record instant updates from `MY_LARGE_SEGMENTS_UPDATE` events with removal update strategy.

## How do we test the changes introduced in this PR?

- Unit tests.

## Extra Notes