### PR TITLE
Bugfix on server-side polling manager

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
-1.18.0 (September XX, 2024)
+1.18.0 (October XX, 2024)
  - Added `factory.destroy()` method, which invokes the `destroy` method on all SDK clients created by the factory.
+ - Bugfixing - Fixed an issue with the server-side polling manager that caused dangling timers when the SDK was destroyed before it was ready.
 
 1.17.0 (September 6, 2024)
  - Added `sync.requestOptions.getHeaderOverrides` configuration option to enhance SDK HTTP request Headers for Authorization Frameworks.

--- a/src/__tests__/testUtils/fetchMock.ts
+++ b/src/__tests__/testUtils/fetchMock.ts
@@ -1,4 +1,5 @@
-// http://www.wheresrhys.co.uk/fetch-mock/#usageinstallation
+// @TODO upgrade fetch-mock when fetch-mock-jest vulnerabilities are fixed
+// https://www.wheresrhys.co.uk/fetch-mock/docs/fetch-mock/Usage/cheatsheet#local-fetch-with-jest
 import fetchMockLib from 'fetch-mock';
 
 const fetchMock = fetchMockLib.sandbox();

--- a/src/sync/polling/pollingManagerSS.ts
+++ b/src/sync/polling/pollingManagerSS.ts
@@ -1,7 +1,6 @@
 import { splitsSyncTaskFactory } from './syncTasks/splitsSyncTask';
 import { segmentsSyncTaskFactory } from './syncTasks/segmentsSyncTask';
 import { IPollingManager, ISegmentsSyncTask, ISplitsSyncTask } from './types';
-import { thenable } from '../../utils/promise/thenable';
 import { POLLING_START, POLLING_STOP, LOG_PREFIX_SYNC_POLLING } from '../../logger/constants';
 import { ISdkFactoryContextSync } from '../../sdkFactory/types';
 
@@ -29,9 +28,9 @@ export function pollingManagerSSFactory(
       log.debug(LOG_PREFIX_SYNC_POLLING + `Segments will be refreshed each ${settings.scheduler.segmentsRefreshRate} millis`);
 
       const startingUp = splitsSyncTask.start();
-      if (thenable(startingUp)) {
+      if (startingUp) {
         startingUp.then(() => {
-          segmentsSyncTask.start();
+          if (splitsSyncTask.isRunning()) segmentsSyncTask.start();
         });
       }
     },


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

 - Bugfixing - Fixed an issue with the server-side polling manager that caused dangling timers when the SDK was destroyed before it was ready.

## How do we test the changes introduced in this PR?

- E2E tests in JS SDK.

## Extra Notes