### PR TITLE
[SDKS-9171] Emit SDK_READY_FROM_CACHE event alongside SDK_READY event in case it has not been emitted

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 2.1.0 (January XX, 2025)
- - Added `trackImpressions` property to SDK Manager's `SplitView` type.
+ - Added `impressionsDisabled` property to SDK Manager's `SplitView` type.
  - Updated implementation of the impressions tracker and strategies to support feature flags with impressions tracking disabled.
 
 2.0.3 (January 9, 2025)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "2.1.0-rc.1",
+      "version": "2.1.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ioredis": "^4.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.1.0-rc.1",
+  "version": "2.1.0-rc.2",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes