### PR TITLE
Added lastUpdate property to ReadinessManager module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 1.16.1 (July 10, 2024)
+ - Added lastUpdate property to ReadinessManager to keep track of the timestamp of the last SDK event, used on React and Redux SDKs.
  - Updated some transitive dependencies for vulnerability fixes.
 
 1.16.0 (June 13, 2024)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-1.16.1 (July 10, 2024)
+1.17.0 (September 6, 2024)
  - Added lastUpdate property to ReadinessManager to keep track of the timestamp of the last SDK event, used on React and Redux SDKs.
  - Updated some transitive dependencies for vulnerability fixes.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
-1.17.0 (September 6, 2024)
- - Added lastUpdate property to ReadinessManager to keep track of the timestamp of the last SDK event, used on React and Redux SDKs.
+1.17.0 (September XX, 2024)
+ - Added `isTimedout` and `lastUpdate` properties to IStatusInterface to keep track of the timestamp of the last SDK event, used on React and Redux SDKs.
  - Updated some transitive dependencies for vulnerability fixes.
 
 1.16.0 (June 13, 2024)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,18 +5933,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6456,28 +6444,16 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -6851,9 +6827,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -12429,12 +12405,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12831,21 +12801,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-          "dev": true
-        }
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
       }
     },
     "mime-db": {
@@ -13129,9 +13091,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pirates": {

--- a/src/readiness/__tests__/readinessManager.spec.ts
+++ b/src/readiness/__tests__/readinessManager.spec.ts
@@ -4,14 +4,16 @@ import { IReadinessManager } from '../types';
 import { SDK_READY, SDK_UPDATE, SDK_SPLITS_ARRIVED, SDK_SEGMENTS_ARRIVED, SDK_READY_FROM_CACHE, SDK_SPLITS_CACHE_LOADED, SDK_READY_TIMED_OUT } from '../constants';
 
 const timeoutMs = 100;
-const statusFlagsCount = 5;
+const statusFlagsCount = 7;
 
 function assertInitialStatus(readinessManager: IReadinessManager) {
   expect(readinessManager.isReady()).toBe(false);
   expect(readinessManager.isReadyFromCache()).toBe(false);
+  expect(readinessManager.isTimedout()).toBe(false);
   expect(readinessManager.hasTimedout()).toBe(false);
   expect(readinessManager.isDestroyed()).toBe(false);
   expect(readinessManager.isOperational()).toBe(false);
+  expect(readinessManager.lastUpdate()).toBe(0);
 }
 
 test('READINESS MANAGER / Share splits but segments (without timeout enabled)', (done) => {
@@ -153,6 +155,7 @@ describe('READINESS MANAGER / Timeout ready event', () => {
     timeoutCounter = 0;
 
     readinessManager.gate.on(SDK_READY_TIMED_OUT, () => {
+      expect(readinessManager.isTimedout()).toBe(true);
       expect(readinessManager.hasTimedout()).toBe(true);
       if (!readinessManager.isReady()) timeoutCounter++;
     });
@@ -166,6 +169,8 @@ describe('READINESS MANAGER / Timeout ready event', () => {
   test('should be fired once', (done) => {
     readinessManager.gate.on(SDK_READY, () => {
       expect(readinessManager.isReady()).toBe(true);
+      expect(readinessManager.isTimedout()).toBe(false);
+      expect(readinessManager.hasTimedout()).toBe(true);
       expect(timeoutCounter).toBe(1);
       done();
     });

--- a/src/readiness/__tests__/readinessManager.spec.ts
+++ b/src/readiness/__tests__/readinessManager.spec.ts
@@ -221,14 +221,24 @@ test('READINESS MANAGER / Destroy after it was ready but before timedout', () =>
     counter++;
   });
 
+  let lastUpdate = readinessManager.lastUpdate();
+  expect(lastUpdate).toBe(0);
+
   readinessManager.splits.emit(SDK_SPLITS_ARRIVED);
   readinessManager.segments.emit(SDK_SEGMENTS_ARRIVED); // ready state
 
+  expect(readinessManager.lastUpdate()).toBeGreaterThan(lastUpdate);
+  lastUpdate = readinessManager.lastUpdate();
+
   readinessManager.segments.emit(SDK_SEGMENTS_ARRIVED); // fires an update
+  expect(readinessManager.lastUpdate()).toBeGreaterThan(lastUpdate);
+  lastUpdate = readinessManager.lastUpdate();
 
   expect(readinessManager.isDestroyed()).toBe(false);
   readinessManager.destroy(); // Destroy the gate, removing all the listeners and clearing the ready timeout.
   expect(readinessManager.isDestroyed()).toBe(true);
+  expect(readinessManager.lastUpdate()).toBeGreaterThan(lastUpdate);
+
   readinessManager.destroy(); // no-op
   readinessManager.destroy(); // no-op
 

--- a/src/readiness/__tests__/sdkReadinessManager.spec.ts
+++ b/src/readiness/__tests__/sdkReadinessManager.spec.ts
@@ -52,7 +52,7 @@ describe('SDK Readiness Manager - Event emitter', () => {
     expect(typeof sdkStatus.ready).toBe('function'); // The sdkStatus exposes a .ready() function.
     expect(typeof sdkStatus.__getStatus).toBe('function'); // The sdkStatus exposes a .__getStatus() function.
     expect(sdkStatus.__getStatus()).toEqual({
-      isReady: false, isReadyFromCache: false, isTimeout: false, hasTimedout: false, isDestroyed: false, isOperational: false, lastUpdate: 0
+      isReady: false, isReadyFromCache: false, isTimedout: false, hasTimedout: false, isDestroyed: false, isOperational: false, lastUpdate: 0
     });
 
     expect(typeof sdkStatus.Event).toBe('object'); // It also exposes the Event map,

--- a/src/readiness/__tests__/sdkReadinessManager.spec.ts
+++ b/src/readiness/__tests__/sdkReadinessManager.spec.ts
@@ -50,6 +50,10 @@ describe('SDK Readiness Manager - Event emitter', () => {
     });
 
     expect(typeof sdkStatus.ready).toBe('function'); // The sdkStatus exposes a .ready() function.
+    expect(typeof sdkStatus.__getStatus).toBe('function'); // The sdkStatus exposes a .__getStatus() function.
+    expect(sdkStatus.__getStatus()).toEqual({
+      isReady: false, isReadyFromCache: false, isTimeout: false, hasTimedout: false, isDestroyed: false, isOperational: false, lastUpdate: 0
+    });
 
     expect(typeof sdkStatus.Event).toBe('object'); // It also exposes the Event map,
     expect(sdkStatus.Event.SDK_READY).toBe(SDK_READY); // which contains the constants for the events, for backwards compatibility.

--- a/src/readiness/readinessManager.ts
+++ b/src/readiness/readinessManager.ts
@@ -42,6 +42,7 @@ export function readinessManagerFactory(
   let lastUpdate = 0;
   function syncLastUpdate() {
     const dateNow = Date.now();
+    // ensure lastUpdate is always increasing per event, is case Date.now() is mocked or its value is the same
     lastUpdate = dateNow > lastUpdate ? dateNow : lastUpdate + 1;
   }
 

--- a/src/readiness/readinessManager.ts
+++ b/src/readiness/readinessManager.ts
@@ -143,8 +143,9 @@ export function readinessManagerFactory(
     },
 
     isReady() { return isReady; },
-    hasTimedout() { return hasTimedout; },
     isReadyFromCache() { return isReadyFromCache; },
+    isTimedout() { return hasTimedout && !isReady; },
+    hasTimedout() { return hasTimedout; },
     isDestroyed() { return isDestroyed; },
     isOperational() { return (isReady || isReadyFromCache) && !isDestroyed; },
     lastUpdate() { return lastUpdate; }

--- a/src/readiness/sdkReadinessManager.ts
+++ b/src/readiness/sdkReadinessManager.ts
@@ -129,6 +129,7 @@ export function sdkReadinessManagerFactory(
             isOperational: readinessManager.isOperational(),
             hasTimedout: readinessManager.hasTimedout(),
             isDestroyed: readinessManager.isDestroyed(),
+            lastUpdate: readinessManager.lastUpdate(),
           };
         },
       }

--- a/src/readiness/sdkReadinessManager.ts
+++ b/src/readiness/sdkReadinessManager.ts
@@ -121,14 +121,14 @@ export function sdkReadinessManagerFactory(
           return readyPromise;
         },
 
-        // Expose status for internal purposes only. Not considered part of the public API, and might be updated eventually.
         __getStatus() {
           return {
             isReady: readinessManager.isReady(),
             isReadyFromCache: readinessManager.isReadyFromCache(),
-            isOperational: readinessManager.isOperational(),
+            isTimedout: readinessManager.isTimedout(),
             hasTimedout: readinessManager.hasTimedout(),
             isDestroyed: readinessManager.isDestroyed(),
+            isOperational: readinessManager.isOperational(),
             lastUpdate: readinessManager.lastUpdate(),
           };
         },

--- a/src/readiness/types.ts
+++ b/src/readiness/types.ts
@@ -53,6 +53,7 @@ export interface IReadinessManager {
   hasTimedout(): boolean,
   isDestroyed(): boolean,
   isOperational(): boolean,
+  lastUpdate(): number,
 
   timeout(): void,
   setDestroyed(): void,

--- a/src/readiness/types.ts
+++ b/src/readiness/types.ts
@@ -50,6 +50,7 @@ export interface IReadinessManager {
   /** Readiness status */
   isReady(): boolean,
   isReadyFromCache(): boolean,
+  isTimedout(): boolean,
   hasTimedout(): boolean,
   isDestroyed(): boolean,
   isOperational(): boolean,

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,6 +403,17 @@ export interface IStatusInterface extends IEventEmitter {
    * @returns {Promise<void>}
    */
   ready(): Promise<void>
+
+  // Expose status for internal purposes only. Not considered part of the public API, and might be updated eventually.
+  __getStatus(): {
+    isReady: boolean;
+    isReadyFromCache: boolean;
+    isTimedout: boolean;
+    hasTimedout: boolean;
+    isDestroyed: boolean;
+    isOperational: boolean;
+    lastUpdate: number;
+  }
 }
 /**
  * Common definitions between clients for different environments interface.


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

Added `lastUpdate` property to ReadinessManager module, a property used by React and Redux SDKs.
`lastUpdate` property is the timestamp of the last client SDK event (SDK_READY, SDK_READY_FROM_CACHE, SDK_READY_TIMEOUT, SDK_UPDATE or when the client `destroy` method is invoked).

## How do we test the changes introduced in this PR?

Unit test

## Extra Notes