### PR TITLE
feat(logger): use console level methods instead of console.log

### DIFF
--- a/src/logger/__tests__/index.spec.ts
+++ b/src/logger/__tests__/index.spec.ts
@@ -49,15 +49,16 @@ function testLogLevels(levelToTest: SplitIO.LogLevel) {
   };
 
   // Spy console method based on level
-  const levelToMethod: Record<SplitIO.LogLevel, keyof typeof console> = {
+  const levelToMethod: Record<Exclude<SplitIO.LogLevel, 'NONE'>, keyof typeof console> = {
     DEBUG: 'debug',
     INFO: 'info',
     WARN: 'warn',
-    ERROR: 'error',
-    NONE: 'log'
+    ERROR: 'error'
   };
 
-  const consoleMethodSpy = jest.spyOn(global.console, levelToMethod[levelToTest] as any);
+  const consoleMethodSpy = levelToTest === 'NONE'
+    ? jest.spyOn(global.console, 'log').mockImplementation(() => {})
+    : jest.spyOn(global.console, levelToMethod[levelToTest] as any);
 
   // Runs the suite with the given value for showLevel option.
   const runTests = (showLevel?: boolean, useCodes?: boolean) => {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -23,7 +23,7 @@ const levelToMethod: Record<Exclude<SplitIO.LogLevel, 'NONE'>, keyof typeof cons
   DEBUG: 'debug',
   INFO: 'info',
   WARN: 'warn',
-  ERROR: 'error',
+  ERROR: 'error'
 };
 
 export function isLogLevelString(str: string): str is SplitIO.LogLevel {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -19,6 +19,13 @@ const LogLevelIndexes = {
   NONE: 5
 };
 
+const levelToMethod: Record<Exclude<SplitIO.LogLevel, 'NONE'>, keyof typeof console> = {
+  DEBUG: 'debug',
+  INFO: 'info',
+  WARN: 'warn',
+  ERROR: 'error',
+};
+
 export function isLogLevelString(str: string): str is SplitIO.LogLevel {
   return !!find(LogLevels, (lvl: string) => str === lvl);
 }
@@ -86,7 +93,11 @@ export class Logger implements ILogger {
 
     const formattedText = this._generateLogMessage(level, msg);
 
-    console.log(formattedText);
+    const method = levelToMethod[level as Exclude<SplitIO.LogLevel, 'NONE'>];
+
+    const fn = typeof console[method] === 'function' ? (console as any)[method] : console.log;
+
+    fn(formattedText);
   }
 
   private _generateLogMessage(level: SplitIO.LogLevel, text: string) {

--- a/src/sdkClient/__tests__/clientInputValidation.spec.ts
+++ b/src/sdkClient/__tests__/clientInputValidation.spec.ts
@@ -21,6 +21,8 @@ const readinessManager: any = {
 describe('clientInputValidationDecorator', () => {
   const clientWithValidation = clientInputValidationDecorator(settings, client, readinessManager);
   const logSpy = jest.spyOn(console, 'log');
+  const logErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const logWarnSpy  = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
   beforeEach(() => {
     logSpy.mockClear();
@@ -28,70 +30,70 @@ describe('clientInputValidationDecorator', () => {
 
   test('should return control and log an error if the passed 2nd argument (feature flag(s) or flag set(s)) is invalid', () => {
     expect(clientWithValidation.getTreatment('key')).toEqual('control');
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatment: you passed a null or undefined feature flag name. It must be a non-empty string.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatment: you passed a null or undefined feature flag name. It must be a non-empty string.');
 
     expect(clientWithValidation.getTreatmentWithConfig('key', [])).toEqual({ treatment: 'control', config: null });
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentWithConfig: you passed an invalid feature flag name. It must be a non-empty string.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentWithConfig: you passed an invalid feature flag name. It must be a non-empty string.');
 
     expect(clientWithValidation.getTreatments('key')).toEqual({});
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatments: feature flag names must be a non-empty array.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatments: feature flag names must be a non-empty array.');
 
     expect(clientWithValidation.getTreatmentsWithConfig('key', [])).toEqual({});
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfig: feature flag names must be a non-empty array.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfig: feature flag names must be a non-empty array.');
 
     expect(clientWithValidation.getTreatmentsByFlagSet('key')).toEqual({});
-    expect(logSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsByFlagSet: you passed a null or undefined flag set. It must be a non-empty string.');
+    expect(logErrorSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsByFlagSet: you passed a null or undefined flag set. It must be a non-empty string.');
 
     expect(clientWithValidation.getTreatmentsWithConfigByFlagSet('key', [])).toEqual({});
-    expect(logSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSet: you passed an invalid flag set. It must be a non-empty string.');
+    expect(logErrorSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSet: you passed an invalid flag set. It must be a non-empty string.');
 
     expect(clientWithValidation.getTreatmentsByFlagSets('key')).toEqual({});
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSets: flag sets must be a non-empty array.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSets: flag sets must be a non-empty array.');
 
     expect(clientWithValidation.getTreatmentsWithConfigByFlagSets('key', [])).toEqual({});
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSets: flag sets must be a non-empty array.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSets: flag sets must be a non-empty array.');
 
     // @TODO should be 8, but there is an additional log from `getTreatmentsByFlagSet` and `getTreatmentsWithConfigByFlagSet` that should be removed
-    expect(logSpy).toBeCalledTimes(10);
+    expect(logErrorSpy).toBeCalledTimes(10);
   });
 
   test('should evaluate but log an error if the passed 4th argument (evaluation options) is invalid', () => {
     expect(clientWithValidation.getTreatment('key', 'ff', undefined, 'invalid')).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatment: evaluation options must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatment: evaluation options must be a plain object.');
     expect(client.getTreatment).toBeCalledWith('key', 'ff', undefined, undefined);
 
     expect(clientWithValidation.getTreatmentWithConfig('key', 'ff', undefined, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentWithConfig: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentWithConfig: properties must be a plain object.');
     expect(client.getTreatmentWithConfig).toBeCalledWith('key', 'ff', undefined, undefined);
 
     expect(clientWithValidation.getTreatments('key', ['ff'], undefined, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatments: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatments: properties must be a plain object.');
     expect(client.getTreatments).toBeCalledWith('key', ['ff'], undefined, undefined);
 
     expect(clientWithValidation.getTreatmentsWithConfig('key', ['ff'], {}, { properties: true })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfig: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfig: properties must be a plain object.');
     expect(client.getTreatmentsWithConfig).toBeCalledWith('key', ['ff'], {}, undefined);
 
     expect(clientWithValidation.getTreatmentsByFlagSet('key', 'flagSet', undefined, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSet: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSet: properties must be a plain object.');
     expect(client.getTreatmentsByFlagSet).toBeCalledWith('key', 'flagset', undefined, undefined);
 
     expect(clientWithValidation.getTreatmentsWithConfigByFlagSet('key', 'flagSet', {}, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSet: properties must be a plain object.');
+    expect(logErrorSpy).toBeCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSet: properties must be a plain object.');
     expect(client.getTreatmentsWithConfigByFlagSet).toBeCalledWith('key', 'flagset', {}, undefined);
 
     expect(clientWithValidation.getTreatmentsByFlagSets('key', ['flagSet'], undefined, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSets: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsByFlagSets: properties must be a plain object.');
     expect(client.getTreatmentsByFlagSets).toBeCalledWith('key', ['flagset'], undefined, undefined);
 
     expect(clientWithValidation.getTreatmentsWithConfigByFlagSets('key', ['flagSet'], {}, { properties: 'invalid' })).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSets: properties must be a plain object.');
+    expect(logErrorSpy).toHaveBeenLastCalledWith('[ERROR] splitio => getTreatmentsWithConfigByFlagSets: properties must be a plain object.');
     expect(client.getTreatmentsWithConfigByFlagSets).toBeCalledWith('key', ['flagset'], {}, undefined);
   });
 
   test('should sanitize the properties in the 4th argument', () => {
     expect(clientWithValidation.getTreatment('key', 'ff', undefined, { properties: { toSanitize: /asd/, correct: 100 }})).toBe(EVALUATION_RESULT);
-    expect(logSpy).toHaveBeenLastCalledWith('[WARN]  splitio => getTreatment: Property "toSanitize" is of invalid type. Setting value to null.');
+    expect(logWarnSpy).toHaveBeenLastCalledWith('[WARN]  splitio => getTreatment: Property "toSanitize" is of invalid type. Setting value to null.');
     expect(client.getTreatment).toBeCalledWith('key', 'ff', undefined, { properties: { toSanitize: null, correct: 100 }});
   });
 

--- a/src/utils/settingsValidation/logger/__tests__/index.spec.ts
+++ b/src/utils/settingsValidation/logger/__tests__/index.spec.ts
@@ -11,7 +11,12 @@ const testTargets = [
 describe('logger validators', () => {
 
   const consoleLogSpy = jest.spyOn(global.console, 'log');
-  afterEach(() => { consoleLogSpy.mockClear(); });
+  const consoleErrorSpy = jest.spyOn(global.console, 'error');
+
+  afterEach(() => {
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+  });
 
   test.each(testTargets)('returns a NONE logger if `debug` property is not defined or false', (validateLogger) => { // @ts-ignore
     expect(getLoggerLogLevel(validateLogger({}))).toBe('NONE');
@@ -29,9 +34,9 @@ describe('logger validators', () => {
     if (validateLogger === builtinValidateLogger) {
       // for builtinValidateLogger, a logger cannot be passed as `debug` property
       expect(getLoggerLogLevel(validateLogger({ debug: loggerMock }))).toBe('NONE');
-      expect(consoleLogSpy).toBeCalledTimes(4);
+      expect(consoleErrorSpy).toBeCalledTimes(4);
     } else {
-      expect(consoleLogSpy).toBeCalledTimes(3);
+      expect(consoleErrorSpy).toBeCalledTimes(3);
     }
   });
 


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?
- Updated Logger to use `console.debug`, `console.info`, `console.warn` and `console.error`
  instead of always `console.log`.
- Ensures log aggregators that hook into console methods (like Datadog) can
  properly capture SDK logs by level.
- Preserves `NONE` log level as disabled (no output).

## How do we test the changes introduced in this PR?
- Run `npm test` → existing logger test suite covers all log levels.
- Verified new unit tests confirm correct console methods are called for each log level.

## Extra Notes
- Fixes: #405