### PR TITLE
Bugfix: handle rejected promises when using segment matchers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.0.3 (December 29, 2024)
+ - Bugfixing - Properly handle rejected promises when using targeting rules with segment matchers in consumer modes (e.g., Redis and Pluggable storages).
+
 2.0.2 (December 3, 2024)
  - Updated the factory `init` and `destroy` methods to support re-initialization after destruction. This update ensures compatibility of the React SDK with React Strict Mode, where the factory's `init` and `destroy` effects are executed an extra time to validate proper resource cleanup.
  - Bugfixing - Sanitize the `SplitSDKMachineName` header value to avoid exceptions on HTTP/S requests when it contains non ISO-8859-1 characters (Related to issue https://github.com/splitio/javascript-client/issues/847).

--- a/src/evaluator/matchers/large_segment.ts
+++ b/src/evaluator/matchers/large_segment.ts
@@ -1,17 +1,10 @@
 import { MaybeThenable } from '../../dtos/types';
 import { ISegmentsCacheBase } from '../../storages/types';
-import { thenable } from '../../utils/promise/thenable';
 
 export function largeSegmentMatcherContext(largeSegmentName: string, storage: { largeSegments?: ISegmentsCacheBase }) {
 
   return function largeSegmentMatcher(key: string): MaybeThenable<boolean> {
     const isInLargeSegment = storage.largeSegments ? storage.largeSegments.isInSegment(largeSegmentName, key) : false;
-
-    if (thenable(isInLargeSegment)) {
-      isInLargeSegment.then(result => {
-        return result;
-      });
-    }
 
     return isInLargeSegment;
   };

--- a/src/evaluator/matchers/segment.ts
+++ b/src/evaluator/matchers/segment.ts
@@ -1,17 +1,10 @@
 import { MaybeThenable } from '../../dtos/types';
 import { ISegmentsCacheBase } from '../../storages/types';
-import { thenable } from '../../utils/promise/thenable';
 
 export function segmentMatcherContext(segmentName: string, storage: { segments: ISegmentsCacheBase }) {
 
   return function segmentMatcher(key: string): MaybeThenable<boolean> {
     const isInSegment = storage.segments.isInSegment(segmentName, key);
-
-    if (thenable(isInSegment)) {
-      isInSegment.then(result => {
-        return result;
-      });
-    }
 
     return isInSegment;
   };

--- a/src/storages/inRedis/SplitsCacheInRedis.ts
+++ b/src/storages/inRedis/SplitsCacheInRedis.ts
@@ -266,10 +266,10 @@ export class SplitsCacheInRedis extends AbstractSplitsCacheAsync {
       return Promise.reject(this.redisError);
     }
 
-    const splits: Record<string, ISplit | null> = {};
     const keys = names.map(name => this.keys.buildSplitKey(name));
     return this.redis.mget(...keys)
       .then(splitDefinitions => {
+        const splits: Record<string, ISplit | null> = {};
         names.forEach((name, idx) => {
           const split = splitDefinitions[idx];
           splits[name] = split && JSON.parse(split);


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

- Updated segment matchers to avoid unhandled rejected promises when using targeting rules with segment matchers in consumer modes (e.g., Redis and Pluggable storages).

## How do we test the changes introduced in this PR?

## Extra Notes