### PR TITLE
Polishing: log fixes, allow disabling telemetry, version bump

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,16 @@
+3.0.0 (May XX, 2026)
+ - Extracted SDK lifecycle methods (`init`, `flush`, and `destroy`) into a reusable `sdkLifecycle` module.
+ - Extracted the `track` method into a standalone `trackMethod` factory for reuse across SDKs.
+ - Added a bloom filter utility and platform-specific modules (`src/platform/`) for reuse across SDKs.
+ - Added support for the Configs SDK:
+   - new type declarations,
+   - a fallback calculator with sanitizer,
+   - default treatment evaluation (without a target),
+   - a new `CONFIGS_UPDATE` metadata type for `SDK_UPDATE` event,
+   - an optional `entityType` field in the `/testImpressions/bulk` payload,
+   - input validation for the target object.
+ - BREAKING CHANGES: Renamed some types and modules, and updated the signatures of others for clarity and reusability.
+
 2.12.0 (February 24, 2026)
  - Added support for ioredis v5 (Related to issue https://github.com/splitio/javascript-commons/issues/471).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.12.0",
+  "version": "3.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@splitsoftware/splitio-commons",
-      "version": "2.12.0",
+      "version": "3.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/ioredis": "^4.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splitsoftware/splitio-commons",
-  "version": "2.12.0",
+  "version": "3.0.0-rc.0",
   "description": "Split JavaScript SDK common components",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/src/logger/messages/error.ts
+++ b/src/logger/messages/error.ts
@@ -2,7 +2,7 @@ import * as c from '../constants';
 
 export const codesError: [number, string][] = [
   // evaluator
-  [c.ERROR_ENGINE_COMBINER_IFELSEIF, c.LOG_PREFIX_ENGINE_COMBINER + 'Invalid feature flag, no valid rules or unsupported targeting rule type found'],
+  [c.ERROR_ENGINE_COMBINER_IFELSEIF, c.LOG_PREFIX_ENGINE_COMBINER + 'Invalid definition, no valid rules or unsupported targeting rule type found'],
   [c.ENGINE_MATCHER_ERROR, c.LOG_PREFIX_ENGINE_MATCHER + '[%s] %s'],
   // SDK
   [c.ERROR_LOGLEVEL_INVALID, 'logger: Invalid Log Level - No changes to the logs will be applied.'],
@@ -13,7 +13,7 @@ export const codesError: [number, string][] = [
   // synchronizer
   [c.ERROR_SYNC_OFFLINE_LOADING, c.LOG_PREFIX_SYNC_OFFLINE + 'There was an issue loading the mock feature flags data. No changes will be applied to the current cache. %s'],
   [c.ERROR_STREAMING_SSE, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to connect or error on streaming connection, with error message: %s'],
-  [c.ERROR_STREAMING_AUTH, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to authenticate for streaming. Error: %s.'],
+  [c.ERROR_STREAMING_AUTH, c.LOG_PREFIX_SYNC_STREAMING + 'Failed to authenticate for streaming. Error: %s'],
   [c.ERROR_HTTP, 'HTTP request failed with %s. URL: %s. Message: %s'],
   // client status
   [c.ERROR_CLIENT_LISTENER, 'A listener was added for %s on the SDK, which has already fired and won\'t be emitted again. The callback won\'t be executed.'],
@@ -34,6 +34,6 @@ export const codesError: [number, string][] = [
   [c.ERROR_INVALID_CONFIG_PARAM, c.LOG_PREFIX_SETTINGS + ': you passed an invalid "%s" config param. It should be one of the following values: %s. Defaulting to "%s".'],
   [c.ERROR_STORAGE_INVALID, c.LOG_PREFIX_SETTINGS+': the provided storage is invalid.%s Falling back into default MEMORY storage'],
   [c.ERROR_MIN_CONFIG_PARAM, c.LOG_PREFIX_SETTINGS + ': the provided "%s" config param is lower than allowed. Setting to the minimum value %s seconds'],
-  [c.ERROR_TOO_MANY_SETS, c.LOG_PREFIX_SETTINGS + ': the amount of flag sets provided are big causing uri length error.'],
+  [c.ERROR_TOO_MANY_SETS, c.LOG_PREFIX_SETTINGS + ': the number of sets provided is too high, which causes a URI length error.'],
   [c.ERROR_SETS_FILTER_EXCLUSIVE, c.LOG_PREFIX_SETTINGS+': the Set filter is exclusive and cannot be used simultaneously with names or prefix filters. Ignoring names and prefixes.'],
 ];

--- a/src/logger/messages/warn.ts
+++ b/src/logger/messages/warn.ts
@@ -11,8 +11,8 @@ export const codesWarn: [number, string][] = codesError.concat([
   [c.STREAMING_PARSING_ERROR_FAILS, c.LOG_PREFIX_SYNC_STREAMING + 'Error parsing SSE error notification: %s'],
   [c.STREAMING_PARSING_MESSAGE_FAILS, c.LOG_PREFIX_SYNC_STREAMING + 'Error parsing SSE message notification: %s'],
   [c.STREAMING_FALLBACK, c.LOG_PREFIX_SYNC_STREAMING + 'Falling back to polling mode. Reason: %s'],
-  [c.SUBMITTERS_PUSH_FAILS, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Dropping %s after retry. Reason: %s.'],
-  [c.SUBMITTERS_PUSH_RETRY, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Failed to push %s, keeping data to retry on next iteration. Reason: %s.'],
+  [c.SUBMITTERS_PUSH_FAILS, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Dropping %s after retry. Reason: %s'],
+  [c.SUBMITTERS_PUSH_RETRY, c.LOG_PREFIX_SYNC_SUBMITTERS + 'Failed to push %s, keeping data to retry on next iteration. Reason: %s'],
   // client status
   [c.CLIENT_NOT_READY_FROM_CACHE, '%s: the SDK is not ready to evaluate. Results may be incorrect. Make sure to wait for SDK readiness before using this method.'],
   [c.CLIENT_NO_LISTENER, 'No listeners for SDK_READY event detected. Incorrect control treatments could have been logged if you called getTreatment/s while the SDK was not yet synchronized with the backend.'],

--- a/src/services/splitApi.ts
+++ b/src/services/splitApi.ts
@@ -61,6 +61,7 @@ export function splitApiFactory(
         });
     },
 
+    // @TODO support filterQueryString and handle ERROR_TOO_MANY_SETS error
     fetchConfigs(since: number, noCache?: boolean, till?: number) {
       const url = `${urls.sdk}/v1/configs?since=${since}${filterQueryString || ''}${till ? '&till=' + till : ''}`;
       return splitHttpClient(url, noCache ? noCacheHeaderOptions : undefined);

--- a/src/storages/inMemory/TelemetryCacheInMemory.ts
+++ b/src/storages/inMemory/TelemetryCacheInMemory.ts
@@ -20,8 +20,8 @@ const ACCEPTANCE_RANGE = 0.001;
  * Record telemetry if mode is not localhost.
  * All factory instances track telemetry on server-side, and 0.1% on client-side.
  */
-export function shouldRecordTelemetry({ settings }: IStorageFactoryParams) {
-  return settings.mode !== LOCALHOST_MODE && (checkIfServerSide(settings) || Math.random() <= ACCEPTANCE_RANGE);
+export function shouldRecordTelemetry({ settings, disableTelemetry }: IStorageFactoryParams) {
+  return !disableTelemetry && settings.mode !== LOCALHOST_MODE && (checkIfServerSide(settings) || Math.random() <= ACCEPTANCE_RANGE);
 }
 
 export class TelemetryCacheInMemory implements ITelemetryCacheSync {

--- a/src/storages/types.ts
+++ b/src/storages/types.ts
@@ -528,6 +528,10 @@ export interface IStorageFactoryParams {
    * For emitting SDK_READY_FROM_CACHE event in consumer mode with Redis to allow immediate evaluations
    */
   onReadyFromCacheCb: () => void,
+  /**
+   * If true, telemetry will not be recorded.
+   */
+  disableTelemetry?: boolean,
 }
 
 


### PR DESCRIPTION
# JavaScript commons library

## What did you accomplish?

- Fixed and improved log messages for Configs SDK clarity
- Added `disableTelemetry` flag to storage factory params
- Version bump to `3.0.0-rc.0` with CHANGES.txt entry

## How do we test the changes introduced in this PR?

- [ ] `npm run check` and `npm run test` pass

## Extra Notes

Builds on `sdk-configs-baseline`.