### PR TITLE
Update SDK to support log level when `logger` is provided

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
+2.7.1 (October 8, 2025)
+ - Bugfix - Update `debug` option to support log levels when `logger` option is used.
+
 2.7.0 (October 7, 2025)
- - Added support for custom loggers: added `logger` configuration option and `LoggerAPI.setLogger` method to allow the SDK to use a custom logger.
+ - Added support for custom loggers: added `logger` configuration option and `factory.Logger.setLogger` method to allow the SDK to use a custom logger.
 
 2.6.0 (September 18, 2025)
  - Added `storage.wrapper` configuration option to allow the SDK to use a custom storage wrapper for the storage type `LOCALSTORAGE`. Default value is `window.localStorage`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ioredis": "^4.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -72,8 +72,6 @@ export class Logger implements ILogger {
     if (logger) {
       if (isLogger(logger)) {
         this.logger = logger;
-        // If custom logger is set, all logs are either enabled or disabled
-        if (this.logLevel !== LogLevelIndexes.NONE) this.setLogLevel(LogLevels.DEBUG);
         return;
       } else {
         this.error('Invalid `logger` instance. It must be an object with `debug`, `info`, `warn` and `error` methods. Defaulting to `console.log`');

--- a/src/utils/settingsValidation/logger/__tests__/index.spec.ts
+++ b/src/utils/settingsValidation/logger/__tests__/index.spec.ts
@@ -49,19 +49,13 @@ describe('logger validators', () => {
   });
 
   test.each(testTargets)('returns a logger with the provided log level if `debug` property is true or a string log level', (validateLogger) => {
-    expect(getLoggerLogLevel(validateLogger({ debug: true }))).toBe('DEBUG');
+    expect(getLoggerLogLevel(validateLogger({ debug: true, logger: loggerMock }))).toBe('DEBUG');
     expect(getLoggerLogLevel(validateLogger({ debug: 'DEBUG' }))).toBe('DEBUG');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'INFO' }))).toBe('INFO');
+    expect(getLoggerLogLevel(validateLogger({ debug: 'INFO', logger: loggerMock }))).toBe('INFO');
     expect(getLoggerLogLevel(validateLogger({ debug: 'WARN' }))).toBe('WARN');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'ERROR' }))).toBe('ERROR');
+    expect(getLoggerLogLevel(validateLogger({ debug: 'ERROR', logger: loggerMock }))).toBe('ERROR');
     expect(getLoggerLogLevel(validateLogger({ debug: 'NONE' }))).toBe('NONE');
-
-    // When combined with the `logger` option, any log level other than `NONE` (false) will be set to `DEBUG` (true)
-    expect(getLoggerLogLevel(validateLogger({ debug: 'DEBUG', logger: loggerMock }))).toBe('DEBUG');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'INFO', logger: loggerMock }))).toBe('DEBUG');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'WARN', logger: loggerMock }))).toBe('DEBUG');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'ERROR', logger: loggerMock }))).toBe('DEBUG');
-    expect(getLoggerLogLevel(validateLogger({ debug: 'NONE', logger: loggerMock }))).toBe('NONE');
+    expect(getLoggerLogLevel(validateLogger({ debug: false }))).toBe('NONE');
 
     expect(consoleLogSpy).not.toBeCalled();
   });

--- a/types/splitio.d.ts
+++ b/types/splitio.d.ts
@@ -93,6 +93,7 @@ interface ISharedSettings {
   urls?: SplitIO.UrlSettings;
   /**
    * Custom logger object. If not provided, the SDK will use the default `console.log` method for all log levels.
+   * Set together with `debug` option to `true` or a log level string to enable logging.
    */
   logger?: SplitIO.Logger;
 }
@@ -145,8 +146,6 @@ interface IPluggableSharedSettings {
    * config.debug = ErrorLogger()
    * ```
    *
-   * When combined with the `logger` option, any log level other than `NONE` (false) will be set to `DEBUG` (true), delegating log level control to the custom logger.
-   *
    * @defaultValue `false`
    */
   debug?: boolean | SplitIO.LogLevel | SplitIO.ILogger;
@@ -169,8 +168,6 @@ interface INonPluggableSharedSettings {
    * config.debug = true
    * config.debug = 'WARN'
    * ```
-   *
-   * When combined with the `logger` option, any log level other than `NONE` (false) will be set to `DEBUG` (true), delegating log level control to the custom logger.
    *
    * @defaultValue `false`
    */


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes