### PR TITLE
Large Segments support: updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.6",
+  "version": "1.16.1-rc.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.16.1-rc.6",
+      "version": "1.16.1-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.5",
+  "version": "1.16.1-rc.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.16.1-rc.5",
+      "version": "1.16.1-rc.6",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.7",
+  "version": "1.16.1-rc.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "1.16.1-rc.7",
+      "version": "1.16.1-rc.8",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.6",
+  "version": "1.16.1-rc.7",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.7",
+  "version": "1.16.1-rc.8",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "1.16.1-rc.5",
+  "version": "1.16.1-rc.6",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.UNBOUNDED.1457552650000.json
+++ b/src/__tests__/mocks/message.MY_LARGE_SEGMENTS_UPDATE.UNBOUNDED.1457552650000.json
@@ -1,4 +1,4 @@
 {
   "type": "message",
-  "data": "{\"data\":\"{\\\"type\\\":\\\"MY_LARGE_SEGMENTS_UPDATE\\\",\\\"changeNumber\\\":1457552650000,\\\"largeSegments\\\":[],\\\"c\\\": 0,\\\"u\\\": 0,\\\"d\\\":\\\"\\\",\\\"i\\\":300,\\\"h\\\":0,\\\"s\\\":0}\"}"
+  "data": "{\"data\":\"{\\\"type\\\":\\\"MY_LARGE_SEGMENTS_UPDATE\\\",\\\"changeNumber\\\":1457552650000,\\\"largeSegments\\\":[],\\\"c\\\": 0,\\\"u\\\": 0,\\\"d\\\":\\\"\\\",\\\"i\\\":300,\\\"h\\\":1,\\\"s\\\":0}\"}"
 }

--- a/src/dtos/types.ts
+++ b/src/dtos/types.ts
@@ -235,7 +235,7 @@ export interface IMySegmentsResponse {
 /** Interface of the parsed JSON response of `/myLargeSegments/{userKey}` */
 export interface IMyLargeSegmentsResponse {
   myLargeSegments: string[],
-  changeNumber: number
+  till: number
 }
 
 /** Metadata internal type for storages */

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -22,7 +22,7 @@ function userKeyToQueryParam(userKey: string) {
  */
 export function splitApiFactory(
   settings: ISettings,
-  platform: IPlatform,
+  platform: Pick<IPlatform, 'getOptions' | 'getFetch'>,
   telemetryTracker: ITelemetryTracker
 ): ISplitApi {
 

--- a/src/services/splitHttpClient.ts
+++ b/src/services/splitHttpClient.ts
@@ -12,7 +12,7 @@ const messageNoFetch = 'Global fetch API is not available.';
  * @param settings SDK settings, used to access authorizationKey, logger instance and metadata (SDK version, ip and hostname) to set additional headers
  * @param platform object containing environment-specific dependencies
  */
-export function splitHttpClientFactory(settings: ISettings, { getOptions, getFetch }: IPlatform): ISplitHttpClient {
+export function splitHttpClientFactory(settings: ISettings, { getOptions, getFetch }: Pick<IPlatform, 'getOptions' | 'getFetch'>): ISplitHttpClient {
 
   const { log, core: { authorizationKey }, version, runtime: { ip, hostname } } = settings;
   const options = getOptions && getOptions(settings);

--- a/src/storages/__tests__/KeyBuilder.spec.ts
+++ b/src/storages/__tests__/KeyBuilder.spec.ts
@@ -116,16 +116,16 @@ test('KEYS / latency and exception keys (telemetry)', () => {
 test('getStorageHash', () => {
   expect(getStorageHash({
     core: { authorizationKey: '<fake-token-rfc>' },
-    sync: { __splitFiltersValidation: { queryString: '&names=p1__split,p2__split' }, flagSpecVersion: '1.1' }
-  } as ISettings)).toBe('fdf7bd89');
+    sync: { __splitFiltersValidation: { queryString: '&names=p1__split,p2__split' }, flagSpecVersion: '1.2' }
+  } as ISettings)).toBe('7ccd6b31');
 
   expect(getStorageHash({
     core: { authorizationKey: '<fake-token-rfc>' },
-    sync: { __splitFiltersValidation: { queryString: '&names=p2__split,p3__split' }, flagSpecVersion: '1.1' }
-  } as ISettings)).toBe('ee4ec91');
+    sync: { __splitFiltersValidation: { queryString: '&names=p2__split,p3__split' }, flagSpecVersion: '1.2' }
+  } as ISettings)).toBe('2a25d0e1');
 
   expect(getStorageHash({
     core: { authorizationKey: '<fake-token-rfc>' },
-    sync: { __splitFiltersValidation: { queryString: null }, flagSpecVersion: '1.1' }
-  } as ISettings)).toBe('2a2c20bb');
+    sync: { __splitFiltersValidation: { queryString: null }, flagSpecVersion: '1.2' }
+  } as ISettings)).toBe('db8943b4');
 });

--- a/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
+++ b/src/sync/streaming/SSEHandler/__tests__/index.spec.ts
@@ -173,7 +173,7 @@ test('`handlerMessage` for update notifications (NotificationProcessor) and stre
   sseHandler.handleMessage(segmentRemovalMessage);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(MY_SEGMENTS_UPDATE_V2, ...expectedParams); // must emit MY_SEGMENTS_UPDATE_V2 with the message parsed data
 
-  expectedParams = [{ type: 'MY_LARGE_SEGMENTS_UPDATE', changeNumber: 1457552650000, c: 0, d: '', u: 0, largeSegments: [], i: 300, h: 0, s: 0 }];
+  expectedParams = [{ type: 'MY_LARGE_SEGMENTS_UPDATE', changeNumber: 1457552650000, c: 0, d: '', u: 0, largeSegments: [], i: 300, h: 1, s: 0 }];
   sseHandler.handleMessage(largeSegmentUnboundedMessage);
   expect(pushEmitter.emit).toHaveBeenLastCalledWith(MY_LARGE_SEGMENTS_UPDATE, ...expectedParams); // must emit MY_SEGMENTS_UPDATE_V2 with the message parsed data
 

--- a/src/sync/streaming/SSEHandler/types.ts
+++ b/src/sync/streaming/SSEHandler/types.ts
@@ -43,7 +43,7 @@ export interface IMyLargeSegmentsUpdateData {
   d: string,
   u: UpdateStrategy,
   i?: number, // time interval in millis
-  h?: number, // hash function. 0 for murmur3_32, 1 for murmur3_64
+  h?: number, // hash function
   s?: number, // seed for hash function
 }
 

--- a/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
+++ b/src/sync/streaming/UpdateWorkers/MySegmentsUpdateWorker.ts
@@ -36,7 +36,7 @@ export function MySegmentsUpdateWorker(mySegmentsSyncTask: IMySegmentsSyncTask, 
 
       syncTask.then((result) => {
         if (!isHandlingEvent) return; // halt if `stop` has been called
-        if (result !== false) {// Unlike `Splits|SegmentsUpdateWorker`, we cannot use `mySegmentsCache.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
+        if (result !== false) { // Unlike `Splits|SegmentsUpdateWorker`, we cannot use `mySegmentsCache.getChangeNumber` since `/mySegments` endpoint doesn't provide this value.
           if (_segmentsData) telemetryTracker.trackUpdatesFromSSE(updateType);
           currentChangeNumber = Math.max(currentChangeNumber, currentMaxChangeNumber); // use `currentMaxChangeNumber`, in case that `maxChangeNumber` was updated during fetch.
         }

--- a/src/sync/streaming/__tests__/pushManager.spec.ts
+++ b/src/sync/streaming/__tests__/pushManager.spec.ts
@@ -194,8 +194,8 @@ describe('pushManager in server-side', () => {
 });
 
 test('getDelay', () => {
-  expect(getDelay({ i: 300, h: 0, s: 0 }, 'nicolas@split.io')).toBe(241);
-  expect(getDelay({ i: 60000, h: 0, s: 1 }, 'emi@split.io')).toBe(14389);
-  expect(getDelay({ i: 60000, h: 0, s: 0 }, 'emi@split.io')).toBe(24593);
+  expect(getDelay({ i: 300, h: 1, s: 0 }, 'nicolas@split.io')).toBe(241);
+  expect(getDelay({ i: 60000, h: 1, s: 1 }, 'emi@split.io')).toBe(14389);
+  expect(getDelay({ i: 60000, h: 1, s: 0 }, 'emi@split.io')).toBe(24593);
   expect(getDelay({}, 'emi@split.io')).toBe(24593);
 });

--- a/src/sync/streaming/pushManager.ts
+++ b/src/sync/streaming/pushManager.ts
@@ -23,6 +23,8 @@ import { TOKEN_REFRESH, AUTH_REJECTION, MY_LARGE_SEGMENT, MY_SEGMENT } from '../
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 
 export function getDelay(parsedData: Pick<IMyLargeSegmentsUpdateData, 'i' | 'h' | 's'>, matchingKey: string) {
+  if (parsedData.h === 0) return 0;
+
   const interval = parsedData.i || 60000;
   const seed = parsedData.s || 0;
 

--- a/src/sync/submitters/telemetrySubmitter.ts
+++ b/src/sync/submitters/telemetrySubmitter.ts
@@ -71,17 +71,19 @@ export function telemetryCacheConfigAdapter(telemetry: ITelemetryCacheSync, sett
     pop(): TelemetryConfigStatsPayload {
       const { urls, scheduler } = settings;
       const isClientSide = settings.core.key !== undefined;
+      const largeSegmentsEnabled = isClientSide && settings.sync.largeSegmentsEnabled;
 
       const { flagSetsTotal, flagSetsIgnored } = getTelemetryFlagSetsStats(settings.sync.__splitFiltersValidation);
 
       return objectAssign(getTelemetryConfigStats(settings.mode, settings.storage.type), {
         sE: settings.streamingEnabled,
-        lE: isClientSide ? settings.sync.largeSegmentsEnabled : undefined,
+        lsE: largeSegmentsEnabled ? largeSegmentsEnabled : undefined,
+        wls: largeSegmentsEnabled ? settings.startup.waitForLargeSegments : undefined,
         rR: {
           sp: scheduler.featuresRefreshRate / 1000,
           se: isClientSide ? undefined : scheduler.segmentsRefreshRate / 1000,
           ms: isClientSide ? scheduler.segmentsRefreshRate / 1000 : undefined,
-          mls: isClientSide && settings.sync.largeSegmentsEnabled ? scheduler.largeSegmentsRefreshRate / 1000 : undefined,
+          mls: largeSegmentsEnabled ? scheduler.largeSegmentsRefreshRate / 1000 : undefined,
           im: scheduler.impressionsRefreshRate / 1000,
           ev: scheduler.eventsPushRate / 1000,
           te: scheduler.telemetryRefreshRate / 1000,

--- a/src/sync/submitters/types.ts
+++ b/src/sync/submitters/types.ts
@@ -231,7 +231,8 @@ export type TelemetryConfigStats = {
 // 'metrics/config' JSON request body
 export type TelemetryConfigStatsPayload = TelemetryConfigStats & {
   sE: boolean, // streamingEnabled
-  lE?: boolean, // largeSegmentsEnabled
+  lsE?: boolean, // largeSegmentsEnabled
+  wls?: boolean, // waitForLargeSegments
   rR: RefreshRates, // refreshRates
   uO: UrlOverrides, // urlOverrides
   iQ: number, // impressionsQueueSize

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -106,7 +106,7 @@ export const DISABLED = 0;
 export const ENABLED = 1;
 export const PAUSED = 2;
 
-export const FLAG_SPEC_VERSION = '1.1';
+export const FLAG_SPEC_VERSION = '1.2';
 
 // Matcher types
 export const IN_SEGMENT = 'IN_SEGMENT';


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

- Update FLAG_SPEC_VERSION to '1.2'.
- Update SSEClient to filter `myLargeSegments` channels if `largeSegmentsEnabled` option is false.
- Update fields in telemetry for large segments.
- Handle new `h` (hashing algorithm) option: `0` for NONE, which means there is no delay for fetching.

## How do we test the changes introduced in this PR?

- Unit tests.

## Extra Notes